### PR TITLE
fix: robust startup sequencing - poll until OpenCode is fully ready

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -286,7 +286,7 @@ version = "0.3.1"
 dependencies = [
  "dirs",
  "log",
- "reqwest 0.12.28",
+ "reqwest",
  "serde",
  "serde_json",
  "tauri",
@@ -456,12 +456,6 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
-
-[[package]]
-name = "cfg_aliases"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
@@ -1245,10 +1239,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "wasi 0.11.1+wasi-snapshot-preview1",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -1258,11 +1250,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "r-efi",
  "wasip2",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -1535,7 +1525,6 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots",
 ]
 
 [[package]]
@@ -1959,12 +1948,6 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
-
-[[package]]
-name = "lru-slab"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "mac"
@@ -2816,61 +2799,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "quinn"
-version = "0.11.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
-dependencies = [
- "bytes",
- "cfg_aliases",
- "pin-project-lite",
- "quinn-proto",
- "quinn-udp",
- "rustc-hash",
- "rustls",
- "socket2",
- "thiserror 2.0.18",
- "tokio",
- "tracing",
- "web-time",
-]
-
-[[package]]
-name = "quinn-proto"
-version = "0.11.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
-dependencies = [
- "bytes",
- "getrandom 0.3.4",
- "lru-slab",
- "rand 0.9.2",
- "ring",
- "rustc-hash",
- "rustls",
- "rustls-pki-types",
- "slab",
- "thiserror 2.0.18",
- "tinyvec",
- "tracing",
- "web-time",
-]
-
-[[package]]
-name = "quinn-udp"
-version = "0.5.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
-dependencies = [
- "cfg_aliases",
- "libc",
- "once_cell",
- "socket2",
- "tracing",
- "windows-sys 0.60.2",
-]
-
-[[package]]
 name = "quote"
 version = "1.0.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2911,16 +2839,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand"
-version = "0.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
-dependencies = [
- "rand_chacha 0.9.0",
- "rand_core 0.9.5",
-]
-
-[[package]]
 name = "rand_chacha"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2941,16 +2859,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand_chacha"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.9.5",
-]
-
-[[package]]
 name = "rand_core"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2966,15 +2874,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.17",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
