### PR TITLE
feat: download OpenCode at runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,9 +12,6 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ !startsWith(github.ref, 'refs/tags/') }}
 
-env:
-  OPENCODE_VERSION: "1.2.27"
-
 jobs:
   build:
     permissions:
@@ -25,30 +22,18 @@ jobs:
         include:
           - platform: macos-latest
             target: aarch64-apple-darwin
-            opencode_asset: opencode-darwin-arm64.zip
-            opencode_sha256: fa680fa79086c7509d3a2c21e49c9264b803da7c0f1b7807ed842b8e37325597
-            opencode_bin: opencode
             builder_args: --mac --arm64
 
           - platform: macos-latest
             target: x86_64-apple-darwin
-            opencode_asset: opencode-darwin-x64.zip
-            opencode_sha256: fc719db27acbc817ff2a4df2bbaa788e02976ddc26a96c84de4fdbe663714b8c
-            opencode_bin: opencode
             builder_args: --mac --x64
 
           - platform: windows-latest
             target: x86_64-pc-windows-msvc
-            opencode_asset: opencode-windows-x64.zip
-            opencode_sha256: 9e2e43568e6f952e8c7cb77b934fbff53f454f0213688f24f3c3769b69703e84
-            opencode_bin: opencode.exe
             builder_args: --win --x64
 
           - platform: ubuntu-22.04
             target: x86_64-unknown-linux-gnu
-            opencode_asset: opencode-linux-x64.tar.gz
-            opencode_sha256: 6fe3820b145857f7ff507d2826058b7acf1fce8258def1498468dd43809e69e8
-            opencode_bin: opencode
             builder_args: --linux deb --x64
 
     runs-on: ${{ matrix.platform }}
@@ -75,25 +60,6 @@ jobs:
 
       - name: Type-check
         run: pnpm typecheck
-
-      - name: Download OpenCode
-        shell: bash
-        run: |
-          mkdir -p resources/bin /tmp/bloxbot-deps
-          curl -fSL --retry 3 --retry-delay 5 \
-            "https://github.com/anomalyco/opencode/releases/download/v${{ env.OPENCODE_VERSION }}/${{ matrix.opencode_asset }}" \
-            -o "/tmp/bloxbot-deps/${{ matrix.opencode_asset }}"
-          printf '%s  %s\n' \
-            "${{ matrix.opencode_sha256 }}" \
-            "/tmp/bloxbot-deps/${{ matrix.opencode_asset }}" \
-            | shasum -a 256 -c -
-          case "${{ matrix.opencode_asset }}" in
-            *.tar.gz) tar -xzf "/tmp/bloxbot-deps/${{ matrix.opencode_asset }}" -C /tmp/bloxbot-deps ;;
-            *.zip) unzip -o "/tmp/bloxbot-deps/${{ matrix.opencode_asset }}" -d /tmp/bloxbot-deps ;;
-          esac
-          mv "/tmp/bloxbot-deps/${{ matrix.opencode_bin }}" \
-            "resources/bin/opencode-${{ matrix.target }}${{ matrix.platform == 'windows-latest' && '.exe' || '' }}"
-          chmod +x resources/bin/opencode-* 2>/dev/null || true
 
       - name: Build application
         run: pnpm build

--- a/.gitignore
+++ b/.gitignore
@@ -22,9 +22,6 @@ release
 *.p12
 *.pfx
 
-# Bundled runtimes (downloaded/built during CI / dev setup, too large for git)
-resources/bin/
-
 # Internal docs (not for public repo)
 PLAN.md
 

--- a/Makefile
+++ b/Makefile
@@ -1,58 +1,24 @@
-# ── BloxBot Build System ─────────────────────────────────────────────────
+# BloxBot build system
 #
 # Usage:
-#   make build       Build the Electron installer — downloads deps if needed
+#   make build       Build the Electron installer
 #   make dev         Run in development mode
 #   make clean       Remove build artifacts
-#   make deps        Download the pinned OpenCode server
 #   make check       Test + type-check + lint
 #
-# Prerequisites: pnpm, curl, unzip
+# OpenCode is downloaded and verified by the app on first launch.
 
-SHELL := /bin/bash
+NODE_MODULES := node_modules/.pnpm
 
