### PR TITLE
Detect the live Roblox Studio connection

### DIFF
--- a/electron/channels.ts
+++ b/electron/channels.ts
@@ -2,6 +2,7 @@ export const channels = {
   checkForUpdate: "app:check-for-update",
   getOpenCodeInfo: "opencode:get-info",
   openCodeStartupProgress: "opencode:startup-progress",
+  isStudioConnected: "studio:is-connected",
   getVersion: "app:get-version",
   installUpdate: "app:install-update",
   loadConfig: "config:load",

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -16,6 +16,7 @@ import {
 import { handleLastWindowClosed } from "./appLifecycle";
 import { channels } from "./channels";
 import { makeOpenCodeLayer, OpenCode } from "./services/OpenCode";
+import { isStudioConnected } from "./services/StudioConnection";
 
 const currentDirectory = dirname(fileURLToPath(import.meta.url));
 const defaultConfig: AppConfig = DEFAULT_APP_CONFIG;
@@ -124,6 +125,7 @@ const registerIpcHandlers = Effect.sync(() => {
       OpenCode.pipe(Effect.flatMap((service) => service.info)),
     ),
   );
+  ipcMain.handle(channels.isStudioConnected, () => isStudioConnected());
   ipcMain.handle(channels.getVersion, () => runMain(Effect.sync(() => app.getVersion())));
   ipcMain.handle(channels.loadConfig, () => runMain(loadConfig));
   ipcMain.handle(channels.patchConfig, (_event, patch: unknown) => runMain(patchConfig(patch)));

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -11,6 +11,7 @@ const api: DesktopApi = {
     ipcRenderer.on(channels.openCodeStartupProgress, handleProgress);
     return () => ipcRenderer.removeListener(channels.openCodeStartupProgress, handleProgress);
   },
+  isStudioConnected: () => ipcRenderer.invoke(channels.isStudioConnected),
   getVersion: () => ipcRenderer.invoke(channels.getVersion),
   openUrl: (url) => ipcRenderer.invoke(channels.openUrl, url),
   loadConfig: () => ipcRenderer.invoke(channels.loadConfig),

--- a/electron/services/StudioConnection.ts
+++ b/electron/services/StudioConnection.ts
@@ -1,0 +1,47 @@
+import { type Systeminformation, networkConnections } from "systeminformation";
+
+type NetworkConnection = Pick<
+  Systeminformation.NetworkConnectionsData,
+  "localAddress" | "localPort" | "peerPort" | "process" | "protocol" | "state"
+>;
+
+function processName(process: string): string {
+  return process.replaceAll("\\", "/").split("/").pop()?.toLowerCase() ?? "";
+}
+
+function isStudioMcp(process: string): boolean {
+  return /^studiomcp(?:\.exe)?$/.test(processName(process));
+}
+
+function isRobloxStudio(process: string): boolean {
+  return /^robloxstudio(?:beta)?(?:\.exe)?$/.test(processName(process));
+}
+
+export function hasStudioMcpConnection(connections: readonly NetworkConnection[]): boolean {
+  const studioMcpPorts = new Set(
+    connections
+      .filter(
+        (connection) =>
+          connection.protocol.startsWith("tcp") &&
+          connection.state.startsWith("LISTEN") &&
+          isStudioMcp(connection.process),
+      )
+      .map((connection) => connection.localPort),
+  );
+
+  return connections.some(
+    (connection) =>
+      connection.protocol.startsWith("tcp") &&
+      connection.state === "ESTABLISHED" &&
+      isRobloxStudio(connection.process) &&
+      (studioMcpPorts.has(connection.localPort) || studioMcpPorts.has(connection.peerPort)),
+  );
+}
+
+export async function isStudioConnected(): Promise<boolean> {
+  try {
+    return hasStudioMcpConnection(await networkConnections());
+  } catch {
+    return false;
+  }
+}

--- a/src/components/StudioSetup.tsx
+++ b/src/components/StudioSetup.tsx
@@ -142,9 +142,32 @@ function StudioSetup({ connected, checking, onCheck, onContinue }: StudioSetupPr
                   type="button"
                   onClick={onCheck}
                   disabled={checking}
-                  className="h-9 rounded-lg bg-foreground px-4 text-xs font-medium text-background transition-opacity hover:opacity-90 disabled:opacity-60"
+                  aria-busy={checking}
+                  className="inline-flex h-9 items-center gap-2 rounded-lg bg-foreground px-4 text-xs font-medium text-background transition-opacity hover:opacity-90 disabled:opacity-60"
                 >
-                  {checking ? "Looking..." : "Check again"}
+                  {checking && (
+                    <svg
+                      className="h-3.5 w-3.5 animate-spin"
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      aria-hidden="true"
+                    >
+                      <circle
+                        className="opacity-25"
+                        cx="12"
+                        cy="12"
+                        r="9"
+                        stroke="currentColor"
+                        strokeWidth="3"
+                      />
+                      <path
+                        className="opacity-90"
+                        fill="currentColor"
+                        d="M21 12a9 9 0 0 0-9-9v3a6 6 0 0 1 6 6h3Z"
+                      />
+                    </svg>
+                  )}
+                  {checking ? "Checking..." : "Check again"}
                 </button>
               )}
             </div>

--- a/src/hooks/useStudioConnection.ts
+++ b/src/hooks/useStudioConnection.ts
@@ -1,16 +1,17 @@
 import type { OpencodeClient } from "@opencode-ai/sdk/v2/client";
 import { useQuery } from "@tanstack/react-query";
 
+import { desktop } from "@/lib/desktop";
 import { qk } from "@/lib/queryKeys";
 import { useOpenCodeClient } from "@/providers/OpenCodeClientProvider";
 
 const STUDIO_MCP_NAME = "roblox-studio";
-const STUDIO_TOOL_PREFIX = `${STUDIO_MCP_NAME}_`;
 
 export type StudioConnectionState = "checking" | "connected" | "waiting";
 
 export async function checkStudioConnection(
-  client: Pick<OpencodeClient, "mcp" | "tool">,
+  client: Pick<OpencodeClient, "mcp">,
+  detectStudioConnection: () => Promise<boolean> = desktop.isStudioConnected,
 ): Promise<Exclude<StudioConnectionState, "checking">> {
   try {
     const current = await client.mcp.status({});
@@ -20,8 +21,7 @@ export async function checkStudioConnection(
       if (refreshed.data?.[STUDIO_MCP_NAME]?.status !== "connected") return "waiting";
     }
 
-    const tools = await client.tool.ids({});
-    return tools.data?.some((id) => id.startsWith(STUDIO_TOOL_PREFIX)) ? "connected" : "waiting";
+    return (await detectStudioConnection()) ? "connected" : "waiting";
   } catch {
     return "waiting";
   }

--- a/src/lib/desktop.ts
+++ b/src/lib/desktop.ts
@@ -22,6 +22,7 @@ export class DesktopError extends Data.TaggedError("DesktopError")<{
 
 interface DesktopEffects {
   readonly getOpenCodeInfo: Effect.Effect<OpenCodeInfo, DesktopError>;
+  readonly isStudioConnected: Effect.Effect<boolean, DesktopError>;
   readonly getVersion: Effect.Effect<string, DesktopError>;
   readonly openUrl: (url: string) => Effect.Effect<void, DesktopError>;
   readonly loadConfig: Effect.Effect<AppConfig, DesktopError>;
@@ -58,6 +59,7 @@ const browserEffects: DesktopEffects = {
       message: "The desktop service is unavailable. Start BloxBot with pnpm dev.",
     }),
   ),
+  isStudioConnected: Effect.succeed(false),
   getVersion: Effect.succeed("0.5.2"),
   openUrl: (url) =>
     Effect.sync(() => window.open(url, "_blank", "noopener,noreferrer")).pipe(Effect.asVoid),
@@ -109,6 +111,9 @@ function makeBridgeEffects(api: DesktopApi): DesktopEffects {
     getOpenCodeInfo: invoke("Failed to get OpenCode connection details", () =>
       api.getOpenCodeInfo(),
     ).pipe(decodeBridgeValue("OpenCode connection details are invalid", OpenCodeInfoSchema)),
+    isStudioConnected: invoke("Failed to check Roblox Studio connection", () =>
+      api.isStudioConnected(),
+    ).pipe(decodeBridgeValue("Roblox Studio connection status is invalid", Schema.Boolean)),
     getVersion: invoke("Failed to get the app version", () => api.getVersion()).pipe(
       decodeBridgeValue("Desktop app version is invalid", Schema.String),
     ),
@@ -137,6 +142,7 @@ export const desktop: DesktopApi = {
   getOpenCodeInfo: () => runPromise(desktopEffects.getOpenCodeInfo),
   onOpenCodeStartupProgress: (listener: StartupProgressListener) =>
     window.bloxbot?.onOpenCodeStartupProgress(listener) ?? (() => {}),
+  isStudioConnected: () => runPromise(desktopEffects.isStudioConnected),
   getVersion: () => runPromise(desktopEffects.getVersion),
   openUrl: (url) => runPromise(desktopEffects.openUrl(url)),
   loadConfig: () => runPromise(desktopEffects.loadConfig),

--- a/src/test/StudioSetup.test.tsx
+++ b/src/test/StudioSetup.test.tsx
@@ -52,4 +52,17 @@ describe("StudioSetup", () => {
     fireEvent.click(screen.getByRole("button", { name: "Let's build" }));
     expect(onContinue).toHaveBeenCalledOnce();
   });
+
+  it("shows progress while checking again", () => {
+    render(<StudioSetup connected={false} checking onCheck={vi.fn()} onContinue={vi.fn()} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Next" }));
+    fireEvent.click(screen.getByRole("button", { name: "Next" }));
+    fireEvent.click(screen.getByRole("button", { name: "Next" }));
+
+    const button = screen.getByRole("button", { name: "Checking..." });
+    expect(button).toBeDisabled();
+    expect(button).toHaveAttribute("aria-busy", "true");
+    expect(button.querySelector(".animate-spin")).toBeVisible();
+  });
 });

--- a/src/test/app.test.tsx
+++ b/src/test/app.test.tsx
@@ -159,11 +159,6 @@ function createClient(overrides: Record<string, unknown> = {}) {
       connect: vi.fn(),
       disconnect: vi.fn(),
     },
-    tool: {
-      ids: vi.fn().mockResolvedValue({
-        data: ["roblox-studio_get_studio_state"],
-      }),
-    },
     instance: { dispose: vi.fn() },
   };
 }
@@ -216,6 +211,7 @@ function seedReadyState(
 
 beforeEach(() => {
   vi.clearAllMocks();
+  vi.spyOn(desktop, "isStudioConnected").mockResolvedValue(true);
   window.localStorage.clear();
   toast.dismiss();
 });

--- a/src/test/desktop.test.ts
+++ b/src/test/desktop.test.ts
@@ -15,6 +15,12 @@ describe("browser desktop fallback", () => {
     );
   });
 
+  it("reports Studio as disconnected outside Electron", async () => {
+    const { desktop } = await import("@/lib/desktop");
+
+    await expect(desktop.isStudioConnected()).resolves.toBe(false);
+  });
+
   it("persists preferences while running as a web preview", async () => {
     const { desktop } = await import("@/lib/desktop");
 

--- a/src/test/studioConnection.test.ts
+++ b/src/test/studioConnection.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+
+import { hasStudioMcpConnection } from "../../electron/services/StudioConnection";
+
+const connection = (
+  input: Partial<{
+    localAddress: string;
+    localPort: string;
+    peerPort: string;
+    process: string;
+    protocol: string;
+    state: string;
+  }>,
+) =>
+  ({
+    localAddress: "127.0.0.1",
+    localPort: "0",
+    peerPort: "0",
+    process: "",
+    protocol: "tcp4",
+    state: "ESTABLISHED",
+    ...input,
+  }) as never;
+
+describe("hasStudioMcpConnection", () => {
+  const listener = connection({
+    localPort: "13469",
+    process: "/Applications/RobloxStudio.app/Contents/MacOS/StudioMCP",
+    state: "LISTEN",
+  });
+
+  it("detects Roblox Studio connected to the StudioMCP listener", () => {
+    expect(
+      hasStudioMcpConnection([
+        listener,
+        connection({
+          localPort: "61234",
+          peerPort: "13469",
+          process: "/Applications/RobloxStudio.app/Contents/MacOS/RobloxStudio",
+        }),
+      ]),
+    ).toBe(true);
+  });
+
+  it("supports the Windows Roblox Studio process name", () => {
+    expect(
+      hasStudioMcpConnection([
+        connection({
+          localPort: "13469",
+          process: "C:\\Program Files\\Roblox\\StudioMCP.exe",
+          state: "LISTENING",
+        }),
+        connection({
+          localPort: "61234",
+          peerPort: "13469",
+          process: "C:\\Program Files\\Roblox\\RobloxStudioBeta.exe",
+        }),
+      ]),
+    ).toBe(true);
+  });
+
+  it("does not mistake StudioMCP's internal proxy connection for Studio", () => {
+    expect(
+      hasStudioMcpConnection([
+        listener,
+        connection({
+          localPort: "61234",
+          peerPort: "13469",
+          process: "/Applications/RobloxStudio.app/Contents/MacOS/StudioMCP",
+        }),
+      ]),
+    ).toBe(false);
+  });
+});

--- a/src/test/useStudioConnection.test.ts
+++ b/src/test/useStudioConnection.test.ts
@@ -11,13 +11,14 @@ describe("checkStudioConnection", () => {
         }),
         connect: vi.fn(),
       },
-      tool: {
-        ids: vi.fn().mockResolvedValue({ data: ["read", "roblox-studio_get_studio_state"] }),
-      },
     };
+    const detectStudioConnection = vi.fn().mockResolvedValue(true);
 
-    await expect(checkStudioConnection(client as never)).resolves.toBe("connected");
+    await expect(checkStudioConnection(client as never, detectStudioConnection)).resolves.toBe(
+      "connected",
+    );
     expect(client.mcp.connect).not.toHaveBeenCalled();
+    expect(detectStudioConnection).toHaveBeenCalledOnce();
   });
 
   it("retries the Studio connection and detects when setup is complete", async () => {
@@ -29,16 +30,15 @@ describe("checkStudioConnection", () => {
           .mockResolvedValueOnce({ data: { "roblox-studio": { status: "connected" } } }),
         connect: vi.fn().mockResolvedValue({}),
       },
-      tool: {
-        ids: vi.fn().mockResolvedValue({ data: ["roblox-studio_get_studio_state"] }),
-      },
     };
 
-    await expect(checkStudioConnection(client as never)).resolves.toBe("connected");
+    await expect(checkStudioConnection(client as never, async () => true)).resolves.toBe(
+      "connected",
+    );
     expect(client.mcp.connect).toHaveBeenCalledWith({ name: "roblox-studio" });
   });
 