-dependencies = [
- "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -3081,44 +2980,6 @@ checksum = "a96887878f22d7bad8a3b6dc5b7440e0ada9a245242924394987b21cf2210a4c"
 
 [[package]]
 name = "reqwest"
-version = "0.12.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
-dependencies = [
- "base64 0.22.1",
- "bytes",
- "futures-core",
- "http",
- "http-body",
- "http-body-util",
- "hyper",
- "hyper-rustls",
- "hyper-util",
- "js-sys",
- "log",
- "percent-encoding",
- "pin-project-lite",
- "quinn",
- "rustls",
- "rustls-pki-types",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "sync_wrapper",
- "tokio",
- "tokio-rustls",
- "tower",
- "tower-http",
- "tower-service",
- "url",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
- "webpki-roots",
-]
-
-[[package]]
-name = "reqwest"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
@@ -3169,12 +3030,6 @@ dependencies = [
  "untrusted",
  "windows-sys 0.52.0",
 ]
-
-[[package]]
-name = "rustc-hash"
-version = "2.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
 name = "rustc_version"
@@ -3230,7 +3085,6 @@ version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
 dependencies = [
- "web-time",
  "zeroize",
 ]
 
@@ -3277,12 +3131,6 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
-
-[[package]]
-name = "ryu"
-version = "1.0.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "same-file"
@@ -3503,18 +3351,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8bbf91e5a4d6315eee45e704372590b30e260ee83af6639d64557f51b067776"
 dependencies = [
  "serde_core",
-]
-
-[[package]]
-name = "serde_urlencoded"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
-dependencies = [
- "form_urlencoded",
- "itoa",
- "ryu",
- "serde",
 ]
 
 [[package]]
@@ -3934,7 +3770,7 @@ dependencies = [
  "percent-encoding",
  "plist",
  "raw-window-handle",
- "reqwest 0.13.2",
+ "reqwest",
  "serde",
  "serde_json",
  "serde_repr",
@@ -4120,7 +3956,7 @@ dependencies = [
  "minisign-verify",
  "osakit",
  "percent-encoding",
- "reqwest 0.13.2",
+ "reqwest",
  "rustls",
  "semver",
  "serde",
@@ -4342,21 +4178,6 @@ dependencies = [
  "displaydoc",
  "zerovec",
 ]
-
-[[package]]
-name = "tinyvec"
-version = "1.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
-dependencies = [
- "tinyvec_macros",
-]
-
-[[package]]
-name = "tinyvec_macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
@@ -4894,16 +4715,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "web-time"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
-dependencies = [
- "js-sys",
- "wasm-bindgen",
-]
-
-[[package]]
 name = "webkit2gtk"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4952,15 +4763,6 @@ name = "webpki-root-certs"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "804f18a4ac2676ffb4e8b5b5fa9ae38af06df08162314f96a68d2a363e21a8ca"
-dependencies = [
- "rustls-pki-types",
-]
-
-[[package]]
-name = "webpki-roots"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
 dependencies = [
  "rustls-pki-types",
 ]

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -286,6 +286,7 @@ version = "0.3.1"
 dependencies = [
  "dirs",
  "log",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "tauri",
@@ -455,6 +456,12 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
@@ -1238,8 +1245,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi 0.11.1+wasi-snapshot-preview1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1249,9 +1258,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi",
  "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1524,6 +1535,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -1947,6 +1959,12 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "mac"
@@ -2798,6 +2816,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+dependencies = [
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand 0.9.2",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2838,6 +2911,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
+]
+
+[[package]]
 name = "rand_chacha"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2858,6 +2941,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
+]
+
+[[package]]
 name = "rand_core"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2873,6 +2966,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.17",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -2979,6 +3081,44 @@ checksum = "a96887878f22d7bad8a3b6dc5b7440e0ada9a245242924394987b21cf2210a4c"
 
 [[package]]
 name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots",
+]
+
+[[package]]
+name = "reqwest"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
@@ -3029,6 +3169,12 @@ dependencies = [
  "untrusted",
  "windows-sys 0.52.0",
 ]
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
 name = "rustc_version"
@@ -3084,6 +3230,7 @@ version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
 dependencies = [
+ "web-time",
  "zeroize",
 ]
 
@@ -3130,6 +3277,12 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "same-file"
@@ -3350,6 +3503,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8bbf91e5a4d6315eee45e704372590b30e260ee83af6639d64557f51b067776"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
 ]
 
 [[package]]
@@ -3769,7 +3934,7 @@ dependencies = [
  "percent-encoding",
  "plist",
  "raw-window-handle",
- "reqwest",
+ "reqwest 0.13.2",
  "serde",
  "serde_json",
  "serde_repr",
@@ -3955,7 +4120,7 @@ dependencies = [
  "minisign-verify",
  "osakit",
  "percent-encoding",
- "reqwest",
+ "reqwest 0.13.2",
  "rustls",
  "semver",
  "serde",
@@ -4177,6 +4342,21 @@ dependencies = [
  "displaydoc",
  "zerovec",
 ]
+
+[[package]]
+name = "tinyvec"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
@@ -4714,6 +4894,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "webkit2gtk"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4762,6 +4952,15 @@ name = "webpki-root-certs"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "804f18a4ac2676ffb4e8b5b5fa9ae38af06df08162314f96a68d2a363e21a8ca"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
 dependencies = [
  "rustls-pki-types",
 ]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -25,7 +25,7 @@ tauri-plugin-store = "2"
 tauri-plugin-updater = "2.10.0"
 tauri-plugin-process = "2.3.1"
 log = "0.4.29"
-reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"] }
+reqwest = { version = "0.13", default-features = false }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["macros", "rt"] }

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -25,6 +25,7 @@ tauri-plugin-store = "2"
 tauri-plugin-updater = "2.10.0"
 tauri-plugin-process = "2.3.1"
 log = "0.4.29"
+reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"] }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["macros", "rt"] }

--- a/src-tauri/src/opencode.rs
+++ b/src-tauri/src/opencode.rs
@@ -445,8 +445,13 @@ async fn do_start(
     // Spawn event handler for stdout, stderr, and process exit.
     spawn_event_handler(rx, Arc::clone(state), app.clone());
 
-    // Wait for the server to accept TCP connections.
-    let addr = std::net::SocketAddr::from(([127, 0, 0, 1], port));
+    // Wait for the HTTP server to be fully ready.
+    // Probe /session to ensure app routes (not just /global/health) are registered.
+    let health_url = format!("http://{LOOPBACK}:{port}/session");
+    let http_client = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(2))
+        .build()
+        .map_err(|e| format!("Failed to create HTTP client: {e}"))?;
 
     loop {
         tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
@@ -461,9 +466,14 @@ async fn do_start(
             }
         }
 
-        if tokio::net::TcpStream::connect(addr).await.is_ok() {
-            log::info!("Server listening on port {port}");
-            return Ok(port);
+        match http_client.get(&health_url).send().await {
+            Ok(resp) => {
+                log::info!("Server ready on port {port} (status {})", resp.status());
+                return Ok(port);
+            }
+            Err(_) => {
+                log::debug!("Server not ready yet, retrying...");
+            }
         }
     }
 }

--- a/src-tauri/src/opencode.rs
+++ b/src-tauri/src/opencode.rs
@@ -472,7 +472,7 @@ async fn do_start(
                 return Ok(port);
             }
             Err(_) => {
-                log::debug!("Server not ready yet, retrying...");
+                log::trace!("Server not ready yet, retrying...");
             }
         }
     }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -11,7 +11,12 @@ ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
   <React.StrictMode>
     <PostHogProvider
       apiKey={POSTHOG_API_KEY}
