### PR TITLE
Secure OpenCode startup and quit development app

### DIFF
--- a/electron/appLifecycle.ts
+++ b/electron/appLifecycle.ts
@@ -1,0 +1,6 @@
+export function shouldQuitAfterLastWindowCloses(
+  platform: NodeJS.Platform,
+  isPackaged: boolean,
+): boolean {
+  return platform !== "darwin" || !isPackaged;
+}

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -7,6 +7,7 @@ import { autoUpdater } from "electron-updater";
 import { Effect, ManagedRuntime } from "effect";
 
 import type { AppConfig } from "../src/types/desktop";
+import { shouldQuitAfterLastWindowCloses } from "./appLifecycle";
 import { channels } from "./channels";
 import { makeOpenCodeLayer, OpenCode } from "./services/OpenCode";
 
@@ -131,7 +132,7 @@ app.whenReady().then(() => {
 });
 
 app.on("window-all-closed", () => {
-  if (process.platform !== "darwin") app.quit();
+  if (shouldQuitAfterLastWindowCloses(process.platform, app.isPackaged)) app.quit();
 });
 
 app.on("before-quit", (event) => {

--- a/electron/services/OpenCode.ts
+++ b/electron/services/OpenCode.ts
@@ -4,6 +4,7 @@ import { mkdir, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 
 import { Context, Data, Effect, Layer } from "effect";
+import { networkConnections, type Systeminformation } from "systeminformation";
 
 import type { OpenCodeInfo } from "../../src/types/desktop";
 import { createOpenCodeConfig } from "../opencodeConfig";
@@ -33,48 +34,69 @@ export interface OpenCodeService {
 
 export class OpenCode extends Context.Tag("@bloxbot/OpenCode")<OpenCode, OpenCodeService>() {}
 
-export function parseOpenCodeListeningPort(output: string): number | null {
-  const match = output.match(/opencode server listening on http:\/\/127\.0\.0\.1:(\d+)/);
-  if (!match) return null;
+type NetworkConnection = Pick<
+  Systeminformation.NetworkConnectionsData,
+  "localAddress" | "localPort" | "pid" | "protocol" | "state"
+>;
 
-  const port = Number(match[1]);
-  return Number.isInteger(port) && port > 0 && port <= 65_535 ? port : null;
+export function findOpenCodeListeningPort(
+  connections: readonly NetworkConnection[],
+  pid: number,
+): number | null {
+  const ports = new Set(
+    connections
+      .filter(
+        (connection) =>
+          connection.pid === pid &&
+          connection.protocol.startsWith("tcp") &&
+          connection.localAddress === LOOPBACK &&
+          connection.state === "LISTEN",
+      )
+      .map((connection) => Number(connection.localPort))
+      .filter((port) => Number.isInteger(port) && port > 0 && port <= 65_535),
+  );
+
+  if (ports.size > 1) {
+    throw new Error(`OpenCode is listening on multiple loopback ports: ${[...ports].join(", ")}`);
+  }
+  return ports.values().next().value ?? null;
 }
 
-async function waitForListeningPort(child: ChildProcessWithoutNullStreams): Promise<number> {
-  return new Promise((resolve, reject) => {
-    let output = "";
-
+async function waitForSpawn(child: ChildProcessWithoutNullStreams): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
     const cleanup = () => {
-      clearTimeout(timeout);
-      child.stdout.off("data", onData);
+      child.off("spawn", onSpawn);
       child.off("error", onError);
-      child.off("exit", onExit);
     };
-    const fail = (error: Error) => {
+    const onSpawn = () => {
+      cleanup();
+      resolve();
+    };
+    const onError = (error: Error) => {
       cleanup();
       reject(error);
     };
-    const onData = (data: Buffer) => {
-      output += data.toString();
-      const port = parseOpenCodeListeningPort(output);
-      if (port !== null) {
-        cleanup();
-        resolve(port);
-      }
-    };
-    const onError = (error: Error) => fail(error);
-    const onExit = (code: number | null) =>
-      fail(new Error(`OpenCode exited during startup with code ${code}`));
-    const timeout = setTimeout(
-      () => fail(new Error("OpenCode did not report a listening port within 60 seconds")),
-      STARTUP_TIMEOUT_MS,
-    );
 
-    child.stdout.on("data", onData);
+    child.once("spawn", onSpawn);
     child.once("error", onError);
-    child.once("exit", onExit);
   });
+}
+
+async function waitForListeningPort(child: ChildProcessWithoutNullStreams): Promise<number> {
+  if (child.pid === undefined) throw new Error("OpenCode started without a process ID");
+
+  const deadline = Date.now() + STARTUP_TIMEOUT_MS;
+  while (Date.now() < deadline) {
+    if (child.exitCode !== null) {
+      throw new Error(`OpenCode exited during startup with code ${child.exitCode}`);
+    }
+
+    const port = findOpenCodeListeningPort(await networkConnections(), child.pid);
+    if (port !== null) return port;
+    await new Promise((resolve) => setTimeout(resolve, 500));
+  }
+
+  throw new Error("OpenCode did not open a listening port within 60 seconds");
 }
 
 async function waitForHealth(
@@ -154,6 +176,7 @@ async function startOpenCode(options: OpenCodeOptions): Promise<OpenCodeResource
   child.stderr.on("data", (data: Buffer) => console.error(`[opencode] ${data.toString().trimEnd()}`));
 
   try {
+    await waitForSpawn(child);
     const listeningPort = await waitForListeningPort(child);
     await waitForHealth(child, listeningPort, authorization);
     return { authorization, child, port: listeningPort, workspace: options.workspace };

--- a/electron/services/OpenCode.ts
+++ b/electron/services/OpenCode.ts
@@ -53,7 +53,7 @@ export function findOpenCodeListeningPort(
           connection.state === "LISTEN",
       )
       .map((connection) => Number(connection.localPort))
-      .filter((port) => Number.isInteger(port) && port > 0 && port <= 65_535),
+      .filter(Number.isInteger),
   );
 
   if (ports.size > 1) {

--- a/electron/services/OpenCode.ts
+++ b/electron/services/OpenCode.ts
@@ -1,6 +1,6 @@
 import { type ChildProcessWithoutNullStreams, spawn } from "node:child_process";
+import { randomBytes } from "node:crypto";
 import { mkdir, writeFile } from "node:fs/promises";
-import { createServer } from "node:net";
 import { join } from "node:path";
 
 import { Context, Data, Effect, Layer } from "effect";
@@ -10,9 +10,8 @@ import { createOpenCodeConfig } from "../opencodeConfig";
 import { ensureOpenCodeBinary } from "./OpenCodeBinary";
 
 const LOOPBACK = "127.0.0.1";
-const PORT_START = 59200;
-const PORT_COUNT = 10;
 const STARTUP_TIMEOUT_MS = 60_000;
+const SERVER_USERNAME = "opencode";
 
 export class OpenCodeError extends Data.TaggedError("OpenCodeError")<{
   message: string;
@@ -34,30 +33,55 @@ export interface OpenCodeService {
 
 export class OpenCode extends Context.Tag("@bloxbot/OpenCode")<OpenCode, OpenCodeService>() {}
 
-async function canListen(port: number): Promise<boolean> {
-  return new Promise((resolve) => {
-    const server = createServer();
-    server.once("error", () => resolve(false));
-    server.listen(port, LOOPBACK, () => server.close(() => resolve(true)));
+export function parseOpenCodeListeningPort(output: string): number | null {
+  const match = output.match(/opencode server listening on http:\/\/127\.0\.0\.1:(\d+)/);
+  if (!match) return null;
+
+  const port = Number(match[1]);
+  return Number.isInteger(port) && port > 0 && port <= 65_535 ? port : null;
+}
+
+async function waitForListeningPort(child: ChildProcessWithoutNullStreams): Promise<number> {
+  return new Promise((resolve, reject) => {
+    let output = "";
+
+    const cleanup = () => {
+      clearTimeout(timeout);
+      child.stdout.off("data", onData);
+      child.off("error", onError);
+      child.off("exit", onExit);
+    };
+    const fail = (error: Error) => {
+      cleanup();
+      reject(error);
+    };
+    const onData = (data: Buffer) => {
+      output += data.toString();
+      const port = parseOpenCodeListeningPort(output);
+      if (port !== null) {
+        cleanup();
+        resolve(port);
+      }
+    };
+    const onError = (error: Error) => fail(error);
+    const onExit = (code: number | null) =>
+      fail(new Error(`OpenCode exited during startup with code ${code}`));
+    const timeout = setTimeout(
+      () => fail(new Error("OpenCode did not report a listening port within 60 seconds")),
+      STARTUP_TIMEOUT_MS,
+    );
+
+    child.stdout.on("data", onData);
+    child.once("error", onError);
+    child.once("exit", onExit);
   });
 }
 
-async function findAvailablePort(): Promise<number> {
-  for (let offset = 0; offset < PORT_COUNT; offset++) {
-    const port = PORT_START + offset;
-    if (await canListen(port)) return port;
-  }
-  throw new Error(`No available port in ${PORT_START}-${PORT_START + PORT_COUNT - 1}`);
-}
-
-async function waitForSpawn(child: ChildProcessWithoutNullStreams): Promise<void> {
-  await new Promise<void>((resolve, reject) => {
-    child.once("spawn", resolve);
-    child.once("error", reject);
-  });
-}
-
-async function waitForHealth(child: ChildProcessWithoutNullStreams, port: number): Promise<void> {
+async function waitForHealth(
+  child: ChildProcessWithoutNullStreams,
+  port: number,
+  authorization: string,
+): Promise<void> {
   const deadline = Date.now() + STARTUP_TIMEOUT_MS;
   const healthUrl = `http://${LOOPBACK}:${port}/global/health`;
 
@@ -67,7 +91,10 @@ async function waitForHealth(child: ChildProcessWithoutNullStreams, port: number
     }
 
     try {
-      const response = await fetch(healthUrl, { signal: AbortSignal.timeout(2_000) });
+      const response = await fetch(healthUrl, {
+        headers: { Authorization: authorization },
+        signal: AbortSignal.timeout(2_000),
+      });
       if (response.ok) return;
     } catch {
       // The server is still starting. Retry until the explicit deadline.
@@ -80,7 +107,6 @@ async function waitForHealth(child: ChildProcessWithoutNullStreams, port: number
 }
 
 async function startOpenCode(options: OpenCodeOptions): Promise<OpenCodeResource> {
-  const port = await findAvailablePort();
   const { executable, version } = await ensureOpenCodeBinary({
     cacheDirectory: options.binaryCacheDirectory,
   });
@@ -102,9 +128,12 @@ async function startOpenCode(options: OpenCodeOptions): Promise<OpenCodeResource
     JSON.stringify(createOpenCodeConfig(), null, 2),
   );
 
+  const password = randomBytes(32).toString("base64url");
+  const authorization = `Basic ${Buffer.from(`${SERVER_USERNAME}:${password}`).toString("base64")}`;
+
   const child = spawn(
     executable,
-    ["serve", "--port", String(port), "--hostname", LOOPBACK, "--print-logs", "--log-level", "INFO"],
+    ["serve", "--port", "0", "--hostname", LOOPBACK, "--print-logs", "--log-level", "INFO"],
     {
       cwd: options.workspace,
       env: {
@@ -113,6 +142,8 @@ async function startOpenCode(options: OpenCodeOptions): Promise<OpenCodeResource
         XDG_CONFIG_HOME: xdgConfig,
         XDG_DATA_HOME: xdgData,
         XDG_STATE_HOME: xdgState,
+        OPENCODE_SERVER_PASSWORD: password,
+        OPENCODE_SERVER_USERNAME: SERVER_USERNAME,
       },
       stdio: "pipe",
       windowsHide: true,
@@ -123,14 +154,13 @@ async function startOpenCode(options: OpenCodeOptions): Promise<OpenCodeResource
   child.stderr.on("data", (data: Buffer) => console.error(`[opencode] ${data.toString().trimEnd()}`));
 
   try {
-    await waitForSpawn(child);
-    await waitForHealth(child, port);
+    const listeningPort = await waitForListeningPort(child);
+    await waitForHealth(child, listeningPort, authorization);
+    return { authorization, child, port: listeningPort, workspace: options.workspace };
   } catch (error) {
     child.kill("SIGKILL");
     throw error;
   }
-
-  return { child, port, workspace: options.workspace };
 }
 
 async function stopOpenCode(resource: OpenCodeResource): Promise<void> {
@@ -179,7 +209,11 @@ export function makeOpenCodeLayer(options: OpenCodeOptions) {
               }),
             );
           }
-          return Effect.succeed({ port: resource.port, workspace: resource.workspace });
+          return Effect.succeed({
+            authorization: resource.authorization,
+            port: resource.port,
+            workspace: resource.workspace,
+          });
         }),
       })),
     ),

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "react-markdown": "^10.1.0",
     "remark-gfm": "^4.0.1",
     "sonner": "^2.0.7",
+    "systeminformation": "^5.31.16",
     "tar": "^7.5.20"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,6 +47,9 @@ importers:
       sonner:
         specifier: ^2.0.7
         version: 2.0.7(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      systeminformation:
+        specifier: ^5.31.16
+        version: 5.31.16
       tar:
         specifier: ^7.5.20
         version: 7.5.20
@@ -3217,6 +3220,12 @@ packages:
 
   symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
+
+  systeminformation@5.31.16:
+    resolution: {integrity: sha512-37NsFaeaqwYxanLgdJAGWj8OXIRgvSBsDXGhlC0uUoHyl9nf4HrNsZjqtQ9Gc99bj9FQpffzYccPVuQ6gpjfqg==}
+    engines: {node: '>=8.0.0'}
+    os: [darwin, linux, win32, freebsd, openbsd, netbsd, sunos, android]
+    hasBin: true
 
   tagged-tag@1.0.0:
     resolution: {integrity: sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==}
@@ -7157,6 +7166,8 @@ snapshots:
       has-flag: 4.0.0
 
   symbol-tree@3.2.4: {}
+
+  systeminformation@5.31.16: {}
 
   tagged-tag@1.0.0: {}
 

--- a/src/providers/OpenCodeClientProvider.tsx
+++ b/src/providers/OpenCodeClientProvider.tsx
@@ -57,16 +57,16 @@ export function OpenCodeClientProvider({
     let retryTimer: ReturnType<typeof setTimeout>;
 
     // The desktop service owns startup, its deadline, and process cleanup.
-    async function waitForPort(): Promise<[number, string]> {
-      const info = await desktop.getOpenCodeInfo();
-      return [info.port, info.workspace];
+    async function getServerInfo() {
+      return desktop.getOpenCodeInfo();
     }
 
     // Step 2: Poll the HTTP server until it responds.
-    async function waitForServer(baseUrl: string): Promise<void> {
+    async function waitForServer(baseUrl: string, authorization: string): Promise<void> {
       while (!cancelled) {
         try {
           const res = await fetch(`${baseUrl}/session`, {
+            headers: { Authorization: authorization },
             method: "GET",
             signal: AbortSignal.timeout(3000),
           });
@@ -83,14 +83,18 @@ export function OpenCodeClientProvider({
 
     async function init() {
       try {
-        const [ocPort, workspace] = await waitForPort();
+        const { port: ocPort, workspace, authorization } = await getServerInfo();
         if (cancelled) return;
 
         const baseUrl = `http://127.0.0.1:${ocPort}`;
-        await waitForServer(baseUrl);
+        await waitForServer(baseUrl, authorization);
         if (cancelled) return;
 
-        const newClient = createOpencodeClient({ baseUrl, directory: workspace });
+        const newClient = createOpencodeClient({
+          baseUrl,
+          directory: workspace,
+          headers: { Authorization: authorization },
+        });
         await prefetchServerState(newClient, queryClient);
         if (cancelled) return;
 

--- a/src/test/appLifecycle.test.ts
+++ b/src/test/appLifecycle.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+
+import { shouldQuitAfterLastWindowCloses } from "../../electron/appLifecycle";
+
+describe("app lifecycle", () => {
+  it("quits when the last development window closes on macOS", () => {
+    expect(shouldQuitAfterLastWindowCloses("darwin", false)).toBe(true);
+  });
+
+  it("keeps the native macOS lifecycle for packaged builds", () => {
+    expect(shouldQuitAfterLastWindowCloses("darwin", true)).toBe(false);
+  });
+
+  it("quits when the last window closes on other platforms", () => {
+    expect(shouldQuitAfterLastWindowCloses("linux", true)).toBe(true);
+    expect(shouldQuitAfterLastWindowCloses("win32", true)).toBe(true);
+  });
+});

--- a/src/test/opencode.test.ts
+++ b/src/test/opencode.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+
+import { parseOpenCodeListeningPort } from "../../electron/services/OpenCode";
+
+describe("OpenCode server startup", () => {
+  it("reads an OS-assigned loopback port from the startup message", () => {
+    expect(
+      parseOpenCodeListeningPort(
+        "logs before\nopencode server listening on http://127.0.0.1:54321\n",
+      ),
+    ).toBe(54321);
+  });
+
+  it("rejects missing and invalid ports", () => {
+    expect(parseOpenCodeListeningPort("starting")).toBeNull();
+    expect(
+      parseOpenCodeListeningPort("opencode server listening on http://127.0.0.1:70000"),
+    ).toBeNull();
+  });
+});

--- a/src/test/opencode.test.ts
+++ b/src/test/opencode.test.ts
@@ -1,20 +1,30 @@
 import { describe, expect, it } from "vitest";
 
-import { parseOpenCodeListeningPort } from "../../electron/services/OpenCode";
+import { findOpenCodeListeningPort } from "../../electron/services/OpenCode";
 
 describe("OpenCode server startup", () => {
-  it("reads an OS-assigned loopback port from the startup message", () => {
-    expect(
-      parseOpenCodeListeningPort(
-        "logs before\nopencode server listening on http://127.0.0.1:54321\n",
-      ),
-    ).toBe(54321);
+  const connection = {
+    localAddress: "127.0.0.1",
+    localPort: "54321",
+    pid: 1234,
+    protocol: "tcp4",
+    state: "LISTEN",
+  };
+
+  it("finds the loopback TCP listener owned by the OpenCode process", () => {
+    expect(findOpenCodeListeningPort([connection], 1234)).toBe(54321);
   });
 
-  it("rejects missing and invalid ports", () => {
-    expect(parseOpenCodeListeningPort("starting")).toBeNull();
+  it("ignores connections that do not belong to the OpenCode listener", () => {
     expect(
-      parseOpenCodeListeningPort("opencode server listening on http://127.0.0.1:70000"),
+      findOpenCodeListeningPort(
+        [
+          { ...connection, pid: 9999 },
+          { ...connection, state: "ESTABLISHED" },
+          { ...connection, localAddress: "0.0.0.0" },
+        ],
+        1234,
+      ),
     ).toBeNull();
   });
 });

--- a/src/types/desktop.ts
+++ b/src/types/desktop.ts
@@ -4,6 +4,7 @@ export interface AppConfig {
 }
 
 export interface OpenCodeInfo {
+  authorization: string;
   port: number;
   workspace: string;
 }


### PR DESCRIPTION
## What changed

- start OpenCode with `--port 0` and discover its TCP listener from the child PID using `systeminformation`
- generate per-launch Basic authentication credentials and use them for health checks and SDK requests
- quit Electron when the final development window closes on macOS while preserving native packaged-app behavior
- add focused tests for process-owned listener selection and platform lifecycle decisions

## Why

Development window closure left Electron, Vite, and OpenCode running. OpenCode also used a predictable fixed port range and exposed an unauthenticated loopback server.

## Impact

Development runs now terminate completely when their final window closes. OpenCode owns no BloxBot-defined fixed port range and rejects unauthenticated local requests. Port discovery uses cross-platform process/network information rather than parsing OpenCode log output.

## Validation

- `pnpm test` — 88 tests passed
- `pnpm typecheck`
- `pnpm build`
- live macOS smoke test confirmed PID-based listener discovery, authenticated startup, and full process/port cleanup after closing the window
- changed source files pass Biome checks

The repository-wide `pnpm lint` command still reports pre-existing unrelated formatting and lint diagnostics outside this change.
