### PR TITLE
fix: add Linux package maintainer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
             target: x86_64-pc-windows-msvc
             builder_args: --win --x64
 
-          - platform: ubuntu-22.04
+          - platform: ubuntu-latest
             target: x86_64-unknown-linux-gnu
             builder_args: --linux deb --x64
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,10 @@
   "type": "module",
   "main": "dist-electron/main/main.js",
   "license": "MIT",
-  "author": "BloxBot",
+  "author": {
+    "name": "OscarWoHA",
+    "email": "3245494+OscarWoHA@users.noreply.github.com"
+  },
   "homepage": "https://bloxbot.ai",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

- define the package author as `OscarWoHA`
- add `3245494+OscarWoHA@users.noreply.github.com` as the package author email
- provide electron-builder with the maintainer metadata required for Debian packages
- move the Linux CI build from the legacy `ubuntu-22.04` runner to `ubuntu-latest`

## Why

The Linux CI job reached `.deb` creation but electron-builder stopped because `package.json` had a string author without an email. Debian packages require maintainer identity metadata. The explicit Ubuntu 22.04 runner was retained from the removed Tauri build and is no longer required by the Electron pipeline.

## Impact

Linux `.deb` builds now include the following metadata:

- Vendor: `OscarWoHA <3245494+OscarWoHA@users.noreply.github.com>`
- Maintainer: `OscarWoHA <3245494+OscarWoHA@users.noreply.github.com>`

Linux CI follows GitHub's current `ubuntu-latest` image. Application runtime behavior is unchanged.

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm build`
- `pnpm exec electron-builder --linux deb --x64 --publish never`
- inspected `release/bloxbot_0.5.2_amd64.deb` control metadata to confirm Vendor and Maintainer
- `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/ci.yml`