-      options={{ api_host: POSTHOG_API_HOST, defaults: "2026-01-30" }}
+      options={{
+        api_host: POSTHOG_API_HOST,
+        defaults: "2026-01-30",
+        advanced_disable_toolbar_metrics: true,
+        disable_session_recording: true,
+      }}
     >
       <App />
     </PostHogProvider>

--- a/src/providers/OpenCodeClientProvider.tsx
+++ b/src/providers/OpenCodeClientProvider.tsx
@@ -49,23 +49,51 @@ export function OpenCodeClientProvider({
 
   const sseAbortRef = useRef<AbortController | null>(null);
 
-  // ── Get port from Rust, create client, fetch server state ────────────
+  // ── Get port from Rust, wait for server, create client ────────────
   useEffect(() => {
     if (ready) return;
 
     let cancelled = false;
     let retryTimer: ReturnType<typeof setTimeout>;
 
-    const attempt = async () => {
+    // Step 1: Poll Tauri command until the sidecar port is available.
+    async function waitForPort(): Promise<[number, string]> {
+      while (!cancelled) {
+        try {
+          return await invoke<[number, string]>("get_opencode_info");
+        } catch {
+          // Sidecar not started yet - expected during dev startup.
+          await new Promise((r) => { retryTimer = setTimeout(r, 1000); });
+        }
+      }
+      throw new Error("cancelled");
+    }
+
+    // Step 2: Poll the HTTP server until it responds.
+    async function waitForServer(baseUrl: string): Promise<void> {
+      while (!cancelled) {
+        try {
+          const res = await fetch(`${baseUrl}/session`, { method: "GET" });
+          // Any HTTP response means the server is ready (even 4xx).
+          if (res.ok || res.status >= 400) return;
+        } catch {
+          // Connection refused - server not ready yet.
+        }
+        await new Promise((r) => { retryTimer = setTimeout(r, 1000); });
+      }
+      throw new Error("cancelled");
+    }
+
+    async function init() {
       try {
-        const [ocPort, workspace] = await invoke<[number, string]>("get_opencode_info");
+        const [ocPort, workspace] = await waitForPort();
         if (cancelled) return;
 
-        const newClient = createOpencodeClient({
-          baseUrl: `http://127.0.0.1:${ocPort}`,
-          directory: workspace,
-        });
+        const baseUrl = `http://127.0.0.1:${ocPort}`;
+        await waitForServer(baseUrl);
+        if (cancelled) return;
 
+        const newClient = createOpencodeClient({ baseUrl, directory: workspace });
         await prefetchServerState(newClient, queryClient);
         if (cancelled) return;
 
@@ -76,12 +104,14 @@ export function OpenCodeClientProvider({
         setInitError(null);
       } catch (err) {
         if (cancelled) return;
-        console.error("Failed to initialize, retrying in 3s:", err);
+        console.error("Failed to initialize OpenCode:", err);
         setInitError(String(err));
-        retryTimer = setTimeout(attempt, 3000);
+        // Retry the whole sequence.
+        retryTimer = setTimeout(init, 3000);
       }
-    };
-    attempt();
+    }
+
+    init();
 
     return () => {
       cancelled = true;

--- a/src/providers/OpenCodeClientProvider.tsx
+++ b/src/providers/OpenCodeClientProvider.tsx
@@ -53,23 +53,16 @@ export function OpenCodeClientProvider({
   useEffect(() => {
     if (ready) return;
 
-    const MAX_PORT_ATTEMPTS = 30; // ~30s before showing error
-    const MAX_SERVER_ATTEMPTS = 15; // ~15s before showing error
-    const POLL_INTERVAL = 1000;
-
     let cancelled = false;
     let retryTimer: ReturnType<typeof setTimeout>;
 
     // Step 1: Poll Tauri command until the sidecar port is available.
     async function waitForPort(): Promise<[number, string]> {
-      for (let attempt = 0; !cancelled; attempt++) {
+      while (!cancelled) {
         try {
           return await invoke<[number, string]>("get_opencode_info");
-        } catch (err) {
-          if (attempt >= MAX_PORT_ATTEMPTS) {
-            throw new Error(`Sidecar not available after ${MAX_PORT_ATTEMPTS}s: ${err}`);
-          }
-          await new Promise((r) => { retryTimer = setTimeout(r, POLL_INTERVAL); });
+        } catch {
+          await new Promise((r) => { retryTimer = setTimeout(r, 1000); });
         }
       }
       throw new Error("cancelled");
@@ -77,20 +70,17 @@ export function OpenCodeClientProvider({
 
     // Step 2: Poll the HTTP server until it responds.
     async function waitForServer(baseUrl: string): Promise<void> {
-      for (let attempt = 0; !cancelled; attempt++) {
+      while (!cancelled) {
         try {
           const res = await fetch(`${baseUrl}/session`, {
             method: "GET",
             signal: AbortSignal.timeout(3000),
           });
-          // Any HTTP response means the server is ready (even 4xx).
           if (res.ok || res.status >= 400) return;
         } catch {
-          if (attempt >= MAX_SERVER_ATTEMPTS) {
-            throw new Error(`Server not responding after ${MAX_SERVER_ATTEMPTS}s`);
-          }
+          // Connection refused or timeout - keep polling.
         }
-        await new Promise((r) => { retryTimer = setTimeout(r, POLL_INTERVAL); });
+        await new Promise((r) => { retryTimer = setTimeout(r, 1000); });
       }
       throw new Error("cancelled");
     }

--- a/src/providers/OpenCodeClientProvider.tsx
+++ b/src/providers/OpenCodeClientProvider.tsx
@@ -53,17 +53,23 @@ export function OpenCodeClientProvider({
   useEffect(() => {
     if (ready) return;
 
+    const MAX_PORT_ATTEMPTS = 30; // ~30s before showing error
+    const MAX_SERVER_ATTEMPTS = 15; // ~15s before showing error
+    const POLL_INTERVAL = 1000;
+
     let cancelled = false;
     let retryTimer: ReturnType<typeof setTimeout>;
 
     // Step 1: Poll Tauri command until the sidecar port is available.
     async function waitForPort(): Promise<[number, string]> {
-      while (!cancelled) {
+      for (let attempt = 0; !cancelled; attempt++) {
         try {
           return await invoke<[number, string]>("get_opencode_info");
-        } catch {
-          // Sidecar not started yet - expected during dev startup.
-          await new Promise((r) => { retryTimer = setTimeout(r, 1000); });
+        } catch (err) {
+          if (attempt >= MAX_PORT_ATTEMPTS) {
+            throw new Error(`Sidecar not available after ${MAX_PORT_ATTEMPTS}s: ${err}`);
+          }
+          await new Promise((r) => { retryTimer = setTimeout(r, POLL_INTERVAL); });
         }
       }
       throw new Error("cancelled");
@@ -71,15 +77,20 @@ export function OpenCodeClientProvider({
 
     // Step 2: Poll the HTTP server until it responds.
     async function waitForServer(baseUrl: string): Promise<void> {
-      while (!cancelled) {
+      for (let attempt = 0; !cancelled; attempt++) {
         try {
-          const res = await fetch(`${baseUrl}/session`, { method: "GET" });
+          const res = await fetch(`${baseUrl}/session`, {
+            method: "GET",
+            signal: AbortSignal.timeout(3000),
+          });
           // Any HTTP response means the server is ready (even 4xx).
           if (res.ok || res.status >= 400) return;
         } catch {
-          // Connection refused - server not ready yet.
+          if (attempt >= MAX_SERVER_ATTEMPTS) {
+            throw new Error(`Server not responding after ${MAX_SERVER_ATTEMPTS}s`);
+          }
         }
-        await new Promise((r) => { retryTimer = setTimeout(r, 1000); });
+        await new Promise((r) => { retryTimer = setTimeout(r, POLL_INTERVAL); });
       }
       throw new Error("cancelled");
     }


### PR DESCRIPTION
## Summary
- **Frontend startup rewrite**: Split init into three sequential phases - `waitForPort()` polls the Tauri command silently, `waitForServer()` polls the HTTP endpoint silently, then `prefetchServerState()` runs only once the server is confirmed alive
- **Rust readiness check**: Replace TCP port probe with HTTP probe on `/session` endpoint - any HTTP response (even 4xx) means routes are registered and ready
- **PostHog config**: Disable toolbar metrics and session recording to avoid `config.js` 404 errors in Tauri webview

## Test plan
- [ ] `make dev` starts without "Could not connect" console errors
- [ ] Loading screen shows until OpenCode is ready, then sessions appear
- [ ] Sessions persist across app restarts
- [ ] PostHog events still fire (provider connect, session create, message send)
- [ ] All tests pass (`make test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)