### PR TITLE
Prepare v0.6.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+## [0.6.6] - 2026-07-24
+
 ### Fixed
 
 - Unblocked Studio setup across platforms by trusting the connected MCP status instead of inspecting OS-specific processes and sockets.
@@ -104,7 +106,8 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 - OpenCode downloads are restricted to official GitHub release assets and verified with SHA-256 digests before installation and on every cache reuse.
 - Electron runs with context isolation, renderer sandboxing, Node.js integration disabled, validated IPC payloads, and external navigation blocked.
 
-[Unreleased]: https://github.com/paralov/app-bloxbot-ai/compare/v0.6.5...HEAD
+[Unreleased]: https://github.com/paralov/app-bloxbot-ai/compare/v0.6.6...HEAD
+[0.6.6]: https://github.com/paralov/app-bloxbot-ai/compare/v0.6.5...v0.6.6
 [0.6.5]: https://github.com/paralov/app-bloxbot-ai/compare/v0.6.4...v0.6.5
 [0.6.4]: https://github.com/paralov/app-bloxbot-ai/compare/v0.6.3...v0.6.4
 [0.6.3]: https://github.com/paralov/app-bloxbot-ai/compare/v0.6.2...v0.6.3

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "bloxbot",
   "private": true,
-  "version": "0.6.5",
+  "version": "0.6.6",
   "description": "AI-assisted Roblox development from a secure desktop app",
   "type": "module",
   "main": "dist-electron/main/main.js",


### PR DESCRIPTION
## Release

- Unblock Studio setup across macOS, Windows, and Linux by trusting the connected MCP status.
- Remove the unreliable OS process/socket gate introduced in 0.6.5.

## Verification

- `node scripts/release.ts validate`
- `node scripts/release-notes.ts 0.6.6`
- `pnpm test` — 137 Vitest tests and 8 release tests
- Fix PR CI passed packaging on macOS, Windows, and Linux
- `pnpm typecheck`
- `pnpm build`
- `pnpm lint` — no errors; existing unrelated warnings only
- `git diff --check`

## After merge

Dispatch the Release workflow from `main`. It will rebuild all three platforms, verify the exact updater-safe asset set, and atomically publish v0.6.6.