### PR TITLE
Release BloxBot v0.6.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+## [0.6.3] - 2026-07-23
+
 ### Changed
 
 - Simplified desktop analytics to PostHog's built-in defaults, with persistent device identity, device profiling, person profiles, feature flags, and app screen pageviews enabled.
@@ -78,7 +80,8 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 - OpenCode downloads are restricted to official GitHub release assets and verified with SHA-256 digests before installation and on every cache reuse.
 - Electron runs with context isolation, renderer sandboxing, Node.js integration disabled, validated IPC payloads, and external navigation blocked.
 
-[Unreleased]: https://github.com/paralov/app-bloxbot-ai/compare/v0.6.2...HEAD
+[Unreleased]: https://github.com/paralov/app-bloxbot-ai/compare/v0.6.3...HEAD
+[0.6.3]: https://github.com/paralov/app-bloxbot-ai/compare/v0.6.2...v0.6.3
 [0.6.2]: https://github.com/paralov/app-bloxbot-ai/compare/v0.6.1...v0.6.2
 [0.6.1]: https://github.com/paralov/app-bloxbot-ai/compare/v0.6.0...v0.6.1
 [0.6.0]: https://github.com/paralov/app-bloxbot-ai/compare/v0.5.2...v0.6.0

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "bloxbot",
   "private": true,
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "AI-assisted Roblox development from a secure desktop app",
   "type": "module",
   "main": "dist-electron/main/main.js",


### PR DESCRIPTION
## Release

Prepares BloxBot v0.6.3 from the PostHog Electron reporting changes merged in #43.

## Changes

- bump the application version from `0.6.2` to `0.6.3`
- move the completed analytics notes into the dated `0.6.3` changelog section
- update the Unreleased and `0.6.3` comparison links

## Included user impact

- restored PostHog EU reporting in packaged Electron builds
- persistent installation identity, person profiles, feature flags, and built-in device profiling
- meaningful `bloxbot://app/<screen>` pageview metadata instead of local-file current URLs

## Validation

- `node scripts/release.ts validate` — v0.6.3 is unused and ready
- generated release notes and installer links verified
- `pnpm test` — 133 Vitest tests and 8 release-script tests passed
- `pnpm typecheck`
- production `pnpm build` with the PostHog project token

## After merge

Run the **Release** workflow from `main`. It will rebuild and package universal macOS, Windows x64, and Linux x64 artifacts, verify the exact seven updater-safe assets, and publish v0.6.3.