-# ── Versions ─────────────────────────────────────────────────────────────
-OPENCODE_VERSION := 1.2.27
-
-# ── Platform detection ───────────────────────────────────────────────────
-UNAME_S := $(shell uname -s)
-UNAME_M := $(shell uname -m)
-
-ifeq ($(UNAME_S),Darwin)
-  ifeq ($(UNAME_M),arm64)
-    TARGET       := aarch64-apple-darwin
-    OC_ASSET     := opencode-darwin-arm64.zip
-    OC_SHA256    := fa680fa79086c7509d3a2c21e49c9264b803da7c0f1b7807ed842b8e37325597
-    OC_BIN       := opencode
-  else
-    TARGET       := x86_64-apple-darwin
-    OC_ASSET     := opencode-darwin-x64.zip
-    OC_SHA256    := fc719db27acbc817ff2a4df2bbaa788e02976ddc26a96c84de4fdbe663714b8c
-    OC_BIN       := opencode
-  endif
-  SHA256_CHECK := shasum -a 256
-else ifeq ($(UNAME_S),Linux)
-  TARGET       := x86_64-unknown-linux-gnu
-  OC_ASSET     := opencode-linux-x64.tar.gz
-  OC_SHA256    := 6fe3820b145857f7ff507d2826058b7acf1fce8258def1498468dd43809e69e8
-  OC_BIN       := opencode
-  SHA256_CHECK := sha256sum
-endif
-
-# ── Paths ────────────────────────────────────────────────────────────────
-OPENCODE_BIN   := resources/bin/opencode-$(TARGET)
-NODE_MODULES   := node_modules/.pnpm
-
-# ── Default target ───────────────────────────────────────────────────────
-.PHONY: build dev clean deps check lint help
+.PHONY: build dev clean nuke test check lint help
 
 help: ## Show this help
 	@grep -E '^[a-zA-Z_-]+:.*?##' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-12s\033[0m %s\n", $$1, $$2}'
 
-build: deps $(NODE_MODULES) ## Build production app bundle
+build: $(NODE_MODULES) ## Build production app bundle
 	pnpm package
 
-dev: deps $(NODE_MODULES) ## Run in development mode
+dev: $(NODE_MODULES) ## Run in development mode
 	pnpm dev
 
 test: $(NODE_MODULES) ## Run frontend tests
@@ -66,37 +32,12 @@ check: $(NODE_MODULES) ## Type-check + lint + test
 lint: $(NODE_MODULES) ## Lint frontend
 	pnpm lint
 
-clean: ## Remove build artifacts (keeps downloaded deps)
+clean: ## Remove build artifacts
 	rm -rf dist dist-electron release
 
-nuke: clean ## Remove everything including downloaded deps
-	rm -rf resources/bin
+nuke: clean ## Remove build artifacts and installed dependencies
 	rm -rf node_modules
-
-deps: $(OPENCODE_BIN) ## Download the OpenCode server
-
-# ── Frontend deps ────────────────────────────────────────────────────────
 
 $(NODE_MODULES): package.json pnpm-lock.yaml
 	pnpm install --frozen-lockfile
 	@touch $@
-
-# ── OpenCode server ─────────────────────────────────────────────────────
-
-$(OPENCODE_BIN):
-	@echo "⬇ Downloading OpenCode v$(OPENCODE_VERSION)..."
-	@mkdir -p resources/bin /tmp/bloxbot-deps
-	curl -fSL --retry 3 \
-		"https://github.com/anomalyco/opencode/releases/download/v$(OPENCODE_VERSION)/$(OC_ASSET)" \
-		-o "/tmp/bloxbot-deps/$(OC_ASSET)"
-	printf '%s  %s\n' "$(OC_SHA256)" "/tmp/bloxbot-deps/$(OC_ASSET)" | $(SHA256_CHECK) -c -
-	@echo "📦 Extracting OpenCode server..."
-	cd /tmp/bloxbot-deps && if [[ "$(OC_ASSET)" == *.tar.gz ]]; then \
-		tar -xzf "$(OC_ASSET)"; \
-	else \
-		unzip -o "$(OC_ASSET)"; \
-	fi
-	mv "/tmp/bloxbot-deps/$(OC_BIN)" "$(OPENCODE_BIN)"
-	chmod +x "$(OPENCODE_BIN)"
-	rm -rf /tmp/bloxbot-deps
-	@echo "✓ OpenCode server ready"

--- a/README.md
+++ b/README.md
@@ -57,12 +57,14 @@ Download the installer for your platform from the [releases page](https://github
 # Install frontend dependencies
 pnpm install
 
-# Download bundled runtimes (Node.js + OpenCode sidecar)
-make deps
-
 # Run in development mode
 make dev
 ```
+
+On first launch, BloxBot downloads the newest compatible OpenCode `1.x.x`
+release and verifies its SHA-256 digest. Later launches check for compatible
+minor and patch updates and can fall back to the newest verified cached copy
+when offline.
 
 ### Project structure
 
@@ -76,8 +78,8 @@ src/                    # React/TypeScript frontend
 electron/               # Electron main process and preload bridge
   icons/                #   Desktop installer icons
   main.ts               #   Secure window, IPC, updates, and lifecycle
+  services/OpenCodeBinary.ts # Runtime download and verified per-user cache
   services/OpenCode.ts  #   Effect-scoped OpenCode process lifecycle
-resources/bin/           # Downloaded, checksum-verified OpenCode server
 ```
 
 ### Key commands

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -8,11 +8,6 @@ files:
   - package.json
   - "!node_modules/**"
 npmRebuild: false
-extraResources:
-  - from: resources/bin
-    to: bin
-    filter:
-      - opencode-*
 asar: true
 mac:
   category: public.app-category.developer-tools

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -11,7 +11,6 @@ import { channels } from "./channels";
 import { makeOpenCodeLayer, OpenCode } from "./services/OpenCode";
 
 const currentDirectory = dirname(fileURLToPath(import.meta.url));
-const projectRoot = join(currentDirectory, "..", "..");
 const defaultConfig: AppConfig = { lastModel: null, hiddenModels: [] };
 
 let mainWindow: BrowserWindow | null = null;
@@ -19,9 +18,7 @@ let quitting = false;
 
 const openCodeRuntime = ManagedRuntime.make(
   makeOpenCodeLayer({
-    isPackaged: app.isPackaged,
-    projectRoot,
-    resourcesPath: process.resourcesPath,
+    binaryCacheDirectory: join(app.getPath("userData"), "opencode"),
     workspace: join(app.getPath("home"), "BloxBot"),
   }),
 );

--- a/electron/services/OpenCode.ts
+++ b/electron/services/OpenCode.ts
@@ -7,6 +7,7 @@ import { Context, Data, Effect, Layer } from "effect";
 
 import type { OpenCodeInfo } from "../../src/types/desktop";
 import { createOpenCodeConfig } from "../opencodeConfig";
+import { ensureOpenCodeBinary } from "./OpenCodeBinary";
 
 const LOOPBACK = "127.0.0.1";
 const PORT_START = 59200;
@@ -23,9 +24,7 @@ interface OpenCodeResource extends OpenCodeInfo {
 }
 
 export interface OpenCodeOptions {
-  isPackaged: boolean;
-  projectRoot: string;
-  resourcesPath: string;
+  binaryCacheDirectory: string;
   workspace: string;
 }
 
@@ -49,23 +48,6 @@ async function findAvailablePort(): Promise<number> {
     if (await canListen(port)) return port;
   }
   throw new Error(`No available port in ${PORT_START}-${PORT_START + PORT_COUNT - 1}`);
-}
-
-function platformTarget(): string {
-  if (process.platform === "darwin") {
-    return process.arch === "arm64" ? "aarch64-apple-darwin" : "x86_64-apple-darwin";
-  }
-  if (process.platform === "win32") return "x86_64-pc-windows-msvc.exe";
-  return "x86_64-unknown-linux-gnu";
-}
-
-function resolveRuntimePaths(options: OpenCodeOptions) {
-  const base = options.isPackaged ? options.resourcesPath : options.projectRoot;
-  const binaryDirectory = options.isPackaged ? join(base, "bin") : join(base, "resources", "bin");
-
-  return {
-    executable: join(binaryDirectory, `opencode-${platformTarget()}`),
-  };
 }
 
 async function waitForSpawn(child: ChildProcessWithoutNullStreams): Promise<void> {
@@ -99,7 +81,10 @@ async function waitForHealth(child: ChildProcessWithoutNullStreams, port: number
 
 async function startOpenCode(options: OpenCodeOptions): Promise<OpenCodeResource> {
   const port = await findAvailablePort();
-  const { executable } = resolveRuntimePaths(options);
+  const { executable, version } = await ensureOpenCodeBinary({
+    cacheDirectory: options.binaryCacheDirectory,
+  });
+  console.info(`[opencode] Starting v${version}`);
   const opencodeHome = join(options.workspace, ".opencode");
   const xdgData = join(opencodeHome, "data");
   const xdgConfig = join(opencodeHome, "config");
@@ -171,7 +156,7 @@ function acquire(options: OpenCodeOptions) {
         message:
           cause instanceof Error
             ? cause.message
-            : "OpenCode failed to start. Run `make deps` and try again.",
+            : "OpenCode failed to download or start.",
         cause,
       }),
   });

--- a/electron/services/OpenCodeBinary.ts
+++ b/electron/services/OpenCodeBinary.ts
@@ -1,0 +1,400 @@
+import { createHash } from "node:crypto";
+import { createReadStream } from "node:fs";
+import {
+  chmod,
+  mkdir,
+  readFile,
+  readdir,
+  rename,
+  rm,
+  stat,
+  writeFile,
+} from "node:fs/promises";
+import { join } from "node:path";
+
+import extractZip from "extract-zip";
+import { x as extractTar } from "tar";
+
+const OPEN_CODE_API = "https://api.github.com/repos/anomalyco/opencode/releases";
+const OPEN_CODE_DOWNLOAD_PREFIX = "https://github.com/anomalyco/opencode/releases/download/";
+const SUPPORTED_MAJOR = 1;
+const RELEASES_PER_PAGE = 100;
+const LOOKUP_TIMEOUT_MS = 15_000;
+const DOWNLOAD_TIMEOUT_MS = 120_000;
+
+interface GitHubAsset {
+  name: string;
+  browser_download_url: string;
+  digest?: string | null;
+}
+
+export interface GitHubRelease {
+  tag_name: string;
+  draft: boolean;
+  prerelease: boolean;
+  assets: GitHubAsset[];
+}
+
+interface Version {
+  major: number;
+  minor: number;
+  patch: number;
+  value: string;
+}
+
+interface AssetSpec {
+  archiveName: string;
+  executableName: string;
+  format: "tar.gz" | "zip";
+}
+
+interface CompatibleRelease {
+  version: Version;
+  asset: GitHubAsset;
+  archiveSha256: string;
+}
+
+interface CacheMetadata {
+  schemaVersion: 1;
+  version: string;
+  platform: NodeJS.Platform;
+  arch: string;
+  assetName: string;
+  archiveSha256: string;
+  binarySha256: string;
+}
+
+export interface OpenCodeBinary {
+  executable: string;
+  version: string;
+}
+
+type Fetch = (input: string | URL | Request, init?: RequestInit) => Promise<Response>;
+type ExtractArchive = (
+  archivePath: string,
+  destination: string,
+  format: AssetSpec["format"],
+) => Promise<void>;
+
+export interface OpenCodeBinaryOptions {
+  cacheDirectory: string;
+  platform?: NodeJS.Platform;
+  arch?: string;
+  fetch?: Fetch;
+  extractArchive?: ExtractArchive;
+}
+
+function parseVersion(tag: string): Version | null {
+  const match = /^v?(\d+)\.(\d+)\.(\d+)$/.exec(tag);
+  if (!match) return null;
+
+  const version = {
+    major: Number(match[1]),
+    minor: Number(match[2]),
+    patch: Number(match[3]),
+    value: `${Number(match[1])}.${Number(match[2])}.${Number(match[3])}`,
+  };
+  return version.major === SUPPORTED_MAJOR ? version : null;
+}
+
+function compareVersions(left: Version, right: Version): number {
+  return left.major - right.major || left.minor - right.minor || left.patch - right.patch;
+}
+
+export function getOpenCodeAssetSpec(platform: NodeJS.Platform, arch: string): AssetSpec {
+  if (platform === "darwin" && arch === "arm64") {
+    return {
+      archiveName: "opencode-darwin-arm64.zip",
+      executableName: "opencode",
+      format: "zip",
+    };
+  }
+  if (platform === "darwin" && arch === "x64") {
+    return {
+      archiveName: "opencode-darwin-x64.zip",
+      executableName: "opencode",
+      format: "zip",
+    };
+  }
+  if (platform === "win32" && arch === "x64") {
+    return {
+      archiveName: "opencode-windows-x64.zip",
+      executableName: "opencode.exe",
+      format: "zip",
+    };
+  }
+  if (platform === "linux" && arch === "x64") {
+    return {
+      archiveName: "opencode-linux-x64.tar.gz",
+      executableName: "opencode",
+      format: "tar.gz",
+    };
+  }
+  throw new Error(`OpenCode does not provide a supported binary for ${platform}/${arch}`);
+}
+
+export function selectCompatibleRelease(
+  releases: GitHubRelease[],
+  archiveName: string,
+): CompatibleRelease | null {
+  const candidates = releases.flatMap((release): CompatibleRelease[] => {
+    if (release.draft || release.prerelease) return [];
+    const version = parseVersion(release.tag_name);
+    if (!version) return [];
+
+    const asset = release.assets.find((candidate) => candidate.name === archiveName);
+    const digest = asset?.digest?.match(/^sha256:([a-f\d]{64})$/i)?.[1]?.toLowerCase();
+    if (!asset || !digest || !asset.browser_download_url.startsWith(OPEN_CODE_DOWNLOAD_PREFIX)) {
+      return [];
+    }
+    return [{ version, asset, archiveSha256: digest }];
+  });
+
+  return candidates.sort((left, right) => compareVersions(right.version, left.version))[0] ?? null;
+}
+
+async function findCompatibleRelease(fetchFn: Fetch, archiveName: string): Promise<CompatibleRelease> {
+  for (let page = 1; page <= 10; page++) {
+    const response = await fetchFn(
+      `${OPEN_CODE_API}?per_page=${RELEASES_PER_PAGE}&page=${page}`,
+      {
+        headers: {
+          Accept: "application/vnd.github+json",
+          "User-Agent": "BloxBot",
+          "X-GitHub-Api-Version": "2022-11-28",
+        },
+        signal: AbortSignal.timeout(LOOKUP_TIMEOUT_MS),
+      },
+    );
+    if (!response.ok) {
+      throw new Error(`GitHub release lookup failed with HTTP ${response.status}`);
+    }
+
+    const releases = (await response.json()) as GitHubRelease[];
+    if (!Array.isArray(releases)) throw new Error("GitHub returned an invalid release list");
+    const release = selectCompatibleRelease(releases, archiveName);
+    if (release) return release;
+    if (releases.length < RELEASES_PER_PAGE) break;
+  }
+
+  throw new Error(`No stable OpenCode ${SUPPORTED_MAJOR}.x.x release is available for ${archiveName}`);
+}
+
+async function sha256File(path: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const hash = createHash("sha256");
+    const stream = createReadStream(path);
+    stream.on("error", reject);
+    stream.on("data", (chunk) => hash.update(chunk));
+    stream.on("end", () => resolve(hash.digest("hex")));
+  });
+}
+
+function isCacheMetadata(value: unknown): value is CacheMetadata {
+  if (!value || typeof value !== "object") return false;
+  const metadata = value as Partial<CacheMetadata>;
+  return (
+    metadata.schemaVersion === 1 &&
+    typeof metadata.version === "string" &&
+    typeof metadata.platform === "string" &&
+    typeof metadata.arch === "string" &&
+    typeof metadata.assetName === "string" &&
+    typeof metadata.archiveSha256 === "string" &&
+    typeof metadata.binarySha256 === "string"
+  );
+}
+
+async function readValidCachedBinary(
+  versionDirectory: string,
+  platform: NodeJS.Platform,
+  arch: string,
+  spec: AssetSpec,
+  expected?: CompatibleRelease,
+): Promise<OpenCodeBinary | null> {
+  try {
+    const metadata = JSON.parse(
+      await readFile(join(versionDirectory, "metadata.json"), "utf8"),
+    ) as unknown;
+    if (!isCacheMetadata(metadata) || !parseVersion(metadata.version)) return null;
+    if (metadata.platform !== platform || metadata.arch !== arch) return null;
+    if (metadata.assetName !== spec.archiveName) return null;
+    if (
+      expected &&
+      (metadata.version !== expected.version.value ||
+        metadata.archiveSha256 !== expected.archiveSha256)
+    ) {
+      return null;
+    }
+
+    const executable = join(versionDirectory, spec.executableName);
+    if (!(await stat(executable)).isFile()) return null;
+    if ((await sha256File(executable)) !== metadata.binarySha256) return null;
+    if (platform !== "win32") await chmod(executable, 0o755);
+    return { executable, version: metadata.version };
+  } catch {
+    return null;
+  }
+}
+
+async function findNewestCachedBinary(
+  platformDirectory: string,
+  platform: NodeJS.Platform,
+  arch: string,
+  spec: AssetSpec,
+): Promise<OpenCodeBinary | null> {
+  let entries;
+  try {
+    entries = await readdir(platformDirectory, { withFileTypes: true });
+  } catch {
+    return null;
+  }
+
+  const versions = entries
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => parseVersion(entry.name))
+    .filter((version): version is Version => version !== null)
+    .sort((left, right) => compareVersions(right, left));
+
+  for (const version of versions) {
+    const cached = await readValidCachedBinary(
+      join(platformDirectory, version.value),
+      platform,
+      arch,
+      spec,
+    );
+    if (cached) return cached;
+  }
+  return null;
+}
+
+async function defaultExtractArchive(
+  archivePath: string,
+  destination: string,
+  format: AssetSpec["format"],
+): Promise<void> {
+  if (format === "zip") {
+    await extractZip(archivePath, { dir: destination });
+    return;
+  }
+  await extractTar({ file: archivePath, cwd: destination, strict: true });
+}
+
+async function installRelease(
+  platformDirectory: string,
+  platform: NodeJS.Platform,
+  arch: string,
+  spec: AssetSpec,
+  release: CompatibleRelease,
+  fetchFn: Fetch,
+  extractArchive: ExtractArchive,
+): Promise<OpenCodeBinary> {
+  const temporaryDirectory = join(
+    platformDirectory,
+    `.download-${process.pid}-${Date.now()}`,
+  );
+  const installDirectory = join(temporaryDirectory, "install");
+  const archivePath = join(temporaryDirectory, spec.archiveName);
+  const versionDirectory = join(platformDirectory, release.version.value);
+
+  await mkdir(installDirectory, { recursive: true });
+  try {
+    const response = await fetchFn(release.asset.browser_download_url, {
+      headers: { "User-Agent": "BloxBot" },
+      signal: AbortSignal.timeout(DOWNLOAD_TIMEOUT_MS),
+    });
+    if (!response.ok) throw new Error(`OpenCode download failed with HTTP ${response.status}`);
+
+    const archive = Buffer.from(await response.arrayBuffer());
+    const archiveSha256 = createHash("sha256").update(archive).digest("hex");
+    if (archiveSha256 !== release.archiveSha256) {
+      throw new Error("The downloaded OpenCode archive failed SHA-256 verification");
+    }
+    await writeFile(archivePath, archive);
+    await extractArchive(archivePath, installDirectory, spec.format);
+
+    const executable = join(installDirectory, spec.executableName);
+    if (!(await stat(executable)).isFile()) {
+      throw new Error(`The OpenCode archive did not contain ${spec.executableName}`);
+    }
+    if (platform !== "win32") await chmod(executable, 0o755);
+
+    const metadata: CacheMetadata = {
+      schemaVersion: 1,
+      version: release.version.value,
+      platform,
+      arch,
+      assetName: spec.archiveName,
+      archiveSha256,
+      binarySha256: await sha256File(executable),
+    };
+    await writeFile(join(installDirectory, "metadata.json"), JSON.stringify(metadata, null, 2));
+
+    await rm(versionDirectory, { recursive: true, force: true });
+    await rename(installDirectory, versionDirectory);
+    return { executable: join(versionDirectory, spec.executableName), version: release.version.value };
+  } finally {
+    await rm(temporaryDirectory, { recursive: true, force: true });
+  }
+}
+
+async function pruneCache(platformDirectory: string, keep = 2): Promise<void> {
+  const entries = await readdir(platformDirectory, { withFileTypes: true });
+  const versions = entries
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => parseVersion(entry.name))
+    .filter((version): version is Version => version !== null)
+    .sort((left, right) => compareVersions(right, left));
+
+  await Promise.all(
+    versions.slice(keep).map((version) =>
+      rm(join(platformDirectory, version.value), { recursive: true, force: true }),
+    ),
+  );
+}
+
+export async function ensureOpenCodeBinary(
+  options: OpenCodeBinaryOptions,
+): Promise<OpenCodeBinary> {
+  const platform = options.platform ?? process.platform;
+  const arch = options.arch ?? process.arch;
+  const fetchFn = options.fetch ?? fetch;
+  const extractArchive = options.extractArchive ?? defaultExtractArchive;
+  const spec = getOpenCodeAssetSpec(platform, arch);
+  const platformDirectory = join(options.cacheDirectory, `${platform}-${arch}`);
+  await mkdir(platformDirectory, { recursive: true });
+
+  try {
+    const release = await findCompatibleRelease(fetchFn, spec.archiveName);
+    const versionDirectory = join(platformDirectory, release.version.value);
+    const cached = await readValidCachedBinary(
+      versionDirectory,
+      platform,
+      arch,
+      spec,
+      release,
+    );
+    const binary =
+      cached ??
+      (await installRelease(
+        platformDirectory,
+        platform,
+        arch,
+        spec,
+        release,
+        fetchFn,
+        extractArchive,
+      ));
+    await pruneCache(platformDirectory);
+    return binary;
+  } catch (cause) {
+    const cached = await findNewestCachedBinary(platformDirectory, platform, arch, spec);
+    if (cached) {
+      console.warn(`[opencode] Update check failed; using cached v${cached.version}`, cause);
+      return cached;
+    }
+    throw new Error(
+      `Unable to download a verified OpenCode ${SUPPORTED_MAJOR}.x.x release and no cached copy is available`,
+      { cause },
+    );
+  }
+}

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",
-    "package": "make deps && pnpm build && electron-builder",
+    "package": "pnpm build && electron-builder",
     "preview": "vite preview",
     "lint": "biome check src/",
     "lint:fix": "biome check --write src/",
