### PR TITLE
Show boot progress and download speed

### DIFF
--- a/electron/channels.ts
+++ b/electron/channels.ts
@@ -1,6 +1,7 @@
 export const channels = {
   checkForUpdate: "app:check-for-update",
   getOpenCodeInfo: "opencode:get-info",
+  openCodeStartupProgress: "opencode:startup-progress",
   getVersion: "app:get-version",
   installUpdate: "app:install-update",
   loadConfig: "config:load",

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -11,6 +11,7 @@ import {
   AppConfigPatchSchema,
   AppConfigSchema,
   DEFAULT_APP_CONFIG,
+  type OpenCodeStartupProgress,
 } from "../src/types/desktop";
 import { handleLastWindowClosed } from "./appLifecycle";
 import { channels } from "./channels";
@@ -32,6 +33,11 @@ const openCodeRuntime = ManagedRuntime.make(
   makeOpenCodeLayer({
     binaryCacheDirectory: join(app.getPath("userData"), "opencode"),
     workspace: join(app.getPath("home"), "BloxBot"),
+    onStartupProgress: (progress: OpenCodeStartupProgress) => {
+      if (mainWindow && !mainWindow.isDestroyed()) {
+        mainWindow.webContents.send(channels.openCodeStartupProgress, progress);
+      }
+    },
   }),
 );
 

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -1,10 +1,16 @@
 import { contextBridge, ipcRenderer } from "electron";
 
-import type { AppConfig, DesktopApi } from "../src/types/desktop";
+import type { AppConfig, DesktopApi, OpenCodeStartupProgress } from "../src/types/desktop";
 import { channels } from "./channels";
 
 const api: DesktopApi = {
   getOpenCodeInfo: () => ipcRenderer.invoke(channels.getOpenCodeInfo),
+  onOpenCodeStartupProgress: (listener) => {
+    const handleProgress = (_event: Electron.IpcRendererEvent, progress: OpenCodeStartupProgress) =>
+      listener(progress);
+    ipcRenderer.on(channels.openCodeStartupProgress, handleProgress);
+    return () => ipcRenderer.removeListener(channels.openCodeStartupProgress, handleProgress);
+  },
   getVersion: () => ipcRenderer.invoke(channels.getVersion),
   openUrl: (url) => ipcRenderer.invoke(channels.openUrl, url),
   loadConfig: () => ipcRenderer.invoke(channels.loadConfig),

--- a/electron/services/OpenCode.ts
+++ b/electron/services/OpenCode.ts
@@ -6,7 +6,7 @@ import { join } from "node:path";
 import { Context, Data, Effect, Layer } from "effect";
 import { networkConnections, type Systeminformation } from "systeminformation";
 
-import type { OpenCodeInfo } from "../../src/types/desktop";
+import type { OpenCodeInfo, OpenCodeStartupProgress } from "../../src/types/desktop";
 import { createOpenCodeConfig } from "../opencodeConfig";
 import { ensureOpenCodeBinary } from "./OpenCodeBinary";
 
@@ -43,6 +43,7 @@ interface PreparedOpenCode {
 export interface OpenCodeOptions {
   binaryCacheDirectory: string;
   workspace: string;
+  onStartupProgress?: (progress: OpenCodeStartupProgress) => void;
 }
 
 export interface OpenCodeService {
@@ -191,11 +192,13 @@ function prepareOpenCode(options: OpenCodeOptions): Effect.Effect<PreparedOpenCo
   return Effect.gen(function* () {
     const { executable, version } = yield* ensureOpenCodeBinary({
       cacheDirectory: options.binaryCacheDirectory,
+      onStartupProgress: options.onStartupProgress,
     }).pipe(
       Effect.mapError(
         (cause) => new OpenCodeError({ message: cause.message, cause }),
       ),
     );
+    yield* Effect.sync(() => options.onStartupProgress?.({ phase: "starting" }));
     yield* Effect.logInfo(`[opencode] Starting v${version}`);
 
     const opencodeHome = join(options.workspace, ".opencode");

--- a/electron/services/OpenCodeBinary.ts
+++ b/electron/services/OpenCodeBinary.ts
@@ -17,6 +17,8 @@ import { Data, Effect, Schema } from "effect";
 import extractZip from "extract-zip";
 import { x as extractTar } from "tar";
 
+import type { OpenCodeStartupProgress } from "../../src/types/desktop";
+
 const OPEN_CODE_API = "https://api.github.com/repos/anomalyco/opencode/releases";
 const OPEN_CODE_DOWNLOAD_PREFIX = "https://github.com/anomalyco/opencode/releases/download/";
 const SUPPORTED_MAJOR = 1;
@@ -95,6 +97,7 @@ type ExtractArchive = (
   destination: string,
   format: AssetSpec["format"],
 ) => Promise<void>;
+type StartupProgressReporter = (progress: OpenCodeStartupProgress) => void;
 
 export interface OpenCodeBinaryOptions {
   cacheDirectory: string;
@@ -102,6 +105,7 @@ export interface OpenCodeBinaryOptions {
   arch?: string;
   fetch?: Fetch;
   extractArchive?: ExtractArchive;
+  onStartupProgress?: StartupProgressReporter;
 }
 
 const fail = (message: string, cause?: unknown) =>
@@ -112,6 +116,63 @@ const tryPromise = <A>(message: string, evaluate: (signal: AbortSignal) => Promi
     try: evaluate,
     catch: (cause) => new OpenCodeBinaryError({ message, cause }),
   });
+
+function contentLength(response: Response): number | null {
+  const header = response.headers.get("content-length");
+  if (header === null) return null;
+  const value = Number(header);
+  return Number.isSafeInteger(value) && value >= 0 ? value : null;
+}
+
+async function readDownload(
+  response: Response,
+  signal: AbortSignal,
+  reportProgress?: StartupProgressReporter,
+): Promise<Buffer | undefined> {
+  if (!response.body) return undefined;
+
+  const totalBytes = contentLength(response);
+  const reader = response.body.getReader();
+  const chunks: Uint8Array[] = [];
+  const startedAt = Date.now();
+  let downloadedBytes = 0;
+  let lastReportAt = startedAt;
+
+  const report = (now: number) => {
+    const elapsedSeconds = Math.max((now - startedAt) / 1000, 0.001);
+    reportProgress?.({
+      phase: "downloading",
+      downloadedBytes,
+      totalBytes,
+      bytesPerSecond: Math.round(downloadedBytes / elapsedSeconds),
+    });
+  };
+  const abortRead = () => void reader.cancel(signal.reason).catch(() => {});
+
+  signal.addEventListener("abort", abortRead, { once: true });
+  report(startedAt);
+
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (signal.aborted) throw signal.reason;
+      if (done) break;
+
+      chunks.push(value);
+      downloadedBytes += value.byteLength;
+      const now = Date.now();
+      if (now - lastReportAt >= 100) {
+        report(now);
+        lastReportAt = now;
+      }
+    }
+    report(Date.now());
+    return Buffer.concat(chunks, downloadedBytes);
+  } finally {
+    signal.removeEventListener("abort", abortRead);
+    reader.releaseLock();
+  }
+}
 
 function parseVersion(tag: string): Version | null {
   const match = /^v?(\d+)\.(\d+)\.(\d+)$/.exec(tag);
@@ -347,6 +408,7 @@ function installRelease(
   release: CompatibleRelease,
   fetchFn: Fetch,
   extractArchive: ExtractArchive,
+  reportProgress?: StartupProgressReporter,
 ): Effect.Effect<OpenCodeBinary, OpenCodeBinaryError> {
   return Effect.acquireUseRelease(
     tryPromise(
@@ -365,12 +427,18 @@ function installRelease(
         const { archiveBuffer, response } = yield* tryPromise(
           "OpenCode download failed",
           async (signal) => {
+            const downloadSignal = AbortSignal.any([
+              signal,
+              AbortSignal.timeout(DOWNLOAD_TIMEOUT_MS),
+            ]);
             const response = await fetchFn(release.asset.browser_download_url, {
               headers: { "User-Agent": "BloxBot" },
-              signal: AbortSignal.any([signal, AbortSignal.timeout(DOWNLOAD_TIMEOUT_MS)]),
+              signal: downloadSignal,
             });
             return {
-              archiveBuffer: response.ok ? await response.arrayBuffer() : undefined,
+              archiveBuffer: response.ok
+                ? await readDownload(response, downloadSignal, reportProgress)
+                : undefined,
               response,
             };
           },
@@ -383,6 +451,7 @@ function installRelease(
         }
 
         const archive = Buffer.from(archiveBuffer);
+        reportProgress?.({ phase: "verifying" });
         const archiveSha256 = createHash("sha256").update(archive).digest("hex");
         if (archiveSha256 !== release.archiveSha256) {
           return yield* fail("The downloaded OpenCode archive failed SHA-256 verification");
@@ -390,6 +459,7 @@ function installRelease(
 
         // Node filesystem and archive APIs do not accept AbortSignal. Mask this
         // publish phase so interruption cannot race cleanup against in-flight writes.
+        reportProgress?.({ phase: "installing" });
         return yield* Effect.uninterruptible(
           Effect.gen(function* () {
             yield* tryPromise("Failed to write the OpenCode archive", () =>
@@ -481,6 +551,7 @@ export function ensureOpenCodeBinary(
   const platformDirectory = join(options.cacheDirectory, `${platform}-${arch}`);
 
   return Effect.gen(function* () {
+    yield* Effect.sync(() => options.onStartupProgress?.({ phase: "checking" }));
     const spec = yield* getOpenCodeAssetSpec(platform, arch);
     yield* tryPromise("Failed to create the OpenCode cache directory", () =>
       mkdir(platformDirectory, { recursive: true }),
@@ -506,6 +577,7 @@ export function ensureOpenCodeBinary(
           release,
           fetchFn,
           extractArchive,
+          options.onStartupProgress,
         ));
       yield* pruneCache(platformDirectory);
       return binary;

--- a/src/components/LoadingScreen.tsx
+++ b/src/components/LoadingScreen.tsx
@@ -7,6 +7,7 @@ interface LoadingScreenProps {
   message?: string;
   detail?: string;
   animation?: StartupAnimation;
+  startup?: StartupProgress;
   /** When true, shows the error state with help actions instead of the dot loader. */
   error?: boolean;
   /** Called when the user clicks "Try Again". */
@@ -16,6 +17,13 @@ interface LoadingScreenProps {
 }
 
 export type StartupAnimation = "sparkles" | "dots" | "blocks";
+
+export interface StartupProgress {
+  step: 1 | 2 | 3;
+  label: string;
+  progress?: number;
+  meta?: string;
+}
 
 type UpdateCheckStatus = "idle" | "checking" | "available" | "downloading" | "up-to-date" | "error";
 
@@ -30,6 +38,7 @@ function LoadingScreen({
   message = "Starting up...",
   detail,
   animation,
+  startup,
   error,
   onRetry,
   retrying,
@@ -267,6 +276,8 @@ function LoadingScreen({
               </a>
             </div>
           </div>
+        ) : startup ? (
+          <StartupProgressGraphic startup={startup} />
         ) : animation ? (
           <StartupAnimationGraphic animation={animation} />
         ) : (
@@ -275,6 +286,60 @@ function LoadingScreen({
             <span className="bloxbot-dot h-1 w-1 rounded-full bg-foreground/25 [animation-delay:150ms]" />
             <span className="bloxbot-dot h-1 w-1 rounded-full bg-foreground/25 [animation-delay:300ms]" />
           </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function StartupProgressGraphic({ startup }: { startup: StartupProgress }) {
+  const currentIndex = startup.step - 1;
+  const currentProgress =
+    startup.progress === undefined ? undefined : Math.min(1, Math.max(0, startup.progress));
+
+  return (
+    <div className="mt-5 w-full max-w-[17rem]">
+      <div
+        className="grid grid-cols-3 gap-1.5"
+        role="progressbar"
+        aria-label={`${startup.label}, step ${startup.step} of 3`}
+        aria-valuemin={currentProgress === undefined ? undefined : 0}
+        aria-valuemax={currentProgress === undefined ? undefined : 100}
+        aria-valuenow={
+          currentProgress === undefined ? undefined : Math.round(currentProgress * 100)
+        }
+      >
+        {[0, 1, 2].map((index) => {
+          const complete = index < currentIndex;
+          const current = index === currentIndex;
+          const fill = complete ? 1 : current ? currentProgress : 0;
+
+          return (
+            <span
+              key={index}
+              className="h-1.5 overflow-hidden rounded-full bg-foreground/10"
+              aria-hidden="true"
+            >
+              {current && fill === undefined ? (
+                <span className="startup-progress-indeterminate block h-full rounded-full bg-foreground/65" />
+              ) : (
+                <span
+                  className="block h-full origin-left rounded-full bg-foreground/65 transition-transform duration-300 ease-out"
+                  style={{ transform: `scaleX(${fill ?? 0})` }}
+                />
+              )}
+            </span>
+          );
+        })}
+      </div>
+      <div className="mt-2.5 flex items-center justify-between gap-4 text-[11px] text-muted-foreground">
+        <span>
+          Step {startup.step} of 3 · {startup.label}
+        </span>
+        {startup.meta && (
+          <span className="shrink-0 font-mono text-[10px] tabular-nums text-foreground/65">
+            {startup.meta}
+          </span>
         )}
       </div>
     </div>

--- a/src/index.css
+++ b/src/index.css
@@ -282,6 +282,16 @@
 
 /* ── Playful startup progress ───────────────────────────────────── */
 
+@keyframes startup-progress-sweep {
+  from { transform: translateX(-110%); }
+  to   { transform: translateX(310%); }
+}
+
+.startup-progress-indeterminate {
+  width: 34%;
+  animation: startup-progress-sweep 1.25s ease-in-out infinite;
+}
+
 @keyframes startup-sparkle {
   0%, 100% { opacity: 0.2; transform: scale(0.55) rotate(0deg); }
   50%      { opacity: 0.9; transform: scale(1) rotate(90deg); }
@@ -387,11 +397,16 @@
 .startup-blocks span:nth-child(3) { animation-delay: 320ms; }
 
 @media (prefers-reduced-motion: reduce) {
+  .startup-progress-indeterminate,
   .startup-sparkles span,
   .startup-connecting::after,
   .startup-connecting span,
   .startup-blocks span {
     animation: none;
+  }
+
+  .startup-progress-indeterminate {
+    width: 38%;
   }
 }
 

--- a/src/lib/desktop.ts
+++ b/src/lib/desktop.ts
@@ -7,6 +7,7 @@ import {
   type DesktopApi,
   type OpenCodeInfo,
   OpenCodeInfoSchema,
+  type OpenCodeStartupProgress,
   type UpdateInfo,
   UpdateInfoSchema,
 } from "@/types/desktop";
@@ -29,6 +30,8 @@ interface DesktopEffects {
   readonly installUpdate: Effect.Effect<void, DesktopError>;
   readonly relaunch: Effect.Effect<void, DesktopError>;
 }
+
+type StartupProgressListener = (progress: OpenCodeStartupProgress) => void;
 
 const loadBrowserConfig = Effect.gen(function* () {
   const stored = yield* Effect.try({
@@ -132,6 +135,8 @@ const runPromise = <A>(effect: Effect.Effect<A, DesktopError>): Promise<A> =>
 /** Promise-only adapter consumed by React and exposed by the Electron bridge contract. */
 export const desktop: DesktopApi = {
   getOpenCodeInfo: () => runPromise(desktopEffects.getOpenCodeInfo),
+  onOpenCodeStartupProgress: (listener: StartupProgressListener) =>
+    window.bloxbot?.onOpenCodeStartupProgress(listener) ?? (() => {}),
   getVersion: () => runPromise(desktopEffects.getVersion),
   openUrl: (url) => runPromise(desktopEffects.openUrl(url)),
   loadConfig: () => runPromise(desktopEffects.loadConfig),

--- a/src/providers/OpenCodeClientProvider.tsx
+++ b/src/providers/OpenCodeClientProvider.tsx
@@ -11,11 +11,12 @@ import {
   useState,
 } from "react";
 import { toast } from "sonner";
-import LoadingScreen, { type StartupAnimation } from "@/components/LoadingScreen";
+import LoadingScreen, { type StartupProgress } from "@/components/LoadingScreen";
 import { captureDetailedAnalytics } from "@/lib/analytics";
 import { desktop } from "@/lib/desktop";
 import { qk } from "@/lib/queryKeys";
 import { sseDispatch } from "@/lib/sseDispatch";
+import type { OpenCodeStartupProgress } from "@/types/desktop";
 
 const SSE_RECONNECT_DELAY = 3000;
 const SSE_FAILURE_THRESHOLD = 3;
@@ -23,26 +24,91 @@ const SSE_FAILURE_THRESHOLD = 3;
 type AppStatus = "waiting" | "ready" | "error";
 export type StartupPhase = "engine" | "connection" | "workspace";
 
-const STARTUP_COPY: Record<StartupPhase, { message: string; animation: StartupAnimation }> = {
-  engine: {
-    message: "Waking things up",
-    animation: "sparkles",
-  },
+interface StartupPresentation {
+  message: string;
+  detail: string;
+  startup: StartupProgress;
+}
+
+const DEFAULT_ENGINE_PROGRESS: OpenCodeStartupProgress = { phase: "checking" };
+
+const STARTUP_COPY: Record<Exclude<StartupPhase, "engine">, StartupPresentation> = {
   connection: {
     message: "Connecting the dots",
-    animation: "dots",
+    detail: "Making sure everything can talk",
+    startup: { step: 2, label: "Connecting" },
   },
   workspace: {
     message: "Setting the stage",
-    animation: "blocks",
+    detail: "Loading your workspace and preferences",
+    startup: { step: 3, label: "Opening" },
   },
 };
 
-export function getStartupPresentation(phase: StartupPhase): {
-  message: string;
-  animation: StartupAnimation;
-} {
-  return STARTUP_COPY[phase];
+export function formatTransferSpeed(bytesPerSecond: number): string {
+  const speed = Number.isFinite(bytesPerSecond) ? Math.max(0, bytesPerSecond) : 0;
+  if (speed < 1024) return `${Math.round(speed)} B/s`;
+  if (speed < 1024 ** 2) return `${(speed / 1024).toFixed(1)} KB/s`;
+  return `${(speed / 1024 ** 2).toFixed(1)} MB/s`;
+}
+
+function getEnginePresentation(progress: OpenCodeStartupProgress): StartupPresentation {
+  if (progress.phase === "downloading") {
+    const fraction =
+      progress.totalBytes && progress.totalBytes > 0
+        ? Math.min(progress.downloadedBytes / progress.totalBytes, 1)
+        : undefined;
+    const percentage = fraction === undefined ? null : `${Math.round(fraction * 100)}%`;
+    return {
+      message: "Downloading a one-time setup",
+      detail: "Future launches will use the saved copy",
+      startup: {
+        step: 1,
+        label: "Preparing",
+        progress: fraction,
+        meta: [percentage, formatTransferSpeed(progress.bytesPerSecond)]
+          .filter(Boolean)
+          .join(" · "),
+      },
+    };
+  }
+
+  if (progress.phase === "verifying") {
+    return {
+      message: "Checking the download",
+      detail: "Making sure everything arrived safely",
+      startup: { step: 1, label: "Preparing", progress: 1 },
+    };
+  }
+
+  if (progress.phase === "installing") {
+    return {
+      message: "Finishing setup",
+      detail: "Unpacking the local engine",
+      startup: { step: 1, label: "Preparing", progress: 1 },
+    };
+  }
+
+  if (progress.phase === "starting") {
+    return {
+      message: "Starting your workspace",
+      detail: "Launching the local engine",
+      startup: { step: 1, label: "Preparing", progress: 1 },
+    };
+  }
+
+  return {
+    message: "Getting things ready",
+    detail: "Checking what this computer needs",
+    startup: { step: 1, label: "Preparing" },
+  };
+}
+
+export function getStartupPresentation(
+  phase: StartupPhase,
+  engineProgress: OpenCodeStartupProgress = DEFAULT_ENGINE_PROGRESS,
+): StartupPresentation {
+  return phase === "engine" ? getEnginePresentation(engineProgress) : STARTUP_COPY[phase];
 }
 
 interface OpenCodeClientContextValue {
@@ -76,6 +142,8 @@ export function OpenCodeClientProvider({
 
   const [status, setStatus] = useState<AppStatus>("waiting");
   const [startupPhase, setStartupPhase] = useState<StartupPhase>("engine");
+  const [engineProgress, setEngineProgress] =
+    useState<OpenCodeStartupProgress>(DEFAULT_ENGINE_PROGRESS);
   const [port, setPort] = useState(0);
   const [client, setClient] = useState<OpencodeClient | null>(null);
   const [ready, setReady] = useState(false);
@@ -89,6 +157,9 @@ export function OpenCodeClientProvider({
 
     let cancelled = false;
     let retryTimer: ReturnType<typeof setTimeout>;
+    const unsubscribeProgress = desktop.onOpenCodeStartupProgress((progress) => {
+      if (!cancelled) setEngineProgress(progress);
+    });
 
     // The desktop service owns startup, its deadline, and process cleanup.
     async function getServerInfo() {
@@ -120,6 +191,7 @@ export function OpenCodeClientProvider({
         setStatus("waiting");
         setInitError(null);
         setStartupPhase("engine");
+        setEngineProgress(DEFAULT_ENGINE_PROGRESS);
         const { port: ocPort, workspace, authorization } = await getServerInfo();
         if (cancelled) return;
 
@@ -154,6 +226,7 @@ export function OpenCodeClientProvider({
 
     return () => {
       cancelled = true;
+      unsubscribeProgress();
       clearTimeout(retryTimer);
     };
   }, [ready, queryClient]);
@@ -246,13 +319,13 @@ export function OpenCodeClientProvider({
   );
 
   if (!ready) {
-    const startup = getStartupPresentation(startupPhase);
+    const startup = getStartupPresentation(startupPhase, engineProgress);
     return (
       <OpenCodeClientContext.Provider value={value}>
         <LoadingScreen
           message={initError ? "Failed to connect to OpenCode" : startup.message}
-          detail={initError ?? undefined}
-          animation={initError ? undefined : startup.animation}
+          detail={initError ?? startup.detail}
+          startup={initError ? undefined : startup.startup}
           error={!!initError}
           onRetry={initError ? () => desktop.relaunch() : undefined}
         />

--- a/src/test/LoadingScreen.test.tsx
+++ b/src/test/LoadingScreen.test.tsx
@@ -6,20 +6,41 @@ import { getStartupPresentation, type StartupPhase } from "@/providers/OpenCodeC
 
 describe("startup progress", () => {
   it.each([
-    ["engine", "Waking things up", "sparkles"],
-    ["connection", "Connecting the dots", "dots"],
-    ["workspace", "Setting the stage", "blocks"],
-  ] as const)("gives the %s phase a short message and playful animation", (phase: StartupPhase, message, animation) => {
-    expect(getStartupPresentation(phase)).toEqual({ message, animation });
+    ["engine", "Getting things ready", "Preparing", 1],
+    ["connection", "Connecting the dots", "Connecting", 2],
+    ["workspace", "Setting the stage", "Opening", 3],
+  ] as const)("gives the %s phase friendly copy and a visible step", (phase: StartupPhase, message, label, step) => {
+    expect(getStartupPresentation(phase)).toMatchObject({
+      message,
+      startup: { label, step },
+    });
   });
 
-  it("shows only the short progress message", () => {
+  it("shows a calm three-step progress treatment", () => {
     const startup = getStartupPresentation("connection");
     const { container } = render(<LoadingScreen {...startup} />);
 
     expect(screen.getByRole("heading", { name: "Connecting the dots" })).toBeVisible();
-    expect(container.querySelector(".startup-connecting")).toBeInTheDocument();
+    expect(screen.getByText("Making sure everything can talk")).toBeVisible();
+    expect(screen.getByRole("progressbar", { name: "Connecting, step 2 of 3" })).toBeVisible();
+    expect(screen.getByText("Step 2 of 3 · Connecting")).toBeVisible();
+    expect(container.querySelector(".startup-progress-indeterminate")).toBeInTheDocument();
     expect(screen.queryByRole("list")).not.toBeInTheDocument();
     expect(screen.queryByText(/OpenCode/i)).not.toBeInTheDocument();
+  });
+
+  it("shows real download percentage and transfer speed", () => {
+    const startup = getStartupPresentation("engine", {
+      phase: "downloading",
+      downloadedBytes: 25,
+      totalBytes: 100,
+      bytesPerSecond: 2 * 1024 ** 2,
+    });
+    render(<LoadingScreen {...startup} />);
+
+    expect(screen.getByRole("heading", { name: "Downloading a one-time setup" })).toBeVisible();
+    expect(screen.getByText("Future launches will use the saved copy")).toBeVisible();
+    expect(screen.getByRole("progressbar")).toHaveAttribute("aria-valuenow", "25");
+    expect(screen.getByText("25% · 2.0 MB/s")).toBeVisible();
   });
 });

--- a/src/test/opencodeBinary.test.ts
+++ b/src/test/opencodeBinary.test.ts
@@ -11,6 +11,7 @@ import {
   getOpenCodeAssetSpec,
   selectCompatibleRelease,
 } from "../../electron/services/OpenCodeBinary";
+import type { OpenCodeStartupProgress } from "../types/desktop";
 
 const temporaryDirectories: string[] = [];
 
@@ -92,10 +93,13 @@ describe("OpenCode binary releases", () => {
     const digest = createHash("sha256").update(archive).digest("hex");
     const assetName = "opencode-darwin-arm64.zip";
     const releases = [release("v1.4.2", assetName, `sha256:${digest}`)];
+    const startupProgress: OpenCodeStartupProgress[] = [];
     const fetch = vi
       .fn()
       .mockResolvedValueOnce(Response.json(releases))
-      .mockResolvedValueOnce(new Response(archive));
+      .mockResolvedValueOnce(
+        new Response(archive, { headers: { "content-length": String(archive.byteLength) } }),
+      );
     const extractArchive = vi.fn(async (_archivePath: string, destination: string) => {
       await writeFile(join(destination, "opencode"), "runtime binary");
     });
@@ -107,6 +111,7 @@ describe("OpenCode binary releases", () => {
         arch: "arm64",
         fetch,
         extractArchive,
+        onStartupProgress: (progress) => startupProgress.push(progress),
       }),
     );
 
@@ -114,6 +119,14 @@ describe("OpenCode binary releases", () => {
     expect(installed.executable).toBe(join(cacheDirectory, "darwin-arm64", "1.4.2", "opencode"));
     await expect(readFile(installed.executable, "utf8")).resolves.toBe("runtime binary");
     expect(fetch).toHaveBeenCalledTimes(2);
+    expect(startupProgress[0]).toEqual({ phase: "checking" });
+    expect(startupProgress).toContainEqual({
+      phase: "downloading",
+      downloadedBytes: archive.byteLength,
+      totalBytes: archive.byteLength,
+      bytesPerSecond: expect.any(Number),
+    });
+    expect(startupProgress.slice(-2)).toEqual([{ phase: "verifying" }, { phase: "installing" }]);
 
     const cached = await Effect.runPromise(
       ensureOpenCodeBinary({

--- a/src/types/desktop.ts
+++ b/src/types/desktop.ts
@@ -37,6 +37,18 @@ export const OpenCodeInfoSchema = Schema.mutable(
 
 export type OpenCodeInfo = typeof OpenCodeInfoSchema.Type;
 
+export type OpenCodeStartupProgress =
+  | { phase: "checking" }
+  | {
+      phase: "downloading";
+      downloadedBytes: number;
+      totalBytes: number | null;
+      bytesPerSecond: number;
+    }
+  | { phase: "verifying" }
+  | { phase: "installing" }
+  | { phase: "starting" };
+
 export const UpdateInfoSchema = Schema.mutable(
   Schema.Struct({
     version: Schema.String,
@@ -48,6 +60,7 @@ export type UpdateInfo = typeof UpdateInfoSchema.Type;
 
 export interface DesktopApi {
   getOpenCodeInfo(): Promise<OpenCodeInfo>;
+  onOpenCodeStartupProgress(listener: (progress: OpenCodeStartupProgress) => void): () => void;
   getVersion(): Promise<string>;
   openUrl(url: string): Promise<void>;
   loadConfig(): Promise<AppConfig>;


### PR DESCRIPTION
## Summary

- replaces the opaque boot animation with a calm three-stage progress treatment
- streams real OpenCode download byte counts from Electron into the renderer
- shows determinate download progress and live transfer speed
- keeps checking, verification, install, connection, and workspace states in friendly language

## Why

First-run setup can spend several seconds checking and downloading the local engine. The old screen only changed its playful animation, which made a healthy startup look stalled. This keeps the default experience simple while answering “is it working?” and “how long is the download taking?”

## Screenshots

### Checking the computer

![Boot checking state](https://github.com/user-attachments/assets/8494132b-1a9b-4f7f-b472-b99ea67d1572)

### Download progress and speed

![Download progress with percentage and transfer speed](https://github.com/user-attachments/assets/8c2799d3-705d-4a3d-8d89-c07ad52d050f)

> The download was locally slowed only long enough to capture the short-lived state. No throttle or preview hook is included in this branch.

## Validation

- `pnpm typecheck`
- `pnpm test` — 134 Vitest tests and 8 release tests passed
- `pnpm lint` — passed with existing warnings
- `pnpm build`
- launched the Electron app against an empty cache and observed the real startup sequence