### PR TITLE
refactor: migrate non-React runtime to Effect

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -4,18 +4,28 @@ import { fileURLToPath } from "node:url";
 
 import { app, BrowserWindow, ipcMain, Menu, shell } from "electron";
 import { autoUpdater } from "electron-updater";
-import { Effect, ManagedRuntime } from "effect";
+import { Data, Effect, ManagedRuntime, Schema } from "effect";
 
-import type { AppConfig } from "../src/types/desktop";
+import {
+  type AppConfig,
+  AppConfigPatchSchema,
+  AppConfigSchema,
+} from "../src/types/desktop";
 import { shouldQuitAfterLastWindowCloses } from "./appLifecycle";
 import { channels } from "./channels";
 import { makeOpenCodeLayer, OpenCode } from "./services/OpenCode";
 
 const currentDirectory = dirname(fileURLToPath(import.meta.url));
 const defaultConfig: AppConfig = { lastModel: null, hiddenModels: [] };
+const configMutex = Effect.unsafeMakeSemaphore(1);
 
 let mainWindow: BrowserWindow | null = null;
 let quitting = false;
+
+class DesktopMainError extends Data.TaggedError("DesktopMainError")<{
+  message: string;
+  cause?: unknown;
+}> {}
 
 const openCodeRuntime = ManagedRuntime.make(
   makeOpenCodeLayer({
@@ -24,122 +34,267 @@ const openCodeRuntime = ManagedRuntime.make(
   }),
 );
 
-function isSafeExternalUrl(rawUrl: string): boolean {
-  try {
-    const url = new URL(rawUrl);
-    return url.protocol === "https:" || url.protocol === "http:";
-  } catch {
-    return false;
-  }
+function isMissingFile(cause: unknown): boolean {
+  return (
+    cause !== null &&
+    typeof cause === "object" &&
+    "code" in cause &&
+    cause.code === "ENOENT"
+  );
 }
 
-async function loadConfig(): Promise<AppConfig> {
-  try {
-    const contents = await readFile(join(app.getPath("userData"), "bloxbot-store.json"), "utf8");
-    return { ...defaultConfig, ...JSON.parse(contents) };
-  } catch {
-    return defaultConfig;
-  }
+function parseExternalUrl(rawUrl: string) {
+  return Effect.try({
+    try: () => new URL(rawUrl),
+    catch: (cause) =>
+      new DesktopMainError({ message: "Only HTTP and HTTPS links can be opened", cause }),
+  }).pipe(
+    Effect.flatMap((url) =>
+      url.protocol === "https:" || url.protocol === "http:"
+        ? Effect.succeed(url)
+        : Effect.fail(
+            new DesktopMainError({ message: "Only HTTP and HTTPS links can be opened" }),
+          ),
+    ),
+  );
 }
 
-async function patchConfig(patch: Partial<AppConfig>): Promise<void> {
-  const next = { ...(await loadConfig()), ...patch };
-  await writeFile(join(app.getPath("userData"), "bloxbot-store.json"), JSON.stringify(next, null, 2));
+const loadConfig = Effect.gen(function* () {
+  const contents = yield* Effect.tryPromise({
+    try: () => readFile(join(app.getPath("userData"), "bloxbot-store.json"), "utf8"),
+    catch: (cause) => new DesktopMainError({ message: "Failed to read app configuration", cause }),
+  }).pipe(
+    Effect.catchAll((error) =>
+      isMissingFile(error.cause) ? Effect.succeed(null) : Effect.fail(error),
+    ),
+  );
+  if (contents === null) return defaultConfig;
+
+  return yield* Effect.gen(function* () {
+    const stored = yield* Effect.try({
+      try: () => JSON.parse(contents) as unknown,
+      catch: (cause) => new DesktopMainError({ message: "App configuration is invalid", cause }),
+    });
+    const candidate =
+      stored !== null && typeof stored === "object" ? { ...defaultConfig, ...stored } : defaultConfig;
+    return yield* Schema.decodeUnknown(AppConfigSchema)(candidate).pipe(
+      Effect.mapError(
+        (cause) => new DesktopMainError({ message: "App configuration is invalid", cause }),
+      ),
+    );
+  }).pipe(
+    Effect.tapError((error) => Effect.logWarning(error.message, error.cause)),
+    Effect.catchAll(() => Effect.succeed(defaultConfig)),
+  );
+});
+
+function patchConfig(input: unknown) {
+  return Effect.gen(function* () {
+    const patch = yield* Schema.decodeUnknown(AppConfigPatchSchema)(input).pipe(
+      Effect.mapError(
+        (cause) => new DesktopMainError({ message: "App configuration patch is invalid", cause }),
+      ),
+    );
+    const current = yield* loadConfig;
+    const next = { ...current, ...patch };
+    yield* Effect.tryPromise({
+      try: () =>
+        writeFile(
+          join(app.getPath("userData"), "bloxbot-store.json"),
+          JSON.stringify(next, null, 2),
+        ),
+      catch: (cause) =>
+        new DesktopMainError({ message: "Failed to write app configuration", cause }),
+    });
+  }).pipe(configMutex.withPermits(1));
 }
 
-function registerIpcHandlers(): void {
+const runMain = <A, E>(effect: Effect.Effect<A, E>) => Effect.runPromise(effect);
+
+const registerIpcHandlers = Effect.sync(() => {
   ipcMain.handle(channels.getOpenCodeInfo, () =>
     openCodeRuntime.runPromise(
       OpenCode.pipe(Effect.flatMap((service) => service.info)),
     ),
   );
-  ipcMain.handle(channels.getVersion, () => app.getVersion());
-  ipcMain.handle(channels.loadConfig, loadConfig);
-  ipcMain.handle(channels.patchConfig, (_event, patch: Partial<AppConfig>) => patchConfig(patch));
-  ipcMain.handle(channels.openUrl, async (_event, url: string) => {
-    if (!isSafeExternalUrl(url)) throw new Error("Only HTTP and HTTPS links can be opened");
-    await shell.openExternal(url);
-  });
-  ipcMain.handle(channels.checkForUpdate, async () => {
-    if (!app.isPackaged) return null;
-    const result = await autoUpdater.checkForUpdates();
-    if (!result) return null;
-    const body = typeof result.updateInfo.releaseNotes === "string" ? result.updateInfo.releaseNotes : null;
-    return { version: result.updateInfo.version, body };
-  });
-  ipcMain.handle(channels.installUpdate, async () => {
-    if (!app.isPackaged) throw new Error("Updates are only available in packaged builds");
-    await autoUpdater.downloadUpdate();
-    autoUpdater.quitAndInstall();
-  });
-  ipcMain.handle(channels.relaunch, () => {
-    app.relaunch();
-    app.quit();
+  ipcMain.handle(channels.getVersion, () => runMain(Effect.sync(() => app.getVersion())));
+  ipcMain.handle(channels.loadConfig, () => runMain(loadConfig));
+  ipcMain.handle(channels.patchConfig, (_event, patch: unknown) => runMain(patchConfig(patch)));
+  ipcMain.handle(channels.openUrl, (_event, rawUrl: string) =>
+    runMain(
+      parseExternalUrl(rawUrl).pipe(
+        Effect.flatMap((url) =>
+          Effect.tryPromise({
+            try: () => shell.openExternal(url.href),
+            catch: (cause) => new DesktopMainError({ message: "Failed to open URL", cause }),
+          }),
+        ),
+      ),
+    ),
+  );
+  ipcMain.handle(channels.checkForUpdate, () =>
+    runMain(
+      Effect.gen(function* () {
+        if (!app.isPackaged) return null;
+        const result = yield* Effect.tryPromise({
+          try: () => autoUpdater.checkForUpdates(),
+          catch: (cause) =>
+            new DesktopMainError({ message: "Failed to check for updates", cause }),
+        });
+        if (!result) return null;
+        const body =
+          typeof result.updateInfo.releaseNotes === "string" ? result.updateInfo.releaseNotes : null;
+        return { version: result.updateInfo.version, body };
+      }),
+    ),
+  );
+  ipcMain.handle(channels.installUpdate, () =>
+    runMain(
+      Effect.gen(function* () {
+        if (!app.isPackaged) {
+          return yield* Effect.fail(
+            new DesktopMainError({ message: "Updates are only available in packaged builds" }),
+          );
+        }
+        yield* Effect.tryPromise({
+          try: () => autoUpdater.downloadUpdate(),
+          catch: (cause) =>
+            new DesktopMainError({ message: "Failed to download the update", cause }),
+        });
+        yield* Effect.sync(() => autoUpdater.quitAndInstall());
+      }),
+    ),
+  );
+  ipcMain.handle(channels.relaunch, () =>
+    runMain(
+      Effect.sync(() => {
+        app.relaunch();
+        app.quit();
+      }),
+    ),
+  );
+});
+
+function createWindow(): Effect.Effect<void, DesktopMainError> {
+  return Effect.gen(function* () {
+    const window = yield* Effect.try({
+      try: () =>
+        new BrowserWindow({
+          title: "BloxBot",
+          width: 800,
+          height: 600,
+          minWidth: 520,
+          minHeight: 400,
+          backgroundColor: "#ffffff",
+          titleBarStyle: "hiddenInset",
+          show: false,
+          webPreferences: {
+            contextIsolation: true,
+            nodeIntegration: false,
+            preload: join(currentDirectory, "..", "preload", "preload.mjs"),
+            sandbox: true,
+          },
+        }),
+      catch: (cause) => new DesktopMainError({ message: "Failed to create app window", cause }),
+    });
+
+    yield* Effect.sync(() => {
+      mainWindow = window;
+      window.webContents.setWindowOpenHandler(({ url }) => {
+        Effect.runFork(
+          parseExternalUrl(url).pipe(
+            Effect.flatMap((externalUrl) =>
+              Effect.tryPromise({
+                try: () => shell.openExternal(externalUrl.href),
+                catch: (cause) =>
+                  new DesktopMainError({ message: "Failed to open URL", cause }),
+              }),
+            ),
+            Effect.catchAll(Effect.logWarning),
+          ),
+        );
+        return { action: "deny" };
+      });
+      window.webContents.on("will-navigate", (event, url) => {
+        const currentUrl = window.webContents.getURL();
+        const shouldBlock = Effect.runSync(
+          Effect.try({
+            try: () => Boolean(currentUrl && new URL(url).origin !== new URL(currentUrl).origin),
+            catch: () => true,
+          }).pipe(Effect.catchAll(() => Effect.succeed(true))),
+        );
+        if (shouldBlock) event.preventDefault();
+      });
+      window.once("ready-to-show", () => Effect.runSync(Effect.sync(() => window.show())));
+      window.on("closed", () =>
+        Effect.runSync(
+          Effect.sync(() => {
+            if (mainWindow === window) mainWindow = null;
+          }),
+        ),
+      );
+    });
+
+    yield* Effect.tryPromise({
+      try: () =>
+        process.env.VITE_DEV_SERVER_URL
+          ? window.loadURL(process.env.VITE_DEV_SERVER_URL)
+          : window.loadFile(join(currentDirectory, "..", "..", "dist", "index.html")),
+      catch: (cause) => new DesktopMainError({ message: "Failed to load the app window", cause }),
+    });
   });
 }
 
-function createWindow(): void {
-  mainWindow = new BrowserWindow({
-    title: "BloxBot",
-    width: 800,
-    height: 600,
-    minWidth: 520,
-    minHeight: 400,
-    backgroundColor: "#ffffff",
-    titleBarStyle: "hiddenInset",
-    show: false,
-    webPreferences: {
-      contextIsolation: true,
-      nodeIntegration: false,
-      preload: join(currentDirectory, "..", "preload", "preload.mjs"),
-      sandbox: true,
-    },
-  });
+const registerAppLifecycle = Effect.sync(() => {
+  app.on("window-all-closed", () =>
+    Effect.runSync(
+      Effect.sync(() => {
+        if (shouldQuitAfterLastWindowCloses(process.platform, app.isPackaged)) app.quit();
+      }),
+    ),
+  );
 
-  mainWindow.webContents.setWindowOpenHandler(({ url }) => {
-    if (isSafeExternalUrl(url)) void shell.openExternal(url);
-    return { action: "deny" };
-  });
-  mainWindow.webContents.on("will-navigate", (event, url) => {
-    const currentUrl = mainWindow?.webContents.getURL();
-    if (currentUrl && new URL(url).origin !== new URL(currentUrl).origin) {
-      event.preventDefault();
-    }
-  });
-  mainWindow.once("ready-to-show", () => mainWindow?.show());
-  mainWindow.on("closed", () => {
-    mainWindow = null;
-  });
-
-  if (process.env.VITE_DEV_SERVER_URL) {
-    void mainWindow.loadURL(process.env.VITE_DEV_SERVER_URL);
-  } else {
-    void mainWindow.loadFile(join(currentDirectory, "..", "..", "dist", "index.html"));
-  }
-}
-
-autoUpdater.autoDownload = false;
-autoUpdater.autoInstallOnAppQuit = true;
-
-app.whenReady().then(() => {
-  registerIpcHandlers();
-  Menu.setApplicationMenu(null);
-  createWindow();
-
-  app.on("activate", () => {
-    if (BrowserWindow.getAllWindows().length === 0) createWindow();
+  app.on("before-quit", (event) => {
+    if (quitting) return;
+    event.preventDefault();
+    Effect.runFork(
+      Effect.tryPromise({
+        try: () => openCodeRuntime.dispose(),
+        catch: (cause) =>
+          new DesktopMainError({ message: "Failed to stop the OpenCode runtime", cause }),
+      }).pipe(
+        Effect.catchAll(Effect.logError),
+        Effect.ensuring(
+          Effect.sync(() => {
+            quitting = true;
+            app.quit();
+          }),
+        ),
+      ),
+    );
   });
 });
 
-app.on("window-all-closed", () => {
-  if (shouldQuitAfterLastWindowCloses(process.platform, app.isPackaged)) app.quit();
-});
-
-app.on("before-quit", (event) => {
-  if (quitting) return;
-  event.preventDefault();
-  void openCodeRuntime.dispose().finally(() => {
-    quitting = true;
-    app.quit();
-  });
-});
+Effect.runFork(
+  Effect.gen(function* () {
+    yield* Effect.sync(() => {
+      autoUpdater.autoDownload = false;
+      autoUpdater.autoInstallOnAppQuit = true;
+    });
+    yield* registerAppLifecycle;
+    yield* Effect.tryPromise({
+      try: () => app.whenReady(),
+      catch: (cause) => new DesktopMainError({ message: "Electron failed to become ready", cause }),
+    });
+    yield* registerIpcHandlers;
+    yield* Effect.sync(() => Menu.setApplicationMenu(null));
+    yield* createWindow();
+    yield* Effect.sync(() =>
+      app.on("activate", () => {
+        if (BrowserWindow.getAllWindows().length === 0) {
+          Effect.runFork(createWindow().pipe(Effect.catchAll(Effect.logError)));
+        }
+      }),
+    );
+  }).pipe(Effect.catchAll(Effect.logError)),
+);

--- a/electron/opencodeConfig.ts
+++ b/electron/opencodeConfig.ts
@@ -1,25 +1,25 @@
 import { join } from "node:path";
 
-function studioMcpCommand(): string[] {
-  if (process.platform === "darwin") {
+function studioMcpCommand(platform: NodeJS.Platform, localAppData?: string): string[] {
+  if (platform === "darwin") {
     return ["/Applications/RobloxStudio.app/Contents/MacOS/StudioMCP"];
   }
 
-  if (process.platform === "win32") {
-    const localAppData = process.env.LOCALAPPDATA ?? "C:\\Users\\Default\\AppData\\Local";
-    return ["cmd.exe", "/c", join(localAppData, "Roblox", "mcp.bat")];
+  if (platform === "win32") {
+    const dataDirectory = localAppData ?? "C:\\Users\\Default\\AppData\\Local";
+    return ["cmd.exe", "/c", join(dataDirectory, "Roblox", "mcp.bat")];
   }
 
   return ["studio-mcp"];
 }
 
-export function createOpenCodeConfig() {
+export function createOpenCodeConfig(platform: NodeJS.Platform, localAppData?: string) {
   return {
     plugin: ["opencode-gemini-auth@latest"],
     mcp: {
       "roblox-studio": {
         type: "local",
-        command: studioMcpCommand(),
+        command: studioMcpCommand(platform, localAppData),
         enabled: true,
       },
     },

--- a/electron/services/OpenCode.ts
+++ b/electron/services/OpenCode.ts
@@ -11,7 +11,7 @@ import { createOpenCodeConfig } from "../opencodeConfig";
 import { ensureOpenCodeBinary } from "./OpenCodeBinary";
 
 const LOOPBACK = "127.0.0.1";
-const STARTUP_TIMEOUT_MS = 60_000;
+const STARTUP_TIMEOUT = "60 seconds";
 const SERVER_USERNAME = "opencode";
 
 export class OpenCodeError extends Data.TaggedError("OpenCodeError")<{
@@ -19,8 +19,25 @@ export class OpenCodeError extends Data.TaggedError("OpenCodeError")<{
   cause?: unknown;
 }> {}
 
-interface OpenCodeResource extends OpenCodeInfo {
+interface OpenCodeProcess {
+  authorization: string;
   child: ChildProcessWithoutNullStreams;
+  workspace: string;
+}
+
+interface OpenCodeResource extends OpenCodeProcess {
+  port: number;
+}
+
+interface PreparedOpenCode {
+  authorization: string;
+  executable: string;
+  password: string;
+  workspace: string;
+  xdgCache: string;
+  xdgConfig: string;
+  xdgData: string;
+  xdgState: string;
 }
 
 export interface OpenCodeOptions {
@@ -42,7 +59,7 @@ type NetworkConnection = Pick<
 export function findOpenCodeListeningPort(
   connections: readonly NetworkConnection[],
   pid: number,
-): number | null {
+): Effect.Effect<number | null, OpenCodeError> {
   const ports = new Set(
     connections
       .filter(
@@ -57,173 +74,258 @@ export function findOpenCodeListeningPort(
   );
 
   if (ports.size > 1) {
-    throw new Error(`OpenCode is listening on multiple loopback ports: ${[...ports].join(", ")}`);
+    return Effect.fail(
+      new OpenCodeError({
+        message: `OpenCode is listening on multiple loopback ports: ${[...ports].join(", ")}`,
+      }),
+    );
   }
-  return ports.values().next().value ?? null;
+  return Effect.succeed(ports.values().next().value ?? null);
 }
 
-async function waitForSpawn(child: ChildProcessWithoutNullStreams): Promise<void> {
-  await new Promise<void>((resolve, reject) => {
+function waitForSpawn(child: ChildProcessWithoutNullStreams): Effect.Effect<void, OpenCodeError> {
+  return Effect.async<void, OpenCodeError>((resume) => {
     const cleanup = () => {
       child.off("spawn", onSpawn);
       child.off("error", onError);
     };
     const onSpawn = () => {
       cleanup();
-      resolve();
+      resume(Effect.void);
     };
-    const onError = (error: Error) => {
+    const onError = (cause: Error) => {
       cleanup();
-      reject(error);
+      resume(Effect.fail(new OpenCodeError({ message: "Failed to spawn OpenCode", cause })));
     };
 
     child.once("spawn", onSpawn);
     child.once("error", onError);
+
+    return Effect.sync(cleanup);
   });
 }
 
-async function waitForListeningPort(child: ChildProcessWithoutNullStreams): Promise<number> {
-  if (child.pid === undefined) throw new Error("OpenCode started without a process ID");
-
-  const deadline = Date.now() + STARTUP_TIMEOUT_MS;
-  while (Date.now() < deadline) {
+function pollListeningPort(
+  child: ChildProcessWithoutNullStreams,
+  pid: number,
+): Effect.Effect<number, OpenCodeError> {
+  return Effect.gen(function* () {
     if (child.exitCode !== null) {
-      throw new Error(`OpenCode exited during startup with code ${child.exitCode}`);
+      return yield* Effect.fail(
+        new OpenCodeError({
+          message: `OpenCode exited during startup with code ${child.exitCode}`,
+        }),
+      );
     }
 
-    const port = findOpenCodeListeningPort(await networkConnections(), child.pid);
+    const connections = yield* Effect.tryPromise({
+      try: () => networkConnections(),
+      catch: (cause) =>
+        new OpenCodeError({ message: "Failed to inspect OpenCode network listeners", cause }),
+    });
+    const port = yield* findOpenCodeListeningPort(connections, pid);
     if (port !== null) return port;
-    await new Promise((resolve) => setTimeout(resolve, 500));
-  }
-
-  throw new Error("OpenCode did not open a listening port within 60 seconds");
+    yield* Effect.sleep("500 millis");
+    return yield* Effect.suspend(() => pollListeningPort(child, pid));
+  });
 }
 
-async function waitForHealth(
+function waitForListeningPort(child: ChildProcessWithoutNullStreams) {
+  if (child.pid === undefined) {
+    return Effect.fail(new OpenCodeError({ message: "OpenCode started without a process ID" }));
+  }
+  return pollListeningPort(child, child.pid).pipe(
+    Effect.timeoutFail({
+      duration: STARTUP_TIMEOUT,
+      onTimeout: () =>
+        new OpenCodeError({ message: "OpenCode did not open a listening port within 60 seconds" }),
+    }),
+  );
+}
+
+function pollHealth(
+  child: ChildProcessWithoutNullStreams,
+  healthUrl: string,
+  authorization: string,
+): Effect.Effect<void, OpenCodeError> {
+  return Effect.gen(function* () {
+    if (child.exitCode !== null) {
+      return yield* Effect.fail(
+        new OpenCodeError({
+          message: `OpenCode exited during startup with code ${child.exitCode}`,
+        }),
+      );
+    }
+
+    const response = yield* Effect.tryPromise({
+      try: (signal) =>
+        fetch(healthUrl, {
+          headers: { Authorization: authorization },
+          signal: AbortSignal.any([signal, AbortSignal.timeout(2_000)]),
+        }),
+      catch: (cause) =>
+        new OpenCodeError({ message: "OpenCode health check did not respond", cause }),
+    }).pipe(Effect.catchAll(() => Effect.succeed(null)));
+    if (response?.ok) return;
+    yield* Effect.sleep("500 millis");
+    return yield* Effect.suspend(() => pollHealth(child, healthUrl, authorization));
+  });
+}
+
+function waitForHealth(
   child: ChildProcessWithoutNullStreams,
   port: number,
   authorization: string,
-): Promise<void> {
-  const deadline = Date.now() + STARTUP_TIMEOUT_MS;
+): Effect.Effect<void, OpenCodeError> {
   const healthUrl = `http://${LOOPBACK}:${port}/global/health`;
+  return pollHealth(child, healthUrl, authorization).pipe(
+    Effect.timeoutFail({
+      duration: STARTUP_TIMEOUT,
+      onTimeout: () =>
+        new OpenCodeError({ message: "OpenCode did not become healthy within 60 seconds" }),
+    }),
+  );
+}
 
-  while (Date.now() < deadline) {
-    if (child.exitCode !== null) {
-      throw new Error(`OpenCode exited during startup with code ${child.exitCode}`);
-    }
+function prepareOpenCode(options: OpenCodeOptions): Effect.Effect<PreparedOpenCode, OpenCodeError> {
+  return Effect.gen(function* () {
+    const { executable, version } = yield* ensureOpenCodeBinary({
+      cacheDirectory: options.binaryCacheDirectory,
+    }).pipe(
+      Effect.mapError(
+        (cause) => new OpenCodeError({ message: cause.message, cause }),
+      ),
+    );
+    yield* Effect.logInfo(`[opencode] Starting v${version}`);
 
-    try {
-      const response = await fetch(healthUrl, {
-        headers: { Authorization: authorization },
-        signal: AbortSignal.timeout(2_000),
+    const opencodeHome = join(options.workspace, ".opencode");
+    const xdgData = join(opencodeHome, "data");
+    const xdgConfig = join(opencodeHome, "config");
+    const xdgCache = join(opencodeHome, "cache");
+    const xdgState = join(opencodeHome, "state");
+    const configDirectory = join(xdgConfig, "opencode");
+    const fileOperation = <A>(message: string, evaluate: () => PromiseLike<A>) =>
+      Effect.tryPromise({
+        try: evaluate,
+        catch: (cause) => new OpenCodeError({ message, cause }),
       });
-      if (response.ok) return;
-    } catch {
-      // The server is still starting. Retry until the explicit deadline.
-    }
 
-    await new Promise((resolve) => setTimeout(resolve, 500));
-  }
+    yield* Effect.all(
+      [options.workspace, xdgData, configDirectory, xdgCache, xdgState].map((directory) =>
+        fileOperation(`Failed to create ${directory}`, () => mkdir(directory, { recursive: true })),
+      ),
+      { concurrency: "unbounded", discard: true },
+    );
+    const config = createOpenCodeConfig(process.platform, process.env.LOCALAPPDATA);
+    yield* fileOperation("Failed to write the OpenCode configuration", () =>
+      writeFile(
+        join(configDirectory, "opencode.json"),
+        JSON.stringify(config, null, 2),
+      ),
+    );
 
-  throw new Error("OpenCode did not become healthy within 60 seconds");
-}
-
-async function startOpenCode(options: OpenCodeOptions): Promise<OpenCodeResource> {
-  const { executable, version } = await ensureOpenCodeBinary({
-    cacheDirectory: options.binaryCacheDirectory,
-  });
-  console.info(`[opencode] Starting v${version}`);
-  const opencodeHome = join(options.workspace, ".opencode");
-  const xdgData = join(opencodeHome, "data");
-  const xdgConfig = join(opencodeHome, "config");
-  const xdgCache = join(opencodeHome, "cache");
-  const xdgState = join(opencodeHome, "state");
-  const configDirectory = join(xdgConfig, "opencode");
-
-  await Promise.all(
-    [options.workspace, xdgData, configDirectory, xdgCache, xdgState].map((directory) =>
-      mkdir(directory, { recursive: true }),
-    ),
-  );
-  await writeFile(
-    join(configDirectory, "opencode.json"),
-    JSON.stringify(createOpenCodeConfig(), null, 2),
-  );
-
-  const password = randomBytes(32).toString("base64url");
-  const authorization = `Basic ${Buffer.from(`${SERVER_USERNAME}:${password}`).toString("base64")}`;
-
-  const child = spawn(
-    executable,
-    ["serve", "--port", "0", "--hostname", LOOPBACK, "--print-logs", "--log-level", "INFO"],
-    {
-      cwd: options.workspace,
-      env: {
-        ...process.env,
-        XDG_CACHE_HOME: xdgCache,
-        XDG_CONFIG_HOME: xdgConfig,
-        XDG_DATA_HOME: xdgData,
-        XDG_STATE_HOME: xdgState,
-        OPENCODE_SERVER_PASSWORD: password,
-        OPENCODE_SERVER_USERNAME: SERVER_USERNAME,
-      },
-      stdio: "pipe",
-      windowsHide: true,
-    },
-  );
-
-  child.stdout.on("data", (data: Buffer) => console.info(`[opencode] ${data.toString().trimEnd()}`));
-  child.stderr.on("data", (data: Buffer) => console.error(`[opencode] ${data.toString().trimEnd()}`));
-
-  try {
-    await waitForSpawn(child);
-    const listeningPort = await waitForListeningPort(child);
-    await waitForHealth(child, listeningPort, authorization);
-    return { authorization, child, port: listeningPort, workspace: options.workspace };
-  } catch (error) {
-    child.kill("SIGKILL");
-    throw error;
-  }
-}
-
-async function stopOpenCode(resource: OpenCodeResource): Promise<void> {
-  if (resource.child.exitCode !== null || resource.child.killed) return;
-
-  resource.child.kill("SIGTERM");
-  await Promise.race([
-    new Promise<void>((resolve) => resource.child.once("exit", () => resolve())),
-    new Promise<void>((resolve) =>
-      setTimeout(() => {
-        resource.child.kill("SIGKILL");
-        resolve();
-      }, 5_000),
-    ),
-  ]);
-}
-
-function acquire(options: OpenCodeOptions) {
-  return Effect.tryPromise({
-    try: () => startOpenCode(options),
-    catch: (cause) =>
-      new OpenCodeError({
-        message:
-          cause instanceof Error
-            ? cause.message
-            : "OpenCode failed to download or start.",
-        cause,
-      }),
+    const password = yield* Effect.try({
+      try: () => randomBytes(32).toString("base64url"),
+      catch: (cause) =>
+        new OpenCodeError({ message: "Failed to generate OpenCode credentials", cause }),
+    });
+    const authorization = `Basic ${Buffer.from(`${SERVER_USERNAME}:${password}`).toString("base64")}`;
+    return {
+      authorization,
+      executable,
+      password,
+      workspace: options.workspace,
+      xdgCache,
+      xdgConfig,
+      xdgData,
+      xdgState,
+    };
   });
 }
 
-function release(resource: OpenCodeResource) {
-  return Effect.promise(() => stopOpenCode(resource));
+function spawnOpenCode(prepared: PreparedOpenCode): Effect.Effect<OpenCodeProcess, OpenCodeError> {
+  return Effect.gen(function* () {
+    const child = yield* Effect.try({
+      try: () =>
+        spawn(
+          prepared.executable,
+          ["serve", "--port", "0", "--hostname", LOOPBACK, "--print-logs", "--log-level", "INFO"],
+          {
+            cwd: prepared.workspace,
+            env: {
+              ...process.env,
+              XDG_CACHE_HOME: prepared.xdgCache,
+              XDG_CONFIG_HOME: prepared.xdgConfig,
+              XDG_DATA_HOME: prepared.xdgData,
+              XDG_STATE_HOME: prepared.xdgState,
+              OPENCODE_SERVER_PASSWORD: prepared.password,
+              OPENCODE_SERVER_USERNAME: SERVER_USERNAME,
+            },
+            stdio: "pipe",
+            windowsHide: true,
+          },
+        ),
+      catch: (cause) => new OpenCodeError({ message: "Failed to start OpenCode", cause }),
+    });
+
+    child.stdout.on("data", (data: Buffer) =>
+      Effect.runSync(Effect.logInfo(`[opencode] ${data.toString().trimEnd()}`)),
+    );
+    child.stderr.on("data", (data: Buffer) =>
+      Effect.runSync(Effect.logError(`[opencode] ${data.toString().trimEnd()}`)),
+    );
+    return {
+      authorization: prepared.authorization,
+      child,
+      workspace: prepared.workspace,
+    };
+  });
+}
+
+function stopOpenCode(resource: OpenCodeProcess): Effect.Effect<void> {
+  return Effect.suspend(() => {
+    if (resource.child.exitCode !== null || resource.child.pid === undefined) return Effect.void;
+
+    const exitedAfterTerminate = Effect.async<void>((resume) => {
+      const cleanup = () => resource.child.off("exit", onExit);
+      const onExit = () => {
+        cleanup();
+        resume(Effect.void);
+      };
+      resource.child.once("exit", onExit);
+      if (resource.child.exitCode !== null) {
+        onExit();
+      } else if (!resource.child.killed) {
+        resource.child.kill("SIGTERM");
+      }
+      return Effect.sync(cleanup);
+    });
+    const forceKill = Effect.sleep("5 seconds").pipe(
+      Effect.tap(() => Effect.sync(() => resource.child.kill("SIGKILL"))),
+    );
+    return Effect.race(exitedAfterTerminate, forceKill);
+  });
+}
+
+function awaitOpenCode(process: OpenCodeProcess): Effect.Effect<OpenCodeResource, OpenCodeError> {
+  return Effect.gen(function* () {
+    yield* waitForSpawn(process.child);
+    const port = yield* waitForListeningPort(process.child);
+    yield* waitForHealth(process.child, port, process.authorization);
+    return { ...process, port };
+  });
 }
 
 export function makeOpenCodeLayer(options: OpenCodeOptions) {
   return Layer.scoped(
     OpenCode,
-    Effect.acquireRelease(acquire(options), release).pipe(
-      Effect.map((resource): OpenCodeService => ({
+    Effect.gen(function* () {
+      // Downloading and readiness polling remain interruptible. Only the short spawn
+      // operation is masked, and its finalizer is registered before any waiting begins.
+      const prepared = yield* prepareOpenCode(options);
+      const process = yield* Effect.acquireRelease(spawnOpenCode(prepared), stopOpenCode);
+      const resource = yield* awaitOpenCode(process);
+      return {
         info: Effect.suspend(() => {
           if (resource.child.exitCode !== null) {
             return Effect.fail(
@@ -238,7 +340,7 @@ export function makeOpenCodeLayer(options: OpenCodeOptions) {
             workspace: resource.workspace,
           });
         }),
-      })),
-    ),
+      } satisfies OpenCodeService;
+    }),
   );
 }

--- a/electron/services/OpenCodeBinary.ts
+++ b/electron/services/OpenCodeBinary.ts
@@ -3,6 +3,7 @@ import { createReadStream } from "node:fs";
 import {
   chmod,
   mkdir,
+  mkdtemp,
   readFile,
   readdir,
   rename,
@@ -12,6 +13,7 @@ import {
 } from "node:fs/promises";
 import { join } from "node:path";
 
+import { Data, Effect, Schema } from "effect";
 import extractZip from "extract-zip";
 import { x as extractTar } from "tar";
 
@@ -22,18 +24,27 @@ const RELEASES_PER_PAGE = 100;
 const LOOKUP_TIMEOUT_MS = 15_000;
 const DOWNLOAD_TIMEOUT_MS = 120_000;
 
-interface GitHubAsset {
-  name: string;
-  browser_download_url: string;
-  digest?: string | null;
-}
+const GitHubAssetSchema = Schema.mutable(
+  Schema.Struct({
+    name: Schema.String,
+    browser_download_url: Schema.String,
+    digest: Schema.optional(Schema.NullOr(Schema.String)),
+  }),
+);
 
-export interface GitHubRelease {
-  tag_name: string;
-  draft: boolean;
-  prerelease: boolean;
-  assets: GitHubAsset[];
-}
+const GitHubReleaseSchema = Schema.mutable(
+  Schema.Struct({
+    tag_name: Schema.String,
+    draft: Schema.Boolean,
+    prerelease: Schema.Boolean,
+    assets: Schema.mutable(Schema.Array(GitHubAssetSchema)),
+  }),
+);
+
+const GitHubReleasesSchema = Schema.mutable(Schema.Array(GitHubReleaseSchema));
+
+export type GitHubRelease = typeof GitHubReleaseSchema.Type;
+type GitHubAsset = typeof GitHubAssetSchema.Type;
 
 interface Version {
   major: number;
@@ -54,20 +65,29 @@ interface CompatibleRelease {
   archiveSha256: string;
 }
 
-interface CacheMetadata {
-  schemaVersion: 1;
-  version: string;
-  platform: NodeJS.Platform;
-  arch: string;
-  assetName: string;
-  archiveSha256: string;
-  binarySha256: string;
-}
+const CacheMetadataSchema = Schema.mutable(
+  Schema.Struct({
+    schemaVersion: Schema.Literal(1),
+    version: Schema.String,
+    platform: Schema.String,
+    arch: Schema.String,
+    assetName: Schema.String,
+    archiveSha256: Schema.String,
+    binarySha256: Schema.String,
+  }),
+);
+
+type CacheMetadata = typeof CacheMetadataSchema.Type;
 
 export interface OpenCodeBinary {
   executable: string;
   version: string;
 }
+
+export class OpenCodeBinaryError extends Data.TaggedError("OpenCodeBinaryError")<{
+  message: string;
+  cause?: unknown;
+}> {}
 
 type Fetch = (input: string | URL | Request, init?: RequestInit) => Promise<Response>;
 type ExtractArchive = (
@@ -83,6 +103,15 @@ export interface OpenCodeBinaryOptions {
   fetch?: Fetch;
   extractArchive?: ExtractArchive;
 }
+
+const fail = (message: string, cause?: unknown) =>
+  Effect.fail(new OpenCodeBinaryError({ message, cause }));
+
+const tryPromise = <A>(message: string, evaluate: (signal: AbortSignal) => PromiseLike<A>) =>
+  Effect.tryPromise({
+    try: evaluate,
+    catch: (cause) => new OpenCodeBinaryError({ message, cause }),
+  });
 
 function parseVersion(tag: string): Version | null {
   const match = /^v?(\d+)\.(\d+)\.(\d+)$/.exec(tag);
@@ -101,36 +130,39 @@ function compareVersions(left: Version, right: Version): number {
   return left.major - right.major || left.minor - right.minor || left.patch - right.patch;
 }
 
-export function getOpenCodeAssetSpec(platform: NodeJS.Platform, arch: string): AssetSpec {
+export function getOpenCodeAssetSpec(
+  platform: NodeJS.Platform,
+  arch: string,
+): Effect.Effect<AssetSpec, OpenCodeBinaryError> {
   if (platform === "darwin" && arch === "arm64") {
-    return {
+    return Effect.succeed({
       archiveName: "opencode-darwin-arm64.zip",
       executableName: "opencode",
       format: "zip",
-    };
+    });
   }
   if (platform === "darwin" && arch === "x64") {
-    return {
+    return Effect.succeed({
       archiveName: "opencode-darwin-x64.zip",
       executableName: "opencode",
       format: "zip",
-    };
+    });
   }
   if (platform === "win32" && arch === "x64") {
-    return {
+    return Effect.succeed({
       archiveName: "opencode-windows-x64.zip",
       executableName: "opencode.exe",
       format: "zip",
-    };
+    });
   }
   if (platform === "linux" && arch === "x64") {
-    return {
+    return Effect.succeed({
       archiveName: "opencode-linux-x64.tar.gz",
       executableName: "opencode",
       format: "tar.gz",
-    };
+    });
   }
-  throw new Error(`OpenCode does not provide a supported binary for ${platform}/${arch}`);
+  return fail(`OpenCode does not provide a supported binary for ${platform}/${arch}`);
 }
 
 export function selectCompatibleRelease(
@@ -153,69 +185,101 @@ export function selectCompatibleRelease(
   return candidates.sort((left, right) => compareVersions(right.version, left.version))[0] ?? null;
 }
 
-async function findCompatibleRelease(fetchFn: Fetch, archiveName: string): Promise<CompatibleRelease> {
-  for (let page = 1; page <= 10; page++) {
-    const response = await fetchFn(
-      `${OPEN_CODE_API}?per_page=${RELEASES_PER_PAGE}&page=${page}`,
-      {
-        headers: {
-          Accept: "application/vnd.github+json",
-          "User-Agent": "BloxBot",
-          "X-GitHub-Api-Version": "2022-11-28",
+function findCompatibleRelease(fetchFn: Fetch, archiveName: string) {
+  return Effect.gen(function* () {
+    for (let page = 1; page <= 10; page++) {
+      const { releasesJson, response } = yield* tryPromise(
+        "GitHub release lookup failed",
+        async (signal) => {
+          const response = await fetchFn(`${OPEN_CODE_API}?per_page=${RELEASES_PER_PAGE}&page=${page}`, {
+          headers: {
+            Accept: "application/vnd.github+json",
+            "User-Agent": "BloxBot",
+            "X-GitHub-Api-Version": "2022-11-28",
+          },
+          signal: AbortSignal.any([signal, AbortSignal.timeout(LOOKUP_TIMEOUT_MS)]),
+          });
+          return {
+            releasesJson: response.ok ? await response.json() : undefined,
+            response,
+          };
         },
-        signal: AbortSignal.timeout(LOOKUP_TIMEOUT_MS),
-      },
-    );
-    if (!response.ok) {
-      throw new Error(`GitHub release lookup failed with HTTP ${response.status}`);
+      );
+      if (!response.ok) {
+        return yield* fail(`GitHub release lookup failed with HTTP ${response.status}`);
+      }
+
+      const releases = yield* Schema.decodeUnknown(GitHubReleasesSchema)(releasesJson).pipe(
+        Effect.mapError(
+          (cause) =>
+            new OpenCodeBinaryError({ message: "GitHub returned an invalid release list", cause }),
+        ),
+      );
+
+      const release = selectCompatibleRelease(releases, archiveName);
+      if (release) return release;
+      if (releases.length < RELEASES_PER_PAGE) break;
     }
 
-    const releases = (await response.json()) as GitHubRelease[];
-    if (!Array.isArray(releases)) throw new Error("GitHub returned an invalid release list");
-    const release = selectCompatibleRelease(releases, archiveName);
-    if (release) return release;
-    if (releases.length < RELEASES_PER_PAGE) break;
-  }
-
-  throw new Error(`No stable OpenCode ${SUPPORTED_MAJOR}.x.x release is available for ${archiveName}`);
-}
-
-async function sha256File(path: string): Promise<string> {
-  return new Promise((resolve, reject) => {
-    const hash = createHash("sha256");
-    const stream = createReadStream(path);
-    stream.on("error", reject);
-    stream.on("data", (chunk) => hash.update(chunk));
-    stream.on("end", () => resolve(hash.digest("hex")));
+    return yield* fail(
+      `No stable OpenCode ${SUPPORTED_MAJOR}.x.x release is available for ${archiveName}`,
+    );
   });
 }
 
-function isCacheMetadata(value: unknown): value is CacheMetadata {
-  if (!value || typeof value !== "object") return false;
-  const metadata = value as Partial<CacheMetadata>;
-  return (
-    metadata.schemaVersion === 1 &&
-    typeof metadata.version === "string" &&
-    typeof metadata.platform === "string" &&
-    typeof metadata.arch === "string" &&
-    typeof metadata.assetName === "string" &&
-    typeof metadata.archiveSha256 === "string" &&
-    typeof metadata.binarySha256 === "string"
-  );
+function sha256File(path: string): Effect.Effect<string, OpenCodeBinaryError> {
+  return Effect.async<string, OpenCodeBinaryError>((resume) => {
+    const hash = createHash("sha256");
+    const stream = createReadStream(path);
+    const cleanup = () => {
+      stream.off("error", onError);
+      stream.off("data", onData);
+      stream.off("end", onEnd);
+    };
+    const onError = (cause: Error) => {
+      cleanup();
+      resume(Effect.fail(new OpenCodeBinaryError({ message: `Failed to hash ${path}`, cause })));
+    };
+    const onData = (chunk: Buffer) => hash.update(chunk);
+    const onEnd = () => {
+      cleanup();
+      resume(Effect.succeed(hash.digest("hex")));
+    };
+
+    stream.once("error", onError);
+    stream.on("data", onData);
+    stream.once("end", onEnd);
+
+    return Effect.sync(() => {
+      cleanup();
+      stream.destroy();
+    });
+  });
 }
 
-async function readValidCachedBinary(
+function readValidCachedBinary(
   versionDirectory: string,
   platform: NodeJS.Platform,
   arch: string,
   spec: AssetSpec,
   expected?: CompatibleRelease,
-): Promise<OpenCodeBinary | null> {
-  try {
-    const metadata = JSON.parse(
-      await readFile(join(versionDirectory, "metadata.json"), "utf8"),
-    ) as unknown;
-    if (!isCacheMetadata(metadata) || !parseVersion(metadata.version)) return null;
+): Effect.Effect<OpenCodeBinary | null, never> {
+  return Effect.gen(function* () {
+    const contents = yield* tryPromise("Failed to read cached OpenCode metadata", () =>
+      readFile(join(versionDirectory, "metadata.json"), "utf8"),
+    );
+    const metadataJson = yield* Effect.try({
+      try: () => JSON.parse(contents) as unknown,
+      catch: (cause) =>
+        new OpenCodeBinaryError({ message: "Cached OpenCode metadata is invalid JSON", cause }),
+    });
+    const metadata = yield* Schema.decodeUnknown(CacheMetadataSchema)(metadataJson).pipe(
+      Effect.mapError(
+        (cause) =>
+          new OpenCodeBinaryError({ message: "Cached OpenCode metadata is invalid", cause }),
+      ),
+    );
+    if (!parseVersion(metadata.version)) return null;
     if (metadata.platform !== platform || metadata.arch !== arch) return null;
     if (metadata.assetName !== spec.archiveName) return null;
     if (
@@ -227,59 +291,55 @@ async function readValidCachedBinary(
     }
 
     const executable = join(versionDirectory, spec.executableName);
-    if (!(await stat(executable)).isFile()) return null;
-    if ((await sha256File(executable)) !== metadata.binarySha256) return null;
-    if (platform !== "win32") await chmod(executable, 0o755);
+    const executableStat = yield* tryPromise("Failed to inspect cached OpenCode binary", () =>
+      stat(executable),
+    );
+    if (!executableStat.isFile()) return null;
+    if ((yield* sha256File(executable)) !== metadata.binarySha256) return null;
+    if (platform !== "win32") {
+      yield* tryPromise("Failed to make the cached OpenCode binary executable", () =>
+        chmod(executable, 0o755),
+      );
+    }
     return { executable, version: metadata.version };
-  } catch {
-    return null;
-  }
+  }).pipe(Effect.catchAll(() => Effect.succeed(null)));
 }
 
-async function findNewestCachedBinary(
+function findNewestCachedBinary(
   platformDirectory: string,
   platform: NodeJS.Platform,
   arch: string,
   spec: AssetSpec,
-): Promise<OpenCodeBinary | null> {
-  let entries;
-  try {
-    entries = await readdir(platformDirectory, { withFileTypes: true });
-  } catch {
-    return null;
-  }
-
-  const versions = entries
-    .filter((entry) => entry.isDirectory())
-    .map((entry) => parseVersion(entry.name))
-    .filter((version): version is Version => version !== null)
-    .sort((left, right) => compareVersions(right, left));
-
-  for (const version of versions) {
-    const cached = await readValidCachedBinary(
-      join(platformDirectory, version.value),
-      platform,
-      arch,
-      spec,
+): Effect.Effect<OpenCodeBinary | null, never> {
+  return Effect.gen(function* () {
+    const entries = yield* tryPromise("Failed to inspect the OpenCode cache", () =>
+      readdir(platformDirectory, { withFileTypes: true }),
     );
-    if (cached) return cached;
-  }
-  return null;
+    const versions = entries
+      .filter((entry) => entry.isDirectory())
+      .map((entry) => parseVersion(entry.name))
+      .filter((version): version is Version => version !== null)
+      .sort((left, right) => compareVersions(right, left));
+
+    for (const version of versions) {
+      const cached = yield* readValidCachedBinary(
+        join(platformDirectory, version.value),
+        platform,
+        arch,
+        spec,
+      );
+      if (cached) return cached;
+    }
+    return null;
+  }).pipe(Effect.catchAll(() => Effect.succeed(null)));
 }
 
-async function defaultExtractArchive(
-  archivePath: string,
-  destination: string,
-  format: AssetSpec["format"],
-): Promise<void> {
-  if (format === "zip") {
-    await extractZip(archivePath, { dir: destination });
-    return;
-  }
-  await extractTar({ file: archivePath, cwd: destination, strict: true });
-}
+const defaultExtractArchive: ExtractArchive = (archivePath, destination, format) =>
+  format === "zip"
+    ? extractZip(archivePath, { dir: destination })
+    : extractTar({ file: archivePath, cwd: destination, strict: true });
 
-async function installRelease(
+function installRelease(
   platformDirectory: string,
   platform: NodeJS.Platform,
   arch: string,
@@ -287,114 +347,186 @@ async function installRelease(
   release: CompatibleRelease,
   fetchFn: Fetch,
   extractArchive: ExtractArchive,
-): Promise<OpenCodeBinary> {
-  const temporaryDirectory = join(
-    platformDirectory,
-    `.download-${process.pid}-${Date.now()}`,
-  );
-  const installDirectory = join(temporaryDirectory, "install");
-  const archivePath = join(temporaryDirectory, spec.archiveName);
-  const versionDirectory = join(platformDirectory, release.version.value);
-
-  await mkdir(installDirectory, { recursive: true });
-  try {
-    const response = await fetchFn(release.asset.browser_download_url, {
-      headers: { "User-Agent": "BloxBot" },
-      signal: AbortSignal.timeout(DOWNLOAD_TIMEOUT_MS),
-    });
-    if (!response.ok) throw new Error(`OpenCode download failed with HTTP ${response.status}`);
-
-    const archive = Buffer.from(await response.arrayBuffer());
-    const archiveSha256 = createHash("sha256").update(archive).digest("hex");
-    if (archiveSha256 !== release.archiveSha256) {
-      throw new Error("The downloaded OpenCode archive failed SHA-256 verification");
-    }
-    await writeFile(archivePath, archive);
-    await extractArchive(archivePath, installDirectory, spec.format);
-
-    const executable = join(installDirectory, spec.executableName);
-    if (!(await stat(executable)).isFile()) {
-      throw new Error(`The OpenCode archive did not contain ${spec.executableName}`);
-    }
-    if (platform !== "win32") await chmod(executable, 0o755);
-
-    const metadata: CacheMetadata = {
-      schemaVersion: 1,
-      version: release.version.value,
-      platform,
-      arch,
-      assetName: spec.archiveName,
-      archiveSha256,
-      binarySha256: await sha256File(executable),
-    };
-    await writeFile(join(installDirectory, "metadata.json"), JSON.stringify(metadata, null, 2));
-
-    await rm(versionDirectory, { recursive: true, force: true });
-    await rename(installDirectory, versionDirectory);
-    return { executable: join(versionDirectory, spec.executableName), version: release.version.value };
-  } finally {
-    await rm(temporaryDirectory, { recursive: true, force: true });
-  }
-}
-
-async function pruneCache(platformDirectory: string, keep = 2): Promise<void> {
-  const entries = await readdir(platformDirectory, { withFileTypes: true });
-  const versions = entries
-    .filter((entry) => entry.isDirectory())
-    .map((entry) => parseVersion(entry.name))
-    .filter((version): version is Version => version !== null)
-    .sort((left, right) => compareVersions(right, left));
-
-  await Promise.all(
-    versions.slice(keep).map((version) =>
-      rm(join(platformDirectory, version.value), { recursive: true, force: true }),
+): Effect.Effect<OpenCodeBinary, OpenCodeBinaryError> {
+  return Effect.acquireUseRelease(
+    tryPromise(
+      "Failed to create a temporary OpenCode directory",
+      () => mkdtemp(join(platformDirectory, ".download-")),
     ),
+    (temporaryDirectory) => {
+      const installDirectory = join(temporaryDirectory, "install");
+      const archivePath = join(temporaryDirectory, spec.archiveName);
+      const versionDirectory = join(platformDirectory, release.version.value);
+
+      return Effect.gen(function* () {
+        yield* tryPromise("Failed to create the OpenCode installation directory", () =>
+          mkdir(installDirectory, { recursive: true }),
+        );
+        const { archiveBuffer, response } = yield* tryPromise(
+          "OpenCode download failed",
+          async (signal) => {
+            const response = await fetchFn(release.asset.browser_download_url, {
+              headers: { "User-Agent": "BloxBot" },
+              signal: AbortSignal.any([signal, AbortSignal.timeout(DOWNLOAD_TIMEOUT_MS)]),
+            });
+            return {
+              archiveBuffer: response.ok ? await response.arrayBuffer() : undefined,
+              response,
+            };
+          },
+        );
+        if (!response.ok) {
+          return yield* fail(`OpenCode download failed with HTTP ${response.status}`);
+        }
+        if (archiveBuffer === undefined) {
+          return yield* fail("OpenCode returned an unreadable download");
+        }
+
+        const archive = Buffer.from(archiveBuffer);
+        const archiveSha256 = createHash("sha256").update(archive).digest("hex");
+        if (archiveSha256 !== release.archiveSha256) {
+          return yield* fail("The downloaded OpenCode archive failed SHA-256 verification");
+        }
+
+        // Node filesystem and archive APIs do not accept AbortSignal. Mask this
+        // publish phase so interruption cannot race cleanup against in-flight writes.
+        return yield* Effect.uninterruptible(
+          Effect.gen(function* () {
+            yield* tryPromise("Failed to write the OpenCode archive", () =>
+              writeFile(archivePath, archive),
+            );
+            yield* tryPromise("Failed to extract the OpenCode archive", () =>
+              extractArchive(archivePath, installDirectory, spec.format),
+            );
+
+            const executable = join(installDirectory, spec.executableName);
+            const executableStat = yield* tryPromise(
+              "Failed to inspect the extracted OpenCode binary",
+              () => stat(executable),
+            );
+            if (!executableStat.isFile()) {
+              return yield* fail(`The OpenCode archive did not contain ${spec.executableName}`);
+            }
+            if (platform !== "win32") {
+              yield* tryPromise("Failed to make the OpenCode binary executable", () =>
+                chmod(executable, 0o755),
+              );
+            }
+
+            const metadata: CacheMetadata = {
+              schemaVersion: 1,
+              version: release.version.value,
+              platform,
+              arch,
+              assetName: spec.archiveName,
+              archiveSha256,
+              binarySha256: yield* sha256File(executable),
+            };
+            yield* tryPromise("Failed to write OpenCode cache metadata", () =>
+              writeFile(
+                join(installDirectory, "metadata.json"),
+                JSON.stringify(metadata, null, 2),
+              ),
+            );
+            yield* tryPromise("Failed to replace the cached OpenCode version", () =>
+              rm(versionDirectory, { recursive: true, force: true }),
+            );
+            yield* tryPromise("Failed to publish the OpenCode installation", () =>
+              rename(installDirectory, versionDirectory),
+            );
+            return {
+              executable: join(versionDirectory, spec.executableName),
+              version: release.version.value,
+            };
+          }),
+        );
+      });
+    },
+    (temporaryDirectory) =>
+      tryPromise("Failed to remove the temporary OpenCode directory", () =>
+        rm(temporaryDirectory, { recursive: true, force: true }),
+      ).pipe(Effect.catchAll((error) => Effect.logWarning(error.message, error.cause))),
   );
 }
 
-export async function ensureOpenCodeBinary(
+function pruneCache(platformDirectory: string, keep = 2) {
+  return Effect.gen(function* () {
+    const entries = yield* tryPromise("Failed to inspect the OpenCode cache", () =>
+      readdir(platformDirectory, { withFileTypes: true }),
+    );
+    const versions = entries
+      .filter((entry) => entry.isDirectory())
+      .map((entry) => parseVersion(entry.name))
+      .filter((version): version is Version => version !== null)
+      .sort((left, right) => compareVersions(right, left));
+
+    yield* Effect.all(
+      versions.slice(keep).map((version) =>
+        tryPromise(`Failed to prune cached OpenCode v${version.value}`, () =>
+          rm(join(platformDirectory, version.value), { recursive: true, force: true }),
+        ),
+      ),
+      { concurrency: 4, discard: true },
+    );
+  });
+}
+
+export function ensureOpenCodeBinary(
   options: OpenCodeBinaryOptions,
-): Promise<OpenCodeBinary> {
+): Effect.Effect<OpenCodeBinary, OpenCodeBinaryError> {
   const platform = options.platform ?? process.platform;
   const arch = options.arch ?? process.arch;
   const fetchFn = options.fetch ?? fetch;
   const extractArchive = options.extractArchive ?? defaultExtractArchive;
-  const spec = getOpenCodeAssetSpec(platform, arch);
   const platformDirectory = join(options.cacheDirectory, `${platform}-${arch}`);
-  await mkdir(platformDirectory, { recursive: true });
 
-  try {
-    const release = await findCompatibleRelease(fetchFn, spec.archiveName);
-    const versionDirectory = join(platformDirectory, release.version.value);
-    const cached = await readValidCachedBinary(
-      versionDirectory,
-      platform,
-      arch,
-      spec,
-      release,
+  return Effect.gen(function* () {
+    const spec = yield* getOpenCodeAssetSpec(platform, arch);
+    yield* tryPromise("Failed to create the OpenCode cache directory", () =>
+      mkdir(platformDirectory, { recursive: true }),
     );
-    const binary =
-      cached ??
-      (await installRelease(
-        platformDirectory,
+
+    const onlineInstall = Effect.gen(function* () {
+      const release = yield* findCompatibleRelease(fetchFn, spec.archiveName);
+      const versionDirectory = join(platformDirectory, release.version.value);
+      const cached = yield* readValidCachedBinary(
+        versionDirectory,
         platform,
         arch,
         spec,
         release,
-        fetchFn,
-        extractArchive,
-      ));
-    await pruneCache(platformDirectory);
-    return binary;
-  } catch (cause) {
-    const cached = await findNewestCachedBinary(platformDirectory, platform, arch, spec);
-    if (cached) {
-      console.warn(`[opencode] Update check failed; using cached v${cached.version}`, cause);
-      return cached;
-    }
-    throw new Error(
-      `Unable to download a verified OpenCode ${SUPPORTED_MAJOR}.x.x release and no cached copy is available`,
-      { cause },
+      );
+      const binary =
+        cached ??
+        (yield* installRelease(
+          platformDirectory,
+          platform,
+          arch,
+          spec,
+          release,
+          fetchFn,
+          extractArchive,
+        ));
+      yield* pruneCache(platformDirectory);
+      return binary;
+    });
+
+    return yield* onlineInstall.pipe(
+      Effect.catchAll((cause) =>
+        findNewestCachedBinary(platformDirectory, platform, arch, spec).pipe(
+          Effect.flatMap((cached) =>
+            cached
+              ? Effect.logWarning(
+                  `[opencode] Update check failed; using cached v${cached.version}`,
+                  cause,
+                ).pipe(Effect.as(cached))
+              : fail(
+                  `Unable to download a verified OpenCode ${SUPPORTED_MAJOR}.x.x release and no cached copy is available`,
+                  cause,
+                ),
+          ),
+        ),
+      ),
     );
-  }
+  });
 }

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1,12 +1,15 @@
-import { desktop } from "@/lib/desktop";
+import { Effect } from "effect";
+import { desktopEffects } from "@/lib/desktop";
 import type { AppConfig } from "@/types/desktop";
 
 export type { AppConfig } from "@/types/desktop";
 
-export async function loadConfig(): Promise<AppConfig> {
-  return desktop.loadConfig();
-}
+export const loadConfigEffect = desktopEffects.loadConfig;
 
-export async function patchConfig(patch: Partial<AppConfig>): Promise<void> {
-  await desktop.patchConfig(patch);
-}
+export const patchConfigEffect = (patch: Partial<AppConfig>) => desktopEffects.patchConfig(patch);
+
+// Promise adapters are kept at the React boundary used by PreferencesProvider.
+export const loadConfig = (): Promise<AppConfig> => Effect.runPromise(loadConfigEffect);
+
+export const patchConfig = (patch: Partial<AppConfig>): Promise<void> =>
+  Effect.runPromise(patchConfigEffect(patch));

--- a/src/lib/desktop.ts
+++ b/src/lib/desktop.ts
@@ -1,42 +1,141 @@
-import type { AppConfig, DesktopApi } from "@/types/desktop";
+import { Data, Effect, Schema } from "effect";
+import {
+  type AppConfig,
+  AppConfigPatchSchema,
+  AppConfigSchema,
+  type DesktopApi,
+  type OpenCodeInfo,
+  OpenCodeInfoSchema,
+  type UpdateInfo,
+  UpdateInfoSchema,
+} from "@/types/desktop";
 
 const CONFIG_KEY = "bloxbot-config";
 const DEFAULT_CONFIG: AppConfig = { lastModel: null, hiddenModels: [] };
 
-function loadBrowserConfig(): AppConfig {
-  try {
-    const stored = window.localStorage.getItem(CONFIG_KEY);
-    return stored ? { ...DEFAULT_CONFIG, ...JSON.parse(stored) } : DEFAULT_CONFIG;
-  } catch {
-    return DEFAULT_CONFIG;
-  }
+export class DesktopError extends Data.TaggedError("DesktopError")<{
+  message: string;
+  cause?: unknown;
+}> {}
+
+interface DesktopEffects {
+  readonly getOpenCodeInfo: Effect.Effect<OpenCodeInfo, DesktopError>;
+  readonly getVersion: Effect.Effect<string, DesktopError>;
+  readonly openUrl: (url: string) => Effect.Effect<void, DesktopError>;
+  readonly loadConfig: Effect.Effect<AppConfig, DesktopError>;
+  readonly patchConfig: (patch: Partial<AppConfig>) => Effect.Effect<void, DesktopError>;
+  readonly checkForUpdate: Effect.Effect<UpdateInfo | null, DesktopError>;
+  readonly installUpdate: Effect.Effect<void, DesktopError>;
+  readonly relaunch: Effect.Effect<void, DesktopError>;
 }
 
-const browserFallback: DesktopApi = {
-  async getOpenCodeInfo() {
-    throw new Error("The desktop service is unavailable. Start BloxBot with pnpm dev.");
-  },
-  async getVersion() {
-    return "0.5.2";
-  },
-  async openUrl(url) {
-    window.open(url, "_blank", "noopener,noreferrer");
-  },
-  async loadConfig() {
-    return loadBrowserConfig();
-  },
-  async patchConfig(patch) {
-    window.localStorage.setItem(CONFIG_KEY, JSON.stringify({ ...loadBrowserConfig(), ...patch }));
-  },
-  async checkForUpdate() {
-    return null;
-  },
-  async installUpdate() {
-    throw new Error("Updates are only available in the desktop app.");
-  },
-  async relaunch() {
-    window.location.reload();
-  },
+const loadBrowserConfig = Effect.gen(function* () {
+  const stored = yield* Effect.try({
+    try: () => {
+      const contents = window.localStorage.getItem(CONFIG_KEY);
+      return contents ? (JSON.parse(contents) as unknown) : DEFAULT_CONFIG;
+    },
+    catch: (cause) => new DesktopError({ message: "Failed to load browser configuration", cause }),
+  });
+  const candidate =
+    stored !== null && typeof stored === "object"
+      ? { ...DEFAULT_CONFIG, ...stored }
+      : DEFAULT_CONFIG;
+  return yield* Schema.decodeUnknown(AppConfigSchema)(candidate).pipe(
+    Effect.mapError(
+      (cause) => new DesktopError({ message: "Browser configuration is invalid", cause }),
+    ),
+  );
+}).pipe(Effect.catchAll(() => Effect.succeed(DEFAULT_CONFIG)));
+
+const browserEffects: DesktopEffects = {
+  getOpenCodeInfo: Effect.fail(
+    new DesktopError({
+      message: "The desktop service is unavailable. Start BloxBot with pnpm dev.",
+    }),
+  ),
+  getVersion: Effect.succeed("0.5.2"),
+  openUrl: (url) =>
+    Effect.sync(() => window.open(url, "_blank", "noopener,noreferrer")).pipe(Effect.asVoid),
+  loadConfig: loadBrowserConfig,
+  patchConfig: (input) =>
+    Effect.gen(function* () {
+      const patch = yield* Schema.decodeUnknown(AppConfigPatchSchema)(input).pipe(
+        Effect.mapError(
+          (cause) => new DesktopError({ message: "Browser configuration patch is invalid", cause }),
+        ),
+      );
+      const current = yield* loadBrowserConfig;
+      yield* Effect.try({
+        try: () =>
+          window.localStorage.setItem(CONFIG_KEY, JSON.stringify({ ...current, ...patch })),
+        catch: (cause) =>
+          new DesktopError({ message: "Failed to save browser configuration", cause }),
+      });
+    }),
+  checkForUpdate: Effect.succeed(null),
+  installUpdate: Effect.fail(
+    new DesktopError({ message: "Updates are only available in the desktop app." }),
+  ),
+  relaunch: Effect.sync(() => window.location.reload()),
 };
 
-export const desktop = window.bloxbot ?? browserFallback;
+const invoke = <A>(message: string, operation: () => Promise<A>) =>
+  Effect.tryPromise({
+    try: operation,
+    catch: (cause) =>
+      new DesktopError({
+        message: cause instanceof Error ? `${message}: ${cause.message}` : message,
+        cause,
+      }),
+  });
+
+const decodeBridgeValue =
+  <A, I>(message: string, schema: Schema.Schema<A, I>) =>
+  <E>(effect: Effect.Effect<unknown, E>) =>
+    effect.pipe(
+      Effect.flatMap(Schema.decodeUnknown(schema)),
+      Effect.mapError((cause) =>
+        cause instanceof DesktopError ? cause : new DesktopError({ message, cause }),
+      ),
+    );
+
+function makeBridgeEffects(api: DesktopApi): DesktopEffects {
+  return {
+    getOpenCodeInfo: invoke("Failed to get OpenCode connection details", () =>
+      api.getOpenCodeInfo(),
+    ).pipe(decodeBridgeValue("OpenCode connection details are invalid", OpenCodeInfoSchema)),
+    getVersion: invoke("Failed to get the app version", () => api.getVersion()).pipe(
+      decodeBridgeValue("Desktop app version is invalid", Schema.String),
+    ),
+    openUrl: (url) => invoke("Failed to open the URL", () => api.openUrl(url)),
+    loadConfig: invoke("Failed to load configuration", () => api.loadConfig()).pipe(
+      decodeBridgeValue("Desktop configuration is invalid", AppConfigSchema),
+    ),
+    patchConfig: (patch) => invoke("Failed to save configuration", () => api.patchConfig(patch)),
+    checkForUpdate: invoke("Failed to check for updates", () => api.checkForUpdate()).pipe(
+      decodeBridgeValue("Update information is invalid", Schema.NullOr(UpdateInfoSchema)),
+    ),
+    installUpdate: invoke("Failed to install the update", () => api.installUpdate()),
+    relaunch: invoke("Failed to relaunch the app", () => api.relaunch()),
+  };
+}
+
+export const desktopEffects: DesktopEffects = window.bloxbot
+  ? makeBridgeEffects(window.bloxbot)
+  : browserEffects;
+
+const runPromise = <A>(effect: Effect.Effect<A, DesktopError>): Promise<A> =>
+  Effect.runPromise(effect);
+
+/** Promise-only adapter consumed by React and exposed by the Electron bridge contract. */
+export const desktop: DesktopApi = {
+  getOpenCodeInfo: () => runPromise(desktopEffects.getOpenCodeInfo),
+  getVersion: () => runPromise(desktopEffects.getVersion),
+  openUrl: (url) => runPromise(desktopEffects.openUrl(url)),
+  loadConfig: () => runPromise(desktopEffects.loadConfig),
+  patchConfig: (patch) => runPromise(desktopEffects.patchConfig(patch)),
+  checkForUpdate: () => runPromise(desktopEffects.checkForUpdate),
+  installUpdate: () => runPromise(desktopEffects.installUpdate),
+  relaunch: () => runPromise(desktopEffects.relaunch),
+};

--- a/src/lib/sseDispatch.ts
+++ b/src/lib/sseDispatch.ts
@@ -7,6 +7,7 @@ import type {
   Todo,
 } from "@opencode-ai/sdk/v2/client";
 import type { QueryClient } from "@tanstack/react-query";
+import { Data, Effect, Schema } from "effect";
 
 import { qk } from "@/lib/queryKeys";
 import type { MessageWithParts } from "@/types";
@@ -16,20 +17,62 @@ export interface MessagesCache {
   messagesById: Record<string, MessageWithParts>;
 }
 
+export class SseDispatchError extends Data.TaggedError("SseDispatchError")<{
+  eventType: string;
+  cause: unknown;
+}> {}
+
+const SseEventEnvelopeSchema = Schema.Struct({
+  type: Schema.String,
+  properties: Schema.Record({ key: Schema.String, value: Schema.Unknown }),
+});
+
 /**
  * Maps an SSE Event to query cache updates.
  * `activeSessionIdRef` is a ref so we can read it without restarting the SSE loop.
  */
 export function sseDispatch(
   queryClient: QueryClient,
+  event: unknown,
+  activeSessionIdRef: { current: string | null },
+): void {
+  Effect.runSync(
+    sseDispatchEffect(queryClient, event, activeSessionIdRef).pipe(
+      Effect.catchAll((error) =>
+        Effect.logWarning(`sseDispatch: malformed ${error.eventType} event, skipping`, error.cause),
+      ),
+    ),
+  );
+}
+
+export function sseDispatchEffect(
+  queryClient: QueryClient,
+  event: unknown,
+  activeSessionIdRef: { current: string | null },
+): Effect.Effect<void, SseDispatchError> {
+  if (!event || typeof event !== "object" || !("type" in event)) return Effect.void;
+
+  return Schema.decodeUnknown(SseEventEnvelopeSchema)(event).pipe(
+    Effect.mapError(
+      (cause) =>
+        new SseDispatchError({
+          eventType: "type" in event && typeof event.type === "string" ? event.type : "unknown",
+          cause,
+        }),
+    ),
+    Effect.flatMap((envelope) =>
+      Effect.sync(() => dispatchEvent(queryClient, envelope as Event, activeSessionIdRef)),
+    ),
+  );
+}
+
+function dispatchEvent(
+  queryClient: QueryClient,
   event: Event,
   activeSessionIdRef: { current: string | null },
-) {
-  if (!event || !event.type) return;
-
+): void {
   const currentSessionId = activeSessionIdRef.current;
 
-  try {
   switch (event.type) {
     case "session.created": {
       const { info } = event.properties;
@@ -101,9 +144,7 @@ export function sseDispatch(
         if (!msg) return prev;
         const partIdx = msg.parts.findIndex((p) => p.id === part.id);
         const newParts =
-          partIdx >= 0
-            ? msg.parts.map((p, i) => (i === partIdx ? part : p))
-            : [...msg.parts, part];
+          partIdx >= 0 ? msg.parts.map((p, i) => (i === partIdx ? part : p)) : [...msg.parts, part];
         return {
           ...prev,
           messagesById: {
@@ -203,8 +244,5 @@ export function sseDispatch(
       }
       break;
     }
-  }
-  } catch (err) {
-    console.warn("sseDispatch: malformed event, skipping", event.type, err);
   }
 }

--- a/src/test/desktop.test.ts
+++ b/src/test/desktop.test.ts
@@ -25,4 +25,17 @@ describe("browser desktop fallback", () => {
       hiddenModels: [],
     });
   });
+
+  it("rejects malformed persisted values through the config schema", async () => {
+    window.localStorage.setItem(
+      "bloxbot-config",
+      JSON.stringify({ lastModel: 42, hiddenModels: "not-an-array" }),
+    );
+    const { desktop } = await import("@/lib/desktop");
+
+    await expect(desktop.loadConfig()).resolves.toEqual({
+      lastModel: null,
+      hiddenModels: [],
+    });
+  });
 });

--- a/src/test/opencode.test.ts
+++ b/src/test/opencode.test.ts
@@ -1,3 +1,4 @@
+import { Effect } from "effect";
 import { describe, expect, it } from "vitest";
 
 import { findOpenCodeListeningPort } from "../../electron/services/OpenCode";
@@ -12,19 +13,34 @@ describe("OpenCode server startup", () => {
   };
 
   it("finds the loopback TCP listener owned by the OpenCode process", () => {
-    expect(findOpenCodeListeningPort([connection], 1234)).toBe(54321);
+    expect(Effect.runSync(findOpenCodeListeningPort([connection], 1234))).toBe(54321);
   });
 
   it("ignores connections that do not belong to the OpenCode listener", () => {
     expect(
-      findOpenCodeListeningPort(
-        [
-          { ...connection, pid: 9999 },
-          { ...connection, state: "ESTABLISHED" },
-          { ...connection, localAddress: "0.0.0.0" },
-        ],
-        1234,
+      Effect.runSync(
+        findOpenCodeListeningPort(
+          [
+            { ...connection, pid: 9999 },
+            { ...connection, state: "ESTABLISHED" },
+            { ...connection, localAddress: "0.0.0.0" },
+          ],
+          1234,
+        ),
       ),
     ).toBeNull();
+  });
+
+  it("fails with a typed Effect error when the process owns multiple listeners", () => {
+    const result = Effect.runSync(
+      Effect.either(
+        findOpenCodeListeningPort([connection, { ...connection, localPort: "54322" }], 1234),
+      ),
+    );
+
+    expect(result).toMatchObject({
+      _tag: "Left",
+      left: { _tag: "OpenCodeError", message: expect.stringContaining("multiple loopback ports") },
+    });
   });
 });

--- a/src/test/opencodeBinary.test.ts
+++ b/src/test/opencodeBinary.test.ts
@@ -1,8 +1,8 @@
 import { createHash } from "node:crypto";
-import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { mkdtemp, readdir, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-
+import { Effect, Fiber, Logger, LogLevel } from "effect";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
@@ -51,11 +51,20 @@ afterEach(async () => {
 
 describe("OpenCode binary releases", () => {
   it("maps every packaged platform to its official archive", () => {
-    expect(getOpenCodeAssetSpec("darwin", "arm64").archiveName).toBe("opencode-darwin-arm64.zip");
-    expect(getOpenCodeAssetSpec("darwin", "x64").archiveName).toBe("opencode-darwin-x64.zip");
-    expect(getOpenCodeAssetSpec("win32", "x64").executableName).toBe("opencode.exe");
-    expect(getOpenCodeAssetSpec("linux", "x64").format).toBe("tar.gz");
-    expect(() => getOpenCodeAssetSpec("win32", "arm64")).toThrow("win32/arm64");
+    expect(Effect.runSync(getOpenCodeAssetSpec("darwin", "arm64")).archiveName).toBe(
+      "opencode-darwin-arm64.zip",
+    );
+    expect(Effect.runSync(getOpenCodeAssetSpec("darwin", "x64")).archiveName).toBe(
+      "opencode-darwin-x64.zip",
+    );
+    expect(Effect.runSync(getOpenCodeAssetSpec("win32", "x64")).executableName).toBe(
+      "opencode.exe",
+    );
+    expect(Effect.runSync(getOpenCodeAssetSpec("linux", "x64")).format).toBe("tar.gz");
+    expect(Effect.runSync(Effect.either(getOpenCodeAssetSpec("win32", "arm64")))).toMatchObject({
+      _tag: "Left",
+      left: { _tag: "OpenCodeBinaryError", message: expect.stringContaining("win32/arm64") },
+    });
   });
 
   it("selects the newest verified stable 1.x.x release and rejects other majors", () => {
@@ -91,27 +100,30 @@ describe("OpenCode binary releases", () => {
       await writeFile(join(destination, "opencode"), "runtime binary");
     });
 
-    const installed = await ensureOpenCodeBinary({
-      cacheDirectory,
-      platform: "darwin",
-      arch: "arm64",
-      fetch,
-      extractArchive,
-    });
+    const installed = await Effect.runPromise(
+      ensureOpenCodeBinary({
+        cacheDirectory,
+        platform: "darwin",
+        arch: "arm64",
+        fetch,
+        extractArchive,
+      }),
+    );
 
     expect(installed.version).toBe("1.4.2");
     expect(installed.executable).toBe(join(cacheDirectory, "darwin-arm64", "1.4.2", "opencode"));
     await expect(readFile(installed.executable, "utf8")).resolves.toBe("runtime binary");
     expect(fetch).toHaveBeenCalledTimes(2);
 
-    vi.spyOn(console, "warn").mockImplementation(() => undefined);
-    const cached = await ensureOpenCodeBinary({
-      cacheDirectory,
-      platform: "darwin",
-      arch: "arm64",
-      fetch: vi.fn().mockRejectedValue(new Error("offline")),
-      extractArchive,
-    });
+    const cached = await Effect.runPromise(
+      ensureOpenCodeBinary({
+        cacheDirectory,
+        platform: "darwin",
+        arch: "arm64",
+        fetch: vi.fn().mockRejectedValue(new Error("offline")),
+        extractArchive,
+      }).pipe(Logger.withMinimumLogLevel(LogLevel.None)),
+    );
 
     expect(cached).toEqual(installed);
     expect(extractArchive).toHaveBeenCalledTimes(1);
@@ -127,32 +139,137 @@ describe("OpenCode binary releases", () => {
       )
       .mockResolvedValueOnce(new Response("tampered archive"));
 
-    await expect(
-      ensureOpenCodeBinary({
-        cacheDirectory,
-        platform: "linux",
-        arch: "x64",
-        fetch,
-        extractArchive: vi.fn(),
-      }),
-    ).rejects.toThrow("no cached copy is available");
+    const result = await Effect.runPromise(
+      Effect.either(
+        ensureOpenCodeBinary({
+          cacheDirectory,
+          platform: "linux",
+          arch: "x64",
+          fetch,
+          extractArchive: vi.fn(),
+        }),
+      ),
+    );
+    expect(result).toMatchObject({
+      _tag: "Left",
+      left: {
+        _tag: "OpenCodeBinaryError",
+        message: expect.stringContaining("no cached copy is available"),
+      },
+    });
   });
 
   it("fails closed when only a new major release exists", async () => {
     const cacheDirectory = await makeTemporaryDirectory();
     const assetName = "opencode-windows-x64.zip";
 
-    await expect(
+    const result = await Effect.runPromise(
+      Effect.either(
+        ensureOpenCodeBinary({
+          cacheDirectory,
+          platform: "win32",
+          arch: "x64",
+          fetch: vi
+            .fn()
+            .mockResolvedValue(
+              Response.json([release("v2.0.0", assetName, `sha256:${"c".repeat(64)}`)]),
+            ),
+        }),
+      ),
+    );
+    expect(result).toMatchObject({
+      _tag: "Left",
+      left: {
+        _tag: "OpenCodeBinaryError",
+        message: expect.stringContaining("no cached copy is available"),
+      },
+    });
+  });
+
+  it("aborts an in-flight download and cleans its temporary directory", async () => {
+    const cacheDirectory = await makeTemporaryDirectory();
+    const assetName = "opencode-darwin-arm64.zip";
+    const releases = [release("v1.4.2", assetName, `sha256:${"a".repeat(64)}`)];
+    let downloadSignal: AbortSignal | undefined;
+    let markDownloadStarted: (() => void) | undefined;
+    const downloadStarted = new Promise<void>((resolve) => {
+      markDownloadStarted = resolve;
+    });
+    const fetch = vi
+      .fn()
+      .mockResolvedValueOnce(Response.json(releases))
+      .mockImplementationOnce((_input: RequestInfo | URL, init?: RequestInit) => {
+        downloadSignal = init?.signal ?? undefined;
+        markDownloadStarted?.();
+        return new Promise<Response>((_resolve, reject) => {
+          downloadSignal?.addEventListener("abort", () => reject(downloadSignal?.reason), {
+            once: true,
+          });
+        });
+      });
+    const fiber = Effect.runFork(
       ensureOpenCodeBinary({
         cacheDirectory,
-        platform: "win32",
-        arch: "x64",
-        fetch: vi
-          .fn()
-          .mockResolvedValue(
-            Response.json([release("v2.0.0", assetName, `sha256:${"c".repeat(64)}`)]),
-          ),
+        platform: "darwin",
+        arch: "arm64",
+        fetch,
+        extractArchive: vi.fn(),
       }),
-    ).rejects.toThrow("no cached copy is available");
+    );
+
+    await downloadStarted;
+    await Effect.runPromise(Fiber.interrupt(fiber));
+
+    expect(downloadSignal?.aborted).toBe(true);
+    const entries = await readdir(join(cacheDirectory, "darwin-arm64"));
+    expect(entries.some((entry) => entry.startsWith(".download-"))).toBe(false);
+  });
+
+  it("waits for non-cancellable extraction before cleaning up on interruption", async () => {
+    const cacheDirectory = await makeTemporaryDirectory();
+    const archive = Buffer.from("verified archive");
+    const digest = createHash("sha256").update(archive).digest("hex");
+    const assetName = "opencode-darwin-arm64.zip";
+    const releases = [release("v1.4.2", assetName, `sha256:${digest}`)];
+    const fetch = vi
+      .fn()
+      .mockResolvedValueOnce(Response.json(releases))
+      .mockResolvedValueOnce(new Response(archive));
+    let markExtractionStarted: (() => void) | undefined;
+    const extractionStarted = new Promise<void>((resolve) => {
+      markExtractionStarted = resolve;
+    });
+    let finishExtraction: (() => Promise<void>) | undefined;
+    const extractArchive = vi.fn(
+      (_archivePath: string, destination: string) =>
+        new Promise<void>((resolve) => {
+          finishExtraction = async () => {
+            await writeFile(join(destination, "opencode"), "runtime binary");
+            resolve();
+          };
+          markExtractionStarted?.();
+        }),
+    );
+    const fiber = Effect.runFork(
+      ensureOpenCodeBinary({
+        cacheDirectory,
+        platform: "darwin",
+        arch: "arm64",
+        fetch,
+        extractArchive,
+      }),
+    );
+
+    await extractionStarted;
+    const interruption = Effect.runPromise(Fiber.interrupt(fiber));
+    const entriesDuringExtraction = await readdir(join(cacheDirectory, "darwin-arm64"));
+    expect(entriesDuringExtraction.some((entry) => entry.startsWith(".download-"))).toBe(true);
+
+    expect(finishExtraction).toBeTypeOf("function");
+    await finishExtraction?.();
+    await interruption;
+
+    const entriesAfterInterruption = await readdir(join(cacheDirectory, "darwin-arm64"));
+    expect(entriesAfterInterruption.some((entry) => entry.startsWith(".download-"))).toBe(false);
   });
 });

--- a/src/test/sseDispatch.test.ts
+++ b/src/test/sseDispatch.test.ts
@@ -5,11 +5,19 @@
  * and assertions on the cache state after dispatching events.
  */
 
-import type { Event, PermissionRequest, QuestionRequest, Session, SessionStatus, Todo } from "@opencode-ai/sdk/v2/client";
+import type {
+  Event,
+  PermissionRequest,
+  QuestionRequest,
+  Session,
+  SessionStatus,
+  Todo,
+} from "@opencode-ai/sdk/v2/client";
 import { QueryClient } from "@tanstack/react-query";
+import { Cause, Effect } from "effect";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { qk } from "@/lib/queryKeys";
-import { type MessagesCache, sseDispatch } from "@/lib/sseDispatch";
+import { type MessagesCache, sseDispatch, sseDispatchEffect } from "@/lib/sseDispatch";
 import type { MessageWithParts } from "@/types";
 
 function makeQC() {
@@ -19,7 +27,13 @@ function makeQC() {
 }
 
 function makeSession(id: string, title: string): Session {
-  return { id, title, time: { created: Date.now(), updated: Date.now() }, version: 1, parentID: "" } as Session;
+  return {
+    id,
+    title,
+    time: { created: Date.now(), updated: Date.now() },
+    version: 1,
+    parentID: "",
+  } as Session;
 }
 
 function dispatch(qc: QueryClient, event: Partial<Event>, activeSessionId: string | null = null) {
@@ -43,6 +57,42 @@ describe("sseDispatch", () => {
 
   it("ignores events with no type", () => {
     dispatch(qc, { properties: {} } as never);
+  });
+
+  it("rejects an invalid SSE envelope in the typed error channel", () => {
+    const result = Effect.runSync(
+      Effect.either(
+        sseDispatchEffect(qc, { type: "session.created", properties: null }, { current: null }),
+      ),
+    );
+
+    expect(result).toMatchObject({
+      _tag: "Left",
+      left: { _tag: "SseDispatchError", eventType: "session.created" },
+    });
+  });
+
+  it("keeps cache programming errors as defects", () => {
+    const brokenClient = {
+      setQueryData: () => {
+        throw new Error("cache programming bug");
+      },
+    } as unknown as QueryClient;
+    const exit = Effect.runSyncExit(
+      sseDispatchEffect(
+        brokenClient,
+        { type: "session.created", properties: { info: makeSession("s1", "One") } },
+        { current: null },
+      ),
+    );
+
+    expect(exit._tag).toBe("Failure");
+    if (exit._tag === "Failure") {
+      expect(Cause.dieOption(exit.cause)).toMatchObject({
+        _tag: "Some",
+        value: expect.objectContaining({ message: "cache programming bug" }),
+      });
+    }
   });
 
   // ── Session events ─────────────────────────────────────────────────
@@ -80,7 +130,6 @@ describe("sseDispatch", () => {
       const sessions = qc.getQueryData<Session[]>(qk.sessions)!;
       expect(sessions).toHaveLength(1);
     });
-
   });
 
   describe("session.updated", () => {
@@ -351,7 +400,8 @@ describe("sseDispatch", () => {
         "s1",
       );
 
-      const part = qc.getQueryData<MessagesCache>(qk.messages("s1"))!.messagesById.m1.parts[0] as any;
+      const part = qc.getQueryData<MessagesCache>(qk.messages("s1"))!.messagesById.m1
+        .parts[0] as any;
       expect(part.output).toBe("out+more");
       expect(part.text).toBe("base"); // unchanged
     });
@@ -372,7 +422,9 @@ describe("sseDispatch", () => {
       );
 
       // Should not throw, cache unchanged
-      expect(qc.getQueryData<MessagesCache>(qk.messages("s1"))!.messagesById.m1.parts).toHaveLength(0);
+      expect(qc.getQueryData<MessagesCache>(qk.messages("s1"))!.messagesById.m1.parts).toHaveLength(
+        0,
+      );
     });
   });
 
@@ -405,10 +457,7 @@ describe("sseDispatch", () => {
         messagesById: {
           m1: {
             info: { id: "m1" } as any,
-            parts: [
-              { id: "p1", type: "text" } as any,
-              { id: "p2", type: "text" } as any,
-            ],
+            parts: [{ id: "p1", type: "text" } as any, { id: "p2", type: "text" } as any],
           },
         },
       });
@@ -479,11 +528,7 @@ describe("sseDispatch", () => {
     it("clears the question on reply", () => {
       qc.setQueryData(qk.questions, { id: "q1", sessionID: "s1" });
 
-      dispatch(
-        qc,
-        { type: "question.replied", properties: { sessionID: "s1" } },
-        "s1",
-      );
+      dispatch(qc, { type: "question.replied", properties: { sessionID: "s1" } }, "s1");
 
       expect(qc.getQueryData(qk.questions)).toBeNull();
     });
@@ -491,11 +536,7 @@ describe("sseDispatch", () => {
     it("clears the question on reject", () => {
       qc.setQueryData(qk.questions, { id: "q1", sessionID: "s1" });
 
-      dispatch(
-        qc,
-        { type: "question.rejected", properties: { sessionID: "s1" } },
-        "s1",
-      );
+      dispatch(qc, { type: "question.rejected", properties: { sessionID: "s1" } }, "s1");
 
       expect(qc.getQueryData(qk.questions)).toBeNull();
     });
@@ -523,11 +564,7 @@ describe("sseDispatch", () => {
     it("clears the permission request", () => {
       qc.setQueryData(qk.permissions, { id: "p1", sessionID: "s1" });
 
-      dispatch(
-        qc,
-        { type: "permission.replied", properties: { sessionID: "s1" } },
-        "s1",
-      );
+      dispatch(qc, { type: "permission.replied", properties: { sessionID: "s1" } }, "s1");
 
       expect(qc.getQueryData(qk.permissions)).toBeNull();
     });

--- a/src/types/desktop.ts
+++ b/src/types/desktop.ts
@@ -1,18 +1,36 @@
-export interface AppConfig {
-  lastModel: string | null;
-  hiddenModels: string[];
-}
+import { Schema } from "effect";
 
-export interface OpenCodeInfo {
-  authorization: string;
-  port: number;
-  workspace: string;
-}
+const MutableStrings = Schema.mutable(Schema.Array(Schema.String));
 
-export interface UpdateInfo {
-  version: string;
-  body: string | null;
-}
+export const AppConfigSchema = Schema.mutable(
+  Schema.Struct({
+    lastModel: Schema.NullOr(Schema.String),
+    hiddenModels: MutableStrings,
+  }),
+);
+
+export type AppConfig = typeof AppConfigSchema.Type;
+
+export const AppConfigPatchSchema = Schema.partial(AppConfigSchema);
+
+export const OpenCodeInfoSchema = Schema.mutable(
+  Schema.Struct({
+    authorization: Schema.String,
+    port: Schema.Number.pipe(Schema.int(), Schema.between(1, 65_535)),
+    workspace: Schema.String,
+  }),
+);
+
+export type OpenCodeInfo = typeof OpenCodeInfoSchema.Type;
+
+export const UpdateInfoSchema = Schema.mutable(
+  Schema.Struct({
+    version: Schema.String,
+    body: Schema.NullOr(Schema.String),
+  }),
+);
+
+export type UpdateInfo = typeof UpdateInfoSchema.Type;
 
 export interface DesktopApi {
   getOpenCodeInfo(): Promise<OpenCodeInfo>;


### PR DESCRIPTION
## Summary

- migrate Electron lifecycle, IPC, configuration, updater, OpenCode startup, and binary management to typed Effect workflows
- add scoped and interruption-safe process/download resources, Schema validation, serialized config writes, and Effect-native browser services
- keep React code and Promise bridge contracts unchanged while strengthening typed-channel, defect, and interruption coverage

## Effect review

A clean-context Effect best-practices review was completed before opening this PR. Its findings were applied, including immediate child finalizer registration, cancellable downloads, uninterruptible archive publication, SSE boundary validation, operational config error propagation, and removal of redundant preload wrapping.

## Verification

- `pnpm test` — 94 tests pass
- `pnpm typecheck`
- `pnpm build`
- `git diff --check`

The build retains the existing Vite large-chunk warning.