### PR TITLE
Require Studio tools before enabling chat

### DIFF
--- a/src/hooks/useStudioConnection.ts
+++ b/src/hooks/useStudioConnection.ts
@@ -5,21 +5,23 @@ import { qk } from "@/lib/queryKeys";
 import { useOpenCodeClient } from "@/providers/OpenCodeClientProvider";
 
 const STUDIO_MCP_NAME = "roblox-studio";
+const STUDIO_TOOL_PREFIX = `${STUDIO_MCP_NAME}_`;
 
 export type StudioConnectionState = "checking" | "connected" | "waiting";
 
 export async function checkStudioConnection(
-  client: Pick<OpencodeClient, "mcp">,
+  client: Pick<OpencodeClient, "mcp" | "tool">,
 ): Promise<Exclude<StudioConnectionState, "checking">> {
   try {
     const current = await client.mcp.status({});
-    if (current.data?.[STUDIO_MCP_NAME]?.status === "connected") {
-      return "connected";
+    if (current.data?.[STUDIO_MCP_NAME]?.status !== "connected") {
+      await client.mcp.connect({ name: STUDIO_MCP_NAME }).catch(() => undefined);
+      const refreshed = await client.mcp.status({});
+      if (refreshed.data?.[STUDIO_MCP_NAME]?.status !== "connected") return "waiting";
     }
 
-    await client.mcp.connect({ name: STUDIO_MCP_NAME }).catch(() => undefined);
-    const refreshed = await client.mcp.status({});
-    return refreshed.data?.[STUDIO_MCP_NAME]?.status === "connected" ? "connected" : "waiting";
+    const tools = await client.tool.ids({});
+    return tools.data?.some((id) => id.startsWith(STUDIO_TOOL_PREFIX)) ? "connected" : "waiting";
   } catch {
     return "waiting";
   }

--- a/src/test/app.test.tsx
+++ b/src/test/app.test.tsx
@@ -159,6 +159,11 @@ function createClient(overrides: Record<string, unknown> = {}) {
       connect: vi.fn(),
       disconnect: vi.fn(),
     },
+    tool: {
+      ids: vi.fn().mockResolvedValue({
+        data: ["roblox-studio_get_studio_state"],
+      }),
+    },
     instance: { dispose: vi.fn() },
   };
 }

--- a/src/test/useStudioConnection.test.ts
+++ b/src/test/useStudioConnection.test.ts
@@ -11,6 +11,9 @@ describe("checkStudioConnection", () => {
         }),
         connect: vi.fn(),
       },
+      tool: {
+        ids: vi.fn().mockResolvedValue({ data: ["read", "roblox-studio_get_studio_state"] }),
+      },
     };
 
     await expect(checkStudioConnection(client as never)).resolves.toBe("connected");
@@ -26,10 +29,29 @@ describe("checkStudioConnection", () => {
           .mockResolvedValueOnce({ data: { "roblox-studio": { status: "connected" } } }),
         connect: vi.fn().mockResolvedValue({}),
       },
+      tool: {
+        ids: vi.fn().mockResolvedValue({ data: ["roblox-studio_get_studio_state"] }),
+      },
     };
 
     await expect(checkStudioConnection(client as never)).resolves.toBe("connected");
     expect(client.mcp.connect).toHaveBeenCalledWith({ name: "roblox-studio" });
+  });
+
+  it("keeps waiting when the MCP bridge has no Studio tools", async () => {
+    const client = {
+      mcp: {
+        status: vi.fn().mockResolvedValue({
+          data: { "roblox-studio": { status: "connected" } },
+        }),
+        connect: vi.fn(),
+      },
+      tool: {
+        ids: vi.fn().mockResolvedValue({ data: ["bash", "read", "write"] }),
+      },
+    };
+
+    await expect(checkStudioConnection(client as never)).resolves.toBe("waiting");
   });
 
   it("keeps waiting when Studio is unavailable", async () => {
@@ -37,6 +59,9 @@ describe("checkStudioConnection", () => {
       mcp: {
         status: vi.fn().mockRejectedValue(new Error("Studio is closed")),
         connect: vi.fn(),
+      },
+      tool: {
+        ids: vi.fn(),
       },
     };
 


### PR DESCRIPTION
## What changed

- Treat Roblox Studio as ready only when OpenCode exposes at least one `roblox-studio_*` tool.
- Keep showing the Studio setup screen when the MCP bridge is running but Studio itself is unavailable.
- Add regression coverage for the bridge-connected/tool-missing state.

## Root cause

OpenCode reported the `roblox-studio` MCP bridge as `connected` even when Roblox Studio was closed. BloxBot used that bridge status to enable chat, but OpenCode's actual tool registry contained only built-in tools. The model was therefore prompted to call `roblox-studio_get_studio_state`, which OpenCode rejected as unavailable.

This uses OpenCode's built-in tool registry endpoint rather than adding a custom Studio probe or protocol.

## Impact

Users can no longer enter chat until the Roblox Studio tools are actually registered. The existing polling automatically unlocks chat after Studio becomes available and returns to setup if the tools disappear.

## Validation

- `pnpm test` — 19 Vitest files / 136 tests and 8 release-script tests passed
- `pnpm typecheck`
- Biome check on changed files
- `pnpm build`
- Reproduced the original mismatch against OpenCode 1.18.4: MCP status `connected`, zero `roblox-studio_*` tool IDs while Studio was closed