### PR TITLE
Tighten Studio agent instructions

### DIFF
--- a/electron/opencodeConfig.ts
+++ b/electron/opencodeConfig.ts
@@ -31,8 +31,9 @@ export function createOpenCodeConfig(platform: NodeJS.Platform, localAppData?: s
       studio: {
         mode: "primary",
         description: "Roblox Studio development assistant",
+        // OpenCode loads project AGENTS.md separately; keep this Studio-specific and compact.
         prompt:
-          "You are BloxBot, an expert Roblox developer working directly in the open Roblox Studio project through its MCP tools. Explore the game tree before editing, use tools instead of asking the user to paste code, preserve the project's existing architecture, and verify every change in Studio. If Studio is unavailable, explain how to enable Studio's MCP server instead of retrying indefinitely.",
+          "Use Studio MCP directly. Inspect relevant instances and scripts before editing; never ask for or guess information MCP can read. Make the smallest coherent change, preserving existing architecture and Luau conventions. Verify changes through reinspection and the most relevant Studio check. Report briefly. If Studio is unavailable, give one clear enable/reconnect instruction, then stop retrying.",
       },
     },
   };

--- a/src/test/opencodeConfig.test.ts
+++ b/src/test/opencodeConfig.test.ts
@@ -10,4 +10,14 @@ describe("OpenCode configuration", () => {
   it("keeps automatic context compaction enabled", () => {
     expect(createOpenCodeConfig("darwin").compaction).toEqual({ auto: true });
   });
+
+  it("keeps Studio instructions concise and action-oriented", () => {
+    const prompt = createOpenCodeConfig("darwin").agent.studio.prompt;
+
+    expect(prompt.trim().split(/\s+/).length).toBeLessThanOrEqual(55);
+    expect(prompt).toMatch(/inspect .* before editing/i);
+    expect(prompt).toContain("smallest coherent change");
+    expect(prompt).toContain("most relevant Studio check");
+    expect(prompt).toContain("stop retrying");
+  });
 });


### PR DESCRIPTION
## Summary

- Replace persona and generic tool prose with a 53-word Studio-specific contract.
- Leave game-specific rules in each workspace AGENTS.md, which OpenCode loads automatically.
- Cap the prompt at 55 words and test the inspect, change, verify, and reconnect behaviors.

## Research

- OpenCode Rules: https://opencode.ai/docs/rules/ documents AGENTS.md as concise, project-specific context loaded automatically.
- OpenCode Agents: https://opencode.ai/docs/agents/ says a custom agent prompt should contain instructions specific to that agent purpose.
- Roblox Studio MCP: https://create.roblox.com/docs/studio/mcp documents built-in inspection, editing, Luau, playtest, console, screenshot, and skill tools, so duplicating their descriptions would only consume context.

## Verification

- pnpm test
- pnpm typecheck
- pnpm build
- pnpm lint (passes with the existing warning-only backlog)