### PR TITLE
Hide Dock icon on close and clean up test coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ dist
 dist-ssr
 dist-electron
 release
+coverage
 *.local
 
 # Environment and secrets

--- a/electron/appLifecycle.ts
+++ b/electron/appLifecycle.ts
@@ -1,6 +1,12 @@
-export function shouldQuitAfterLastWindowCloses(
+interface LastWindowCloseActions {
+  readonly hideDock: () => void;
+  readonly quit: () => void;
+}
+
+export function handleLastWindowClosed(
   platform: NodeJS.Platform,
-  isPackaged: boolean,
-): boolean {
-  return platform !== "darwin" || !isPackaged;
+  actions: LastWindowCloseActions,
+): void {
+  if (platform === "darwin") actions.hideDock();
+  actions.quit();
 }

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -11,7 +11,7 @@ import {
   AppConfigPatchSchema,
   AppConfigSchema,
 } from "../src/types/desktop";
-import { shouldQuitAfterLastWindowCloses } from "./appLifecycle";
+import { handleLastWindowClosed } from "./appLifecycle";
 import { channels } from "./channels";
 import { makeOpenCodeLayer, OpenCode } from "./services/OpenCode";
 
@@ -249,7 +249,10 @@ const registerAppLifecycle = Effect.sync(() => {
   app.on("window-all-closed", () =>
     Effect.runSync(
       Effect.sync(() => {
-        if (shouldQuitAfterLastWindowCloses(process.platform, app.isPackaged)) app.quit();
+        handleLastWindowClosed(process.platform, {
+          hideDock: () => app.dock?.hide(),
+          quit: () => app.quit(),
+        });
       }),
     ),
   );

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "@types/react": "^18.3.1",
     "@types/react-dom": "^18.3.1",
     "@vitejs/plugin-react": "^6.0.3",
+    "@vitest/coverage-v8": "^4.1.10",
     "electron": "^43.1.1",
     "electron-builder": "^26.15.3",
     "jsdom": "^29.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -78,6 +78,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^6.0.3
         version: 6.0.3(vite@8.1.5(@types/node@25.2.2)(jiti@2.7.0))
+      '@vitest/coverage-v8':
+        specifier: ^4.1.10
+        version: 4.1.10(vitest@4.1.10)
       electron:
         specifier: ^43.1.1
         version: 43.1.1
@@ -107,7 +110,7 @@ importers:
         version: 1.1.0
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.0)(@types/node@25.2.2)(jsdom@29.0.1(@noble/hashes@1.8.0))(msw@2.12.10(@types/node@25.2.2)(typescript@5.6.3))(vite@8.1.5(@types/node@25.2.2)(jiti@2.7.0))
+        version: 4.1.10(@opentelemetry/api@1.9.0)(@types/node@25.2.2)(@vitest/coverage-v8@4.1.10)(jsdom@29.0.1(@noble/hashes@1.8.0))(msw@2.12.10(@types/node@25.2.2)(typescript@5.6.3))(vite@8.1.5(@types/node@25.2.2)(jiti@2.7.0))
 
 packages:
 
@@ -199,8 +202,16 @@ packages:
     resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helper-string-parser@7.29.7':
+    resolution: {integrity: sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/helper-validator-identifier@7.28.5':
     resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@7.29.7':
+    resolution: {integrity: sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-validator-option@7.27.1':
@@ -213,6 +224,11 @@ packages:
 
   '@babel/parser@7.29.0':
     resolution: {integrity: sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  '@babel/parser@7.29.7':
+    resolution: {integrity: sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
@@ -261,6 +277,14 @@ packages:
   '@babel/types@7.29.0':
     resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
     engines: {node: '>=6.9.0'}
+
+  '@babel/types@7.29.7':
+    resolution: {integrity: sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==}
+    engines: {node: '>=6.9.0'}
+
+  '@bcoe/v8-coverage@1.0.2':
+    resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
+    engines: {node: '>=18'}
 
   '@biomejs/biome@2.3.14':
     resolution: {integrity: sha512-QMT6QviX0WqXJCaiqVMiBUCr5WRQ1iFSjvOLoTk6auKukJMvnMzWucXpwZB0e8F00/1/BsS9DzcKgWH+CLqVuA==}
@@ -1057,6 +1081,15 @@ packages:
       babel-plugin-react-compiler:
         optional: true
 
+  '@vitest/coverage-v8@4.1.10':
+    resolution: {integrity: sha512-IM49HmthevbgAO4anp1hwtoT9wYe59w0LR00gr+eagHE+ZJ5lK4sLPeO0ubgoJcwLk6dehU3R24N+FbEEKDc8g==}
+    peerDependencies:
+      '@vitest/browser': 4.1.10
+      vitest: 4.1.10
+    peerDependenciesMeta:
+      '@vitest/browser':
+        optional: true
+
   '@vitest/expect@4.1.10':
     resolution: {integrity: sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==}
 
@@ -1169,6 +1202,9 @@ packages:
   ast-types@0.16.1:
     resolution: {integrity: sha512-6t10qk83GOG8p0vKmaCr8eiilZwO171AvbROMtvvNiwrTly62t+7XkA8RdIIVbpMhCASAsxgAzdRSwh6nw/5Dg==}
     engines: {node: '>=4'}
+
+  ast-v8-to-istanbul@1.0.5:
+    resolution: {integrity: sha512-UPAgKJFSEGMWSDr3LX4tqnAb4f7KGT8O40Tyx8wbYmmZ/yn58lNCm8h3svs3eXgiGd5AXxz8NDOvXWvicq+rJA==}
 
   async-exit-hook@2.0.1:
     resolution: {integrity: sha512-NW2cX8m1Q7KPA7a5M2ULQeZ2wR5qI5PAbw5L0UOMxdioVk9PMZ0h1TmyZEkPYrCvYjDlFICusOu1dlEKAAeXBw==}
@@ -1967,6 +2003,9 @@ packages:
     resolution: {integrity: sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
 
+  html-escaper@2.0.2:
+    resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
+
   html-url-attributes@3.0.1:
     resolution: {integrity: sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==}
 
@@ -2143,6 +2182,18 @@ packages:
     resolution: {integrity: sha512-FFUtZMpoZ8RqHS3XeXEmHWLA4thH+ZxCv2lOiPIn1Xc7CxrqhWzNSDzD+/chS/zbYezmiwWLdQC09JdQKmthOw==}
     engines: {node: '>=20'}
 
+  istanbul-lib-coverage@3.2.2:
+    resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
+    engines: {node: '>=8'}
+
+  istanbul-lib-report@3.0.1:
+    resolution: {integrity: sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==}
+    engines: {node: '>=10'}
+
+  istanbul-reports@3.2.0:
+    resolution: {integrity: sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==}
+    engines: {node: '>=8'}
+
   jake@10.9.4:
     resolution: {integrity: sha512-wpHYzhxiVQL+IV05BLE2Xn34zW1S223hvjtqk0+gsPrwd/8JNLXJgZZM/iPFsYc1xyphF+6M6EvdE5E9MBGkDA==}
     engines: {node: '>=10'}
@@ -2154,6 +2205,9 @@ packages:
 
   jose@6.1.3:
     resolution: {integrity: sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ==}
+
+  js-tokens@10.0.0:
+    resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
@@ -2342,6 +2396,13 @@ packages:
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  magicast@0.5.3:
+    resolution: {integrity: sha512-pVKE4UdSQ7DvHzivsCIFx2BJn1mHG6KsyrFcaxFx6tONdneEuThrDx0Cj3AMg58KyN4pzYT+LHOotxDQDjNvkw==}
+
+  make-dir@4.0.0:
+    resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
+    engines: {node: '>=10'}
 
   markdown-table@3.0.4:
     resolution: {integrity: sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==}
@@ -3788,7 +3849,11 @@ snapshots:
 
   '@babel/helper-string-parser@7.27.1': {}
 
+  '@babel/helper-string-parser@7.29.7': {}
+
   '@babel/helper-validator-identifier@7.28.5': {}
+
+  '@babel/helper-validator-identifier@7.29.7': {}
 
   '@babel/helper-validator-option@7.27.1': {}
 
@@ -3800,6 +3865,10 @@ snapshots:
   '@babel/parser@7.29.0':
     dependencies:
       '@babel/types': 7.29.0
+
+  '@babel/parser@7.29.7':
+    dependencies:
+      '@babel/types': 7.29.7
 
   '@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0)':
     dependencies:
@@ -3865,6 +3934,13 @@ snapshots:
     dependencies:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
+
+  '@babel/types@7.29.7':
+    dependencies:
+      '@babel/helper-string-parser': 7.29.7
+      '@babel/helper-validator-identifier': 7.29.7
+
+  '@bcoe/v8-coverage@1.0.2': {}
 
   '@biomejs/biome@2.3.14':
     optionalDependencies:
@@ -4625,6 +4701,20 @@ snapshots:
       '@rolldown/pluginutils': 1.0.1
       vite: 8.1.5(@types/node@25.2.2)(jiti@2.7.0)
 
+  '@vitest/coverage-v8@4.1.10(vitest@4.1.10)':
+    dependencies:
+      '@bcoe/v8-coverage': 1.0.2
+      '@vitest/utils': 4.1.10
+      ast-v8-to-istanbul: 1.0.5
+      istanbul-lib-coverage: 3.2.2
+      istanbul-lib-report: 3.0.1
+      istanbul-reports: 3.2.0
+      magicast: 0.5.3
+      obug: 2.1.1
+      std-env: 4.0.0
+      tinyrainbow: 3.1.0
+      vitest: 4.1.10(@opentelemetry/api@1.9.0)(@types/node@25.2.2)(@vitest/coverage-v8@4.1.10)(jsdom@29.0.1(@noble/hashes@1.8.0))(msw@2.12.10(@types/node@25.2.2)(typescript@5.6.3))(vite@8.1.5(@types/node@25.2.2)(jiti@2.7.0))
+
   '@vitest/expect@4.1.10':
     dependencies:
       '@standard-schema/spec': 1.1.0
@@ -4777,6 +4867,12 @@ snapshots:
   ast-types@0.16.1:
     dependencies:
       tslib: 2.8.1
+
+  ast-v8-to-istanbul@1.0.5:
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      estree-walker: 3.0.3
+      js-tokens: 10.0.0
 
   async-exit-hook@2.0.1: {}
 
@@ -5660,6 +5756,8 @@ snapshots:
     transitivePeerDependencies:
       - '@noble/hashes'
 
+  html-escaper@2.0.2: {}
+
   html-url-attributes@3.0.1: {}
 
   http-cache-semantics@4.2.0: {}
@@ -5790,6 +5888,19 @@ snapshots:
 
   isexe@4.0.0: {}
 
+  istanbul-lib-coverage@3.2.2: {}
+
+  istanbul-lib-report@3.0.1:
+    dependencies:
+      istanbul-lib-coverage: 3.2.2
+      make-dir: 4.0.0
+      supports-color: 7.2.0
+
+  istanbul-reports@3.2.0:
+    dependencies:
+      html-escaper: 2.0.2
+      istanbul-lib-report: 3.0.1
+
   jake@10.9.4:
     dependencies:
       async: 3.2.6
@@ -5799,6 +5910,8 @@ snapshots:
   jiti@2.7.0: {}
 
   jose@6.1.3: {}
+
+  js-tokens@10.0.0: {}
 
   js-tokens@4.0.0: {}
 
@@ -5960,6 +6073,16 @@ snapshots:
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  magicast@0.5.3:
+    dependencies:
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.0
+      source-map-js: 1.2.1
+
+  make-dir@4.0.0:
+    dependencies:
+      semver: 7.8.5
 
   markdown-table@3.0.4: {}
 
@@ -7384,7 +7507,7 @@ snapshots:
       fsevents: 2.3.3
       jiti: 2.7.0
 
-  vitest@4.1.10(@opentelemetry/api@1.9.0)(@types/node@25.2.2)(jsdom@29.0.1(@noble/hashes@1.8.0))(msw@2.12.10(@types/node@25.2.2)(typescript@5.6.3))(vite@8.1.5(@types/node@25.2.2)(jiti@2.7.0)):
+  vitest@4.1.10(@opentelemetry/api@1.9.0)(@types/node@25.2.2)(@vitest/coverage-v8@4.1.10)(jsdom@29.0.1(@noble/hashes@1.8.0))(msw@2.12.10(@types/node@25.2.2)(typescript@5.6.3))(vite@8.1.5(@types/node@25.2.2)(jiti@2.7.0)):
     dependencies:
       '@vitest/expect': 4.1.10
       '@vitest/mocker': 4.1.10(msw@2.12.10(@types/node@25.2.2)(typescript@5.6.3))(vite@8.1.5(@types/node@25.2.2)(jiti@2.7.0))
@@ -7409,6 +7532,7 @@ snapshots:
     optionalDependencies:
       '@opentelemetry/api': 1.9.0
       '@types/node': 25.2.2
+      '@vitest/coverage-v8': 4.1.10(vitest@4.1.10)
       jsdom: 29.0.1(@noble/hashes@1.8.0)
     transitivePeerDependencies:
       - msw

--- a/src/test/ChatInput.test.tsx
+++ b/src/test/ChatInput.test.tsx
@@ -10,10 +10,10 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { useRef } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { qk } from "@/lib/queryKeys";
-import type { MessagesCache } from "@/lib/sseDispatch";
 import ChatInput from "@/components/ChatInput";
 import { Toaster } from "@/components/ui/sonner";
+import { qk } from "@/lib/queryKeys";
+import type { MessagesCache } from "@/lib/sseDispatch";
 import { ActiveSessionContext } from "@/providers/ActiveSessionProvider";
 import { OpenCodeClientContext } from "@/providers/OpenCodeClientProvider";
 import { PreferencesProvider } from "@/providers/PreferencesProvider";
@@ -21,7 +21,13 @@ import { PreferencesProvider } from "@/providers/PreferencesProvider";
 // ── Helpers ──────────────────────────────────────────────────────────
 
 function makeSession(id: string, title: string): Session {
-  return { id, title, time: { created: Date.now(), updated: Date.now() }, version: 1, parentID: "" } as Session;
+  return {
+    id,
+    title,
+    time: { created: Date.now(), updated: Date.now() },
+    version: 1,
+    parentID: "",
+  } as Session;
 }
 
 function createClient(overrides: Record<string, unknown> = {}) {
@@ -43,7 +49,14 @@ function createClient(overrides: Record<string, unknown> = {}) {
       list: vi.fn().mockResolvedValue({
         data: {
           all: [
-            { id: "anthropic", name: "Anthropic", env: [], models: { "claude-3.5-sonnet": { id: "claude-3.5-sonnet", name: "Claude 3.5 Sonnet" } } },
+            {
+              id: "anthropic",
+              name: "Anthropic",
+              env: [],
+              models: {
+                "claude-3.5-sonnet": { id: "claude-3.5-sonnet", name: "Claude 3.5 Sonnet" },
+              },
+            },
           ],
           connected: ["anthropic"],
           default: { anthropic: "claude-3.5-sonnet" },
@@ -74,7 +87,12 @@ function seedState(qc: QueryClient, session: Session) {
   qc.setQueryData(qk.agents, []);
   qc.setQueryData(qk.providers, {
     all: [
-      { id: "anthropic", name: "Anthropic", env: [], models: { "claude-3.5-sonnet": { id: "claude-3.5-sonnet", name: "Claude 3.5 Sonnet" } } },
+      {
+        id: "anthropic",
+        name: "Anthropic",
+        env: [],
+        models: { "claude-3.5-sonnet": { id: "claude-3.5-sonnet", name: "Claude 3.5 Sonnet" } },
+      },
     ],
     connected: ["anthropic"],
     default: { anthropic: "claude-3.5-sonnet" },
@@ -111,7 +129,13 @@ function TestChatInput({
   return (
     <QueryClientProvider client={queryClient}>
       <OpenCodeClientContext.Provider
-        value={{ client: client as never, status: clientStatus as "waiting" | "ready" | "error", port: 4096, ready: clientStatus === "ready", initError: null }}
+        value={{
+          client: client as never,
+          status: clientStatus as "waiting" | "ready" | "error",
+          port: 4096,
+          ready: clientStatus === "ready",
+          initError: null,
+        }}
       >
         <ActiveSessionContext.Provider
           value={{
@@ -144,17 +168,6 @@ afterEach(() => {
 // ── Tests ────────────────────────────────────────────────────────────
 
 describe("ChatInput", () => {
-  it("renders the textarea and send button", async () => {
-    const client = createClient();
-    const qc = createQueryClient();
-
-    render(<TestChatInput client={client} queryClient={qc} />);
-
-    const textarea = await screen.findByPlaceholderText("Describe what you want to build...");
-    expect(textarea).toBeInTheDocument();
-    expect(screen.getByTitle("Send")).toBeInTheDocument();
-  });
-
   it("sends a text message on submit", async () => {
     const client = createClient();
     const qc = createQueryClient();
@@ -226,7 +239,9 @@ describe("ChatInput", () => {
 
     render(<TestChatInput client={client} queryClient={qc} />);
 
-    const textarea = await screen.findByPlaceholderText("Describe what you want to build...") as HTMLTextAreaElement;
+    const textarea = (await screen.findByPlaceholderText(
+      "Describe what you want to build...",
+    )) as HTMLTextAreaElement;
 
     await act(async () => {
       fireEvent.change(textarea, { target: { value: "Test message" } });
@@ -316,12 +331,40 @@ describe("ChatInput", () => {
     });
   });
 
-  it("has an attach images button", async () => {
+  it("attaches an image to the submitted message", async () => {
     const client = createClient();
     const qc = createQueryClient();
 
-    render(<TestChatInput client={client} queryClient={qc} />);
+    const { container } = render(<TestChatInput client={client} queryClient={qc} />);
+    const fileInput = container.querySelector<HTMLInputElement>('input[type="file"]');
+    expect(fileInput).not.toBeNull();
+    if (!fileInput) throw new Error("Image file input was not rendered");
 
-    expect(await screen.findByTitle("Attach images")).toBeInTheDocument();
+    const image = new File(["image contents"], "reference.png", { type: "image/png" });
+    await act(async () => {
+      fireEvent.change(fileInput, { target: { files: [image] } });
+    });
+
+    expect(await screen.findByText("reference.png")).toBeInTheDocument();
+
+    await act(async () => {
+      fireEvent.click(screen.getByTitle("Send"));
+    });
+
+    await waitFor(() => expect(client.session.promptAsync).toHaveBeenCalledOnce());
+    expect(client.session.promptAsync).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionID: "s1",
+        parts: [
+          { type: "text", text: " " },
+          {
+            type: "file",
+            mime: "image/png",
+            url: expect.stringMatching(/^data:image\/png;base64,/),
+            filename: "reference.png",
+          },
+        ],
+      }),
+    );
   });
 });

--- a/src/test/appLifecycle.test.ts
+++ b/src/test/appLifecycle.test.ts
@@ -1,18 +1,30 @@
 import { describe, expect, it } from "vitest";
 
-import { shouldQuitAfterLastWindowCloses } from "../../electron/appLifecycle";
+import { handleLastWindowClosed } from "../../electron/appLifecycle";
 
 describe("app lifecycle", () => {
-  it("quits when the last development window closes on macOS", () => {
-    expect(shouldQuitAfterLastWindowCloses("darwin", false)).toBe(true);
+  it("hides the Dock icon before quitting on macOS", () => {
+    const actions: string[] = [];
+
+    handleLastWindowClosed("darwin", {
+      hideDock: () => actions.push("hide Dock"),
+      quit: () => actions.push("quit"),
+    });
+
+    expect(actions).toEqual(["hide Dock", "quit"]);
   });
 
-  it("keeps the native macOS lifecycle for packaged builds", () => {
-    expect(shouldQuitAfterLastWindowCloses("darwin", true)).toBe(false);
-  });
+  it.each([
+    "linux",
+    "win32",
+  ] as const)("quits without trying to hide a Dock icon on %s", (platform) => {
+    const actions: string[] = [];
 
-  it("quits when the last window closes on other platforms", () => {
-    expect(shouldQuitAfterLastWindowCloses("linux", true)).toBe(true);
-    expect(shouldQuitAfterLastWindowCloses("win32", true)).toBe(true);
+    handleLastWindowClosed(platform, {
+      hideDock: () => actions.push("hide Dock"),
+      quit: () => actions.push("quit"),
+    });
+
+    expect(actions).toEqual(["quit"]);
   });
 });

--- a/src/test/sseDispatch.test.ts
+++ b/src/test/sseDispatch.test.ts
@@ -15,7 +15,7 @@ import type {
 } from "@opencode-ai/sdk/v2/client";
 import { QueryClient } from "@tanstack/react-query";
 import { Cause, Effect } from "effect";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
 import { qk } from "@/lib/queryKeys";
 import { type MessagesCache, sseDispatch, sseDispatchEffect } from "@/lib/sseDispatch";
 import type { MessageWithParts } from "@/types";
@@ -567,18 +567,6 @@ describe("sseDispatch", () => {
       dispatch(qc, { type: "permission.replied", properties: { sessionID: "s1" } }, "s1");
 
       expect(qc.getQueryData(qk.permissions)).toBeNull();
-    });
-  });
-
-  // ── MCP events ─────────────────────────────────────────────────────
-
-  describe("mcp.tools.changed", () => {
-    it("is a no-op (studio status indicator removed)", () => {
-      const spy = vi.spyOn(qc, "invalidateQueries");
-
-      dispatch(qc, { type: "mcp.tools.changed", properties: {} });
-
-      expect(spy).not.toHaveBeenCalled();
     });
   });
 });


### PR DESCRIPTION
## Summary

- Hide the macOS Dock icon as soon as the last window closes.
- Continue through the existing `app.quit()` / `before-quit` cleanup path so the OpenCode runtime is disposed normally.
- Remove two redundant tests, replace the image-button presence check with behavioral attachment coverage, and restore `pnpm test:coverage`.

## Root cause

Packaged macOS builds deliberately kept the native app lifecycle after the last window closed. That left the Dock icon visible and did not start the existing quit cleanup. Hiding the Dock icon before calling `app.quit()` gives immediate visual feedback while the established asynchronous cleanup completes.

## Impact

Closing the final window now removes BloxBot from the Dock immediately on macOS. Other platforms still quit normally, and cleanup behavior is unchanged.

## Validation

- `pnpm test` — 92 tests passed
- `pnpm test:coverage` — 54.45% statements, 58.03% lines
- `pnpm typecheck`
- `pnpm build`