### PR TITLE
Prepare v0.6.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+## [0.6.4] - 2026-07-23
+
+### Added
+
+- Added clear startup stages plus real percentage and transfer-speed feedback while BloxBot downloads OpenCode.
+
+### Changed
+
+- Tightened the Studio agent instructions around inspecting before editing, making focused changes, validating in Studio, and deferring project-specific rules to each workspace's `AGENTS.md`.
+
 ## [0.6.3] - 2026-07-23
 
 ### Changed
@@ -80,7 +90,8 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 - OpenCode downloads are restricted to official GitHub release assets and verified with SHA-256 digests before installation and on every cache reuse.
 - Electron runs with context isolation, renderer sandboxing, Node.js integration disabled, validated IPC payloads, and external navigation blocked.
 
-[Unreleased]: https://github.com/paralov/app-bloxbot-ai/compare/v0.6.3...HEAD
+[Unreleased]: https://github.com/paralov/app-bloxbot-ai/compare/v0.6.4...HEAD
+[0.6.4]: https://github.com/paralov/app-bloxbot-ai/compare/v0.6.3...v0.6.4
 [0.6.3]: https://github.com/paralov/app-bloxbot-ai/compare/v0.6.2...v0.6.3
 [0.6.2]: https://github.com/paralov/app-bloxbot-ai/compare/v0.6.1...v0.6.2
 [0.6.1]: https://github.com/paralov/app-bloxbot-ai/compare/v0.6.0...v0.6.1

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "bloxbot",
   "private": true,
-  "version": "0.6.3",
+  "version": "0.6.4",
   "description": "AI-assisted Roblox development from a secure desktop app",
   "type": "module",
   "main": "dist-electron/main/main.js",


### PR DESCRIPTION
## Release

- Show clear startup stages, real OpenCode download percentage, and transfer speed.
- Replace the Studio agent persona/tool prose with a compact inspect-change-verify contract while preserving workspace AGENTS.md rules.

## Verification

- node scripts/release.ts validate
- pnpm test — 135 Vitest tests and 8 release tests
- pnpm typecheck
- pnpm build

## After merge

Dispatch the Release workflow from main. It will build all three platforms, verify the exact updater-safe asset set, and atomically publish v0.6.4.