### PR TITLE
Improve setup failure recovery UI

### DIFF
--- a/src/components/LoadingScreen.tsx
+++ b/src/components/LoadingScreen.tsx
@@ -6,6 +6,8 @@ import type { UpdateInfo } from "@/types/desktop";
 interface LoadingScreenProps {
   message?: string;
   detail?: string;
+  /** Full diagnostic text, hidden behind a disclosure in the error state. */
+  technicalDetail?: string;
   animation?: StartupAnimation;
   startup?: StartupProgress;
   /** When true, shows the error state with help actions instead of the dot loader. */
@@ -37,6 +39,7 @@ type UpdateCheckStatus = "idle" | "checking" | "available" | "downloading" | "up
 function LoadingScreen({
   message = "Starting up...",
   detail,
+  technicalDetail,
   animation,
   startup,
   error,
@@ -45,6 +48,7 @@ function LoadingScreen({
 }: LoadingScreenProps) {
   const [updateStatus, setUpdateStatus] = useState<UpdateCheckStatus>("idle");
   const [updateVersion, setUpdateVersion] = useState<string | null>(null);
+  const [copyStatus, setCopyStatus] = useState<"idle" | "copied" | "error">("idle");
   const updateRef = useRef<UpdateInfo | null>(null);
 
   async function handleCheckForUpdates() {
@@ -76,9 +80,23 @@ function LoadingScreen({
     }
   }
 
+  async function handleCopyDetails() {
+    if (!technicalDetail) return;
+    try {
+      await navigator.clipboard.writeText(technicalDetail);
+      setCopyStatus("copied");
+    } catch {
+      setCopyStatus("error");
+    }
+  }
+
   return (
-    <div className="flex h-full w-full flex-col items-center justify-center px-6">
-      <div className="animate-fade-in flex w-full max-w-sm flex-col items-center">
+    <div className="flex h-full w-full flex-col items-center justify-center overflow-y-auto px-6 py-10">
+      <div
+        className="animate-fade-in flex w-full max-w-sm flex-col items-center"
+        role={error ? "alert" : undefined}
+        aria-live={error ? "assertive" : undefined}
+      >
         {/* BloxBot face  - inline SVG so we can animate individual parts */}
         <svg
           width="80"
@@ -141,12 +159,10 @@ function LoadingScreen({
         </svg>
 
         {/* Status text */}
-        <h1 className="mt-5 text-sm font-semibold text-foreground/80">{message}</h1>
+        <h1 className="mt-5 text-base font-semibold text-foreground">{message}</h1>
 
         {detail && (
-          <p
-            className={`mt-1.5 max-w-sm text-center text-xs leading-relaxed ${error ? "text-destructive" : "text-muted-foreground"}`}
-          >
+          <p className="mt-2 max-w-sm text-center text-xs leading-relaxed text-muted-foreground">
             {detail}
           </p>
         )}
@@ -192,7 +208,7 @@ function LoadingScreen({
                       <path d="M3 22v-6h6" />
                       <path d="M21 12a9 9 0 0 1-15 6.7L3 16" />
                     </svg>
-                    Try Again
+                    Restart setup
                   </>
                 )}
               </button>
@@ -272,9 +288,36 @@ function LoadingScreen({
                 rel="noreferrer"
                 className="underline transition-colors hover:text-foreground"
               >
-                bloxbot.ai
+                Get help
               </a>
             </div>
+
+            {technicalDetail && (
+              <details className="mt-1 w-full max-w-sm rounded-lg border bg-card text-left text-xs text-muted-foreground">
+                <summary className="cursor-pointer select-none px-3 py-2.5 font-medium text-foreground/75 transition-colors hover:text-foreground">
+                  Technical details
+                </summary>
+                <div className="border-t px-3 py-3">
+                  <p className="leading-relaxed">
+                    Share these details if support asks for them. They may include local file paths.
+                  </p>
+                  <pre className="mt-2 max-h-32 overflow-auto whitespace-pre-wrap break-words rounded-md bg-muted p-2 font-mono text-[10px] leading-relaxed text-foreground/70">
+                    {technicalDetail}
+                  </pre>
+                  <button
+                    type="button"
+                    onClick={handleCopyDetails}
+                    className="mt-2 font-medium text-foreground/70 underline transition-colors hover:text-foreground"
+                  >
+                    {copyStatus === "copied"
+                      ? "Copied"
+                      : copyStatus === "error"
+                        ? "Couldn't copy"
+                        : "Copy details"}
+                  </button>
+                </div>
+              </details>
+            )}
           </div>
         ) : startup ? (
           <StartupProgressGraphic startup={startup} />

--- a/src/providers/OpenCodeClientProvider.tsx
+++ b/src/providers/OpenCodeClientProvider.tsx
@@ -30,6 +30,12 @@ interface StartupPresentation {
   startup: StartupProgress;
 }
 
+interface StartupErrorPresentation {
+  message: string;
+  detail: string;
+  technicalDetail: string;
+}
+
 const DEFAULT_ENGINE_PROGRESS: OpenCodeStartupProgress = { phase: "checking" };
 
 const STARTUP_COPY: Record<Exclude<StartupPhase, "engine">, StartupPresentation> = {
@@ -109,6 +115,40 @@ export function getStartupPresentation(
   engineProgress: OpenCodeStartupProgress = DEFAULT_ENGINE_PROGRESS,
 ): StartupPresentation {
   return phase === "engine" ? getEnginePresentation(engineProgress) : STARTUP_COPY[phase];
+}
+
+export function getStartupErrorPresentation(error: unknown): StartupErrorPresentation {
+  const technicalDetail = error instanceof Error ? (error.stack ?? error.message) : String(error);
+  const normalized = technicalDetail.toLowerCase();
+
+  if (
+    normalized.includes("github release lookup") ||
+    normalized.includes("opencode download") ||
+    normalized.includes("verified opencode")
+  ) {
+    return {
+      message: "Setup couldn't finish",
+      detail:
+        "BloxBot couldn't download its setup files. Check your internet connection, VPN, or firewall, then restart setup.",
+      technicalDetail,
+    };
+  }
+
+  if (normalized.includes("does not provide a supported binary")) {
+    return {
+      message: "This computer isn't supported yet",
+      detail:
+        "BloxBot couldn't find a compatible setup package for this system. Check for an app update or contact support.",
+      technicalDetail,
+    };
+  }
+
+  return {
+    message: "Setup couldn't finish",
+    detail:
+      "BloxBot hit a problem while preparing its local engine. Restart setup, or check for an app update if it happens again.",
+    technicalDetail,
+  };
 }
 
 interface OpenCodeClientContextValue {
@@ -320,14 +360,16 @@ export function OpenCodeClientProvider({
 
   if (!ready) {
     const startup = getStartupPresentation(startupPhase, engineProgress);
+    const startupError = initError ? getStartupErrorPresentation(initError) : null;
     return (
       <OpenCodeClientContext.Provider value={value}>
         <LoadingScreen
-          message={initError ? "Failed to connect to OpenCode" : startup.message}
-          detail={initError ?? startup.detail}
-          startup={initError ? undefined : startup.startup}
-          error={!!initError}
-          onRetry={initError ? () => desktop.relaunch() : undefined}
+          message={startupError?.message ?? startup.message}
+          detail={startupError?.detail ?? startup.detail}
+          technicalDetail={startupError?.technicalDetail}
+          startup={startupError ? undefined : startup.startup}
+          error={!!startupError}
+          onRetry={startupError ? () => desktop.relaunch() : undefined}
         />
       </OpenCodeClientContext.Provider>
     );

--- a/src/test/LoadingScreen.test.tsx
+++ b/src/test/LoadingScreen.test.tsx
@@ -1,8 +1,12 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 
 import LoadingScreen from "@/components/LoadingScreen";
-import { getStartupPresentation, type StartupPhase } from "@/providers/OpenCodeClientProvider";
+import {
+  getStartupErrorPresentation,
+  getStartupPresentation,
+  type StartupPhase,
+} from "@/providers/OpenCodeClientProvider";
 
 describe("startup progress", () => {
   it.each([
@@ -42,5 +46,34 @@ describe("startup progress", () => {
     expect(screen.getByText("Future launches will use the saved copy")).toBeVisible();
     expect(screen.getByRole("progressbar")).toHaveAttribute("aria-valuenow", "25");
     expect(screen.getByText("25% · 2.0 MB/s")).toBeVisible();
+  });
+
+  it("turns a verbose download failure into calm, actionable copy", () => {
+    const technicalDetail =
+      "Unable to download a verified OpenCode 1.x.x release and no cached copy is available: GitHub release lookup failed with HTTP 403 at file:///C:/Users/example/main.js";
+    const presentation = getStartupErrorPresentation(technicalDetail);
+
+    render(
+      <LoadingScreen
+        message={presentation.message}
+        detail={presentation.detail}
+        technicalDetail={presentation.technicalDetail}
+        error
+        onRetry={() => {}}
+      />,
+    );
+
+    expect(screen.getByRole("heading", { name: "Setup couldn't finish" })).toBeVisible();
+    expect(
+      screen.getByText(
+        "BloxBot couldn't download its setup files. Check your internet connection, VPN, or firewall, then restart setup.",
+      ),
+    ).toBeVisible();
+    expect(screen.getByRole("button", { name: "Restart setup" })).toBeVisible();
+
+    const disclosure = screen.getByText("Technical details");
+    expect(screen.getByText(technicalDetail)).not.toBeVisible();
+    fireEvent.click(disclosure);
+    expect(screen.getByText(technicalDetail)).toBeVisible();
   });
 });


### PR DESCRIPTION
## What changed

- translate startup download failures into calm, actionable setup copy
- keep the full diagnostic available behind a collapsed **Technical details** section
- add a one-click copy action for support details
- keep the recovery screen scroll-safe and announce the failure as an alert
- rename the primary action to **Restart setup** so it matches what the app actually does

## Why

Issue #56 showed the complete nested OpenCode/Effect error and local file paths as the main UI. The diagnostic overflowed the window, pushed useful context out of view, and gave the user no clear explanation or recovery path.

The new treatment prioritizes three things: what happened, what the user can try, and where the diagnostic lives if support needs it.

Closes #56

## Screenshots

### Before

<img width="988" alt="Setup failure before: raw diagnostic fills the window" src="https://github.com/user-attachments/assets/ad5cb734-ba44-4f9c-a2b4-d02f9700a750" />

### Improved recovery

<img width="988" alt="Setup failure after: concise explanation and restart action" src="https://github.com/user-attachments/assets/ab0f0798-2661-414d-9d5a-8a4e28d75250" />

### Technical details expanded

<img width="988" alt="Setup failure after: bounded technical details panel" src="https://github.com/user-attachments/assets/d82cb6a2-de88-47e6-aba7-eb74aecc8a6f" />

## Validation

- `pnpm test` — 138 app tests and 8 release tests passed
- `pnpm typecheck`
- `pnpm build`
- `pnpm lint` — completed with pre-existing warnings outside this change
- focused Biome check for changed files — clean
- visual comparison at the issue viewport, including collapsed and expanded diagnostic states
