### PR TITLE
Release v0.6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+## [0.6.2] - 2026-07-21
+
+### Changed
+
+- Model quota failures now use OpenCode's structured status and action data, with native usage-limit guidance for free models instead of message matching.
+- Automatic OpenCode context compaction is enabled by default, and the OpenCode SDK has been updated to its current status schema.
+- React Query synchronization now uses scoped cache keys, precise event-driven updates, reconnect reconciliation, and targeted mutation rollback instead of broad invalidation.
+- Removed the bundled third-party Gemini OAuth plugin; Google API-key authentication and other supported providers remain available.
+- Refined the detailed-analytics consent prompt into a compact decision card with full-width copy and clear actions.
+
+### Fixed
+
+- Prevented stale HTTP snapshots and out-of-order event updates from restoring deleted sessions, reviving stale messages, or leaking drafts between conversations.
+- Corrected session mutation failure handling, optional action rendering, sidebar interactions, and related React subscription ownership issues.
+
 ## [0.6.1] - 2026-07-21
 
 ### Changed
@@ -54,6 +69,7 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 - OpenCode downloads are restricted to official GitHub release assets and verified with SHA-256 digests before installation and on every cache reuse.
 - Electron runs with context isolation, renderer sandboxing, Node.js integration disabled, validated IPC payloads, and external navigation blocked.
 
-[Unreleased]: https://github.com/paralov/app-bloxbot-ai/compare/v0.6.1...HEAD
+[Unreleased]: https://github.com/paralov/app-bloxbot-ai/compare/v0.6.2...HEAD
+[0.6.2]: https://github.com/paralov/app-bloxbot-ai/compare/v0.6.1...v0.6.2
 [0.6.1]: https://github.com/paralov/app-bloxbot-ai/compare/v0.6.0...v0.6.1
 [0.6.0]: https://github.com/paralov/app-bloxbot-ai/compare/v0.5.2...v0.6.0

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "bloxbot",
   "private": true,
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "AI-assisted Roblox development from a secure desktop app",
   "type": "module",
   "main": "dist-electron/main/main.js",


### PR DESCRIPTION
## Summary

- bump the desktop application version from 0.6.1 to 0.6.2
- document the structured quota handling, automatic context compaction, React Query reliability work, Gemini plugin removal, and consent-dialog polish
- advance changelog comparison links for the new release

## Why

PR #41 merged after v0.6.1 was published. A new packaged release is required for desktop users to receive those changes.

## Validation

- `node scripts/release.ts validate`
- `pnpm test` — 138 app tests and 8 release tests passed
- `pnpm typecheck`
- `pnpm build`
- `git diff --check`