@@ -31,12 +31,14 @@
     "@tanstack/react-virtual": "^3.13.23",
     "effect": "^3.22.0",
     "electron-updater": "^6.8.9",
+    "extract-zip": "^2.0.1",
     "posthog-js": "^1.363.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-markdown": "^10.1.0",
     "remark-gfm": "^4.0.1",
-    "sonner": "^2.0.7"
+    "sonner": "^2.0.7",
+    "tar": "^7.5.20"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.3.14",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       electron-updater:
         specifier: ^6.8.9
         version: 6.8.9
+      extract-zip:
+        specifier: ^2.0.1
+        version: 2.0.1
       posthog-js:
         specifier: ^1.363.1
         version: 1.363.1
@@ -44,6 +47,9 @@ importers:
       sonner:
         specifier: ^2.0.7
         version: 2.0.7(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      tar:
+        specifier: ^7.5.20
+        version: 7.5.20
     devDependencies:
       '@biomejs/biome':
         specifier: ^2.3.14
@@ -1028,6 +1034,9 @@ packages:
   '@types/validate-npm-package-name@4.0.2':
     resolution: {integrity: sha512-lrpDziQipxCEeK5kWxvljWYhUvOiB2A9izZd9B2AFarYAkqZshb4lPbRs7zKEic6eGtH8V/2qJW+dPp9OtF6bw==}
 
+  '@types/yauzl@2.10.3':
+    resolution: {integrity: sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==}
+
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
     deprecated: Potential CWE-502 - Update to 1.3.1 or higher
@@ -1224,6 +1233,9 @@ packages:
     resolution: {integrity: sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
+
+  buffer-crc32@0.2.13:
+    resolution: {integrity: sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==}
 
   buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
@@ -1732,6 +1744,11 @@ packages:
   extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
 
+  extract-zip@2.0.1:
+    resolution: {integrity: sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==}
+    engines: {node: '>= 10.17.0'}
+    hasBin: true
+
   fast-check@3.23.2:
     resolution: {integrity: sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A==}
     engines: {node: '>=8.0.0'}
@@ -1748,6 +1765,9 @@ packages:
 
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
+
+  fd-slicer@1.1.0:
+    resolution: {integrity: sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==}
 
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
@@ -2123,10 +2143,6 @@ packages:
   jake@10.9.4:
     resolution: {integrity: sha512-wpHYzhxiVQL+IV05BLE2Xn34zW1S223hvjtqk0+gsPrwd/8JNLXJgZZM/iPFsYc1xyphF+6M6EvdE5E9MBGkDA==}
     engines: {node: '>=10'}
-    hasBin: true
-
-  jiti@2.6.1:
-    resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
     hasBin: true
 
   jiti@2.7.0:
@@ -2744,6 +2760,9 @@ packages:
   pe-library@0.4.1:
     resolution: {integrity: sha512-eRWB5LBz7PpDu4PUlwT0PhnQfTQJlDDdPa35urV4Osrm0t0AqQFGn+UIkU3klZvwJ8KPO3VbBFsXquA6p6kqZw==}
     engines: {node: '>=12', npm: '>=6'}
+
+  pend@1.2.0:
+    resolution: {integrity: sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==}
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
@@ -3594,6 +3613,9 @@ packages:
   yargs@17.7.2:
     resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
     engines: {node: '>=12'}
+
+  yauzl@2.10.0:
+    resolution: {integrity: sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==}
 
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
@@ -4582,6 +4604,11 @@ snapshots:
 
   '@types/validate-npm-package-name@4.0.2': {}
 
+  '@types/yauzl@2.10.3':
+    dependencies:
+      '@types/node': 25.2.2
+    optional: true
+
   '@ungap/structured-clone@1.3.0': {}
 
   '@vitejs/plugin-react@6.0.3(vite@8.1.5(@types/node@25.2.2)(jiti@2.7.0))':
@@ -4704,7 +4731,7 @@ snapshots:
       fs-extra: 10.1.0
       hosted-git-info: 4.1.0
       isbinaryfile: 5.0.7
-      jiti: 2.6.1
+      jiti: 2.7.0
       js-yaml: 4.1.1
       json5: 2.2.3
       lazy-val: 1.0.5
@@ -4809,6 +4836,8 @@ snapshots:
       electron-to-chromium: 1.5.286
       node-releases: 2.0.27
       update-browserslist-db: 1.2.3(browserslist@4.28.1)
+
+  buffer-crc32@0.2.13: {}
 
   buffer-from@1.1.2: {}
 
@@ -5345,6 +5374,16 @@ snapshots:
 
   extend@3.0.2: {}
 
+  extract-zip@2.0.1:
+    dependencies:
+      debug: 4.4.3
+      get-stream: 5.2.0
+      yauzl: 2.10.0
+    optionalDependencies:
+      '@types/yauzl': 2.10.3
+    transitivePeerDependencies:
+      - supports-color
+
   fast-check@3.23.2:
     dependencies:
       pure-rand: 6.1.0
@@ -5364,6 +5403,10 @@ snapshots:
   fastq@1.20.1:
     dependencies:
       reusify: 1.1.0
+
+  fd-slicer@1.1.0:
+    dependencies:
+      pend: 1.2.0
 
   fdir@6.5.0(picomatch@4.0.3):
     optionalDependencies:
@@ -5743,8 +5786,6 @@ snapshots:
       async: 3.2.6
       filelist: 1.0.6
       picocolors: 1.1.1
-
-  jiti@2.6.1: {}
 
   jiti@2.7.0: {}
 
@@ -6527,6 +6568,8 @@ snapshots:
   pathe@2.0.3: {}
 
   pe-library@0.4.1: {}
+
+  pend@1.2.0: {}
 
   picocolors@1.1.1: {}
 
@@ -7452,6 +7495,11 @@ snapshots:
       string-width: 4.2.3
       y18n: 5.0.8
       yargs-parser: 21.1.1
+
+  yauzl@2.10.0:
+    dependencies:
+      buffer-crc32: 0.2.13
+      fd-slicer: 1.1.0
 
   yocto-queue@0.1.0: {}
 

--- a/src/test/opencodeBinary.test.ts
+++ b/src/test/opencodeBinary.test.ts
@@ -1,0 +1,158 @@
+import { createHash } from "node:crypto";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  ensureOpenCodeBinary,
+  type GitHubRelease,
+  getOpenCodeAssetSpec,
+  selectCompatibleRelease,
+} from "../../electron/services/OpenCodeBinary";
+
+const temporaryDirectories: string[] = [];
+
+async function makeTemporaryDirectory() {
+  const directory = await mkdtemp(join(tmpdir(), "bloxbot-opencode-test-"));
+  temporaryDirectories.push(directory);
+  return directory;
+}
+
+function release(
+  version: string,
+  assetName: string,
+  digest: string | null,
+  options: { draft?: boolean; prerelease?: boolean } = {},
+): GitHubRelease {
+  return {
+    tag_name: version,
+    draft: options.draft ?? false,
+    prerelease: options.prerelease ?? false,
+    assets: [
+      {
+        name: assetName,
+        browser_download_url: `https://github.com/anomalyco/opencode/releases/download/${version}/${assetName}`,
+        digest,
+      },
+    ],
+  };
+}
+
+afterEach(async () => {
+  vi.restoreAllMocks();
+  await Promise.all(
+    temporaryDirectories
+      .splice(0)
+      .map((directory) => rm(directory, { recursive: true, force: true })),
+  );
+});
+
+describe("OpenCode binary releases", () => {
+  it("maps every packaged platform to its official archive", () => {
+    expect(getOpenCodeAssetSpec("darwin", "arm64").archiveName).toBe("opencode-darwin-arm64.zip");
+    expect(getOpenCodeAssetSpec("darwin", "x64").archiveName).toBe("opencode-darwin-x64.zip");
+    expect(getOpenCodeAssetSpec("win32", "x64").executableName).toBe("opencode.exe");
+    expect(getOpenCodeAssetSpec("linux", "x64").format).toBe("tar.gz");
+    expect(() => getOpenCodeAssetSpec("win32", "arm64")).toThrow("win32/arm64");
+  });
+
+  it("selects the newest verified stable 1.x.x release and rejects other majors", () => {
+    const assetName = "opencode-darwin-arm64.zip";
+    const digest = `sha256:${"a".repeat(64)}`;
+    const selected = selectCompatibleRelease(
+      [
+        release("v2.0.0", assetName, digest),
+        release("v1.12.0-beta.1", assetName, digest),
+        release("v1.11.9", assetName, digest, { prerelease: true }),
+        release("v1.10.3", assetName, null),
+        release("v1.9.12", assetName, digest),
+        release("v1.11.2", assetName, digest),
+      ],
+      assetName,
+    );
+
+    expect(selected?.version.value).toBe("1.11.2");
+    expect(selected?.archiveSha256).toBe("a".repeat(64));
+  });
+
+  it("downloads, verifies, installs, and reuses a cached binary when offline", async () => {
+    const cacheDirectory = await makeTemporaryDirectory();
+    const archive = Buffer.from("verified archive");
+    const digest = createHash("sha256").update(archive).digest("hex");
+    const assetName = "opencode-darwin-arm64.zip";
+    const releases = [release("v1.4.2", assetName, `sha256:${digest}`)];
+    const fetch = vi
+      .fn()
+      .mockResolvedValueOnce(Response.json(releases))
+      .mockResolvedValueOnce(new Response(archive));
+    const extractArchive = vi.fn(async (_archivePath: string, destination: string) => {
+      await writeFile(join(destination, "opencode"), "runtime binary");
+    });
+
+    const installed = await ensureOpenCodeBinary({
+      cacheDirectory,
+      platform: "darwin",
+      arch: "arm64",
+      fetch,
+      extractArchive,
+    });
+
+    expect(installed.version).toBe("1.4.2");
+    expect(installed.executable).toBe(join(cacheDirectory, "darwin-arm64", "1.4.2", "opencode"));
+    await expect(readFile(installed.executable, "utf8")).resolves.toBe("runtime binary");
+    expect(fetch).toHaveBeenCalledTimes(2);
+
+    vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const cached = await ensureOpenCodeBinary({
+      cacheDirectory,
+      platform: "darwin",
+      arch: "arm64",
+      fetch: vi.fn().mockRejectedValue(new Error("offline")),
+      extractArchive,
+    });
+
+    expect(cached).toEqual(installed);
+    expect(extractArchive).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not install an archive whose digest does not match", async () => {
+    const cacheDirectory = await makeTemporaryDirectory();
+    const assetName = "opencode-linux-x64.tar.gz";
+    const fetch = vi
+      .fn()
+      .mockResolvedValueOnce(
+        Response.json([release("v1.7.0", assetName, `sha256:${"b".repeat(64)}`)]),
+      )
+      .mockResolvedValueOnce(new Response("tampered archive"));
+
+    await expect(
+      ensureOpenCodeBinary({
+        cacheDirectory,
+        platform: "linux",
+        arch: "x64",
+        fetch,
+        extractArchive: vi.fn(),
+      }),
+    ).rejects.toThrow("no cached copy is available");
+  });
+
+  it("fails closed when only a new major release exists", async () => {
+    const cacheDirectory = await makeTemporaryDirectory();
+    const assetName = "opencode-windows-x64.zip";
+
+    await expect(
+      ensureOpenCodeBinary({
+        cacheDirectory,
+        platform: "win32",
+        arch: "x64",
+        fetch: vi
+          .fn()
+          .mockResolvedValue(
+            Response.json([release("v2.0.0", assetName, `sha256:${"c".repeat(64)}`)]),
+          ),
+      }),
+    ).rejects.toThrow("no cached copy is available");
+  });
+});


### PR DESCRIPTION
## Summary

- resolve and download the newest stable OpenCode `1.x.x` release when the app starts
- verify GitHub's SHA-256 archive digest before installing the executable
- cache binaries per platform and architecture, validate cached executable hashes, and retain one previous version for offline fallback
- reject prereleases, drafts, unverified assets, and releases outside major version 1
- remove the pinned OpenCode binary from the Makefile, CI workflow, and Electron package

## Why

OpenCode was pinned and downloaded during application builds, so users could not receive compatible minor and patch updates without a new BloxBot release. The binary was also embedded in every installer even though it can be acquired and verified independently at runtime.

## Impact

The first app launch requires network access to download OpenCode. Subsequent launches check for newer compatible `1.x.x` releases and can start from the newest verified cached copy when offline. Major-version upgrades remain opt-in through an application change.

## Validation

- `pnpm test` — 83 tests passed
- `pnpm typecheck`
- `pnpm build`
- `pnpm exec biome check src/test/opencodeBinary.test.ts`
- `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/ci.yml`
- `pnpm exec electron-builder --mac --arm64 --dir --publish never`
- live release test selected, verified, extracted, and ran OpenCode `1.18.3`
- verified the packaged app contains no bundled OpenCode binary