-  it("keeps waiting when the MCP bridge has no Studio tools", async () => {
+  it("keeps waiting when Roblox Studio is not connected to the MCP bridge", async () => {
     const client = {
       mcp: {
         status: vi.fn().mockResolvedValue({
@@ -46,12 +46,11 @@ describe("checkStudioConnection", () => {
         }),
         connect: vi.fn(),
       },
-      tool: {
-        ids: vi.fn().mockResolvedValue({ data: ["bash", "read", "write"] }),
-      },
     };
 
-    await expect(checkStudioConnection(client as never)).resolves.toBe("waiting");
+    await expect(checkStudioConnection(client as never, async () => false)).resolves.toBe(
+      "waiting",
+    );
   });
 
   it("keeps waiting when Studio is unavailable", async () => {
@@ -60,11 +59,8 @@ describe("checkStudioConnection", () => {
         status: vi.fn().mockRejectedValue(new Error("Studio is closed")),
         connect: vi.fn(),
       },
-      tool: {
-        ids: vi.fn(),
-      },
     };
 
-    await expect(checkStudioConnection(client as never)).resolves.toBe("waiting");
+    await expect(checkStudioConnection(client as never, async () => true)).resolves.toBe("waiting");
   });
 });

--- a/src/types/desktop.ts
+++ b/src/types/desktop.ts
@@ -61,6 +61,7 @@ export type UpdateInfo = typeof UpdateInfoSchema.Type;
 export interface DesktopApi {
   getOpenCodeInfo(): Promise<OpenCodeInfo>;
   onOpenCodeStartupProgress(listener: (progress: OpenCodeStartupProgress) => void): () => void;
+  isStudioConnected(): Promise<boolean>;
   getVersion(): Promise<string>;
   openUrl(url: string): Promise<void>;
   loadConfig(): Promise<AppConfig>;


### PR DESCRIPTION
## What changed

- Require both a connected OpenCode MCP client and a live Roblox Studio → StudioMCP localhost connection before enabling chat.
- Detect that connection in Electron through the existing `systeminformation` dependency and expose only a boolean to the renderer.
- Show a spinner and `Checking...` state after the user clicks **Check again**.
- Cover macOS, Windows, the StudioMCP self-connection false-positive, renderer fallback, and button feedback.

## Root cause

PR #48 used OpenCode's `/experimental/tool/ids` endpoint as the readiness signal because its SDK documentation says it includes dynamically registered tools. In OpenCode 1.18.4, that endpoint reads the built-in `ToolRegistry` only and never includes MCP tools. BloxBot therefore remained on the setup screen even while Roblox Studio showed a connected client.

The MCP bridge status alone is also insufficient: StudioMCP can start and report connected before Roblox Studio itself is available. The new check combines that status with the actual local TCP connection from the Roblox Studio process to StudioMCP.

## Screenshots

### Checking for Studio

![Checking again shows a spinner](https://github.com/user-attachments/assets/77915422-805d-41b7-80bb-620ae4f36537)

### Connected

![BloxBot detects the live Roblox Studio connection](https://github.com/user-attachments/assets/57f04b30-b2f4-429f-9360-4abcd8800b87)

## Validation

- Live macOS dev run detected the active connection on StudioMCP port `13469` and advanced to **Studio connected**.
- A direct StudioMCP diagnostic listed the open `Place1` Studio instance and its 27 tools.
- `pnpm test` — 20 Vitest files / 141 tests plus 8 release-script tests passed.
- `pnpm typecheck`
- Biome check on all changed files
- `pnpm build`