### PR TITLE
Prepare v0.6.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+## [0.6.7] - 2026-07-26
+
+### Fixed
+
+- Replaced the raw startup stack trace with a clear setup-recovery screen, actionable restart and update options, and collapsible copyable technical details for support.
+
 ## [0.6.6] - 2026-07-24
 
 ### Fixed
@@ -106,7 +112,8 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 - OpenCode downloads are restricted to official GitHub release assets and verified with SHA-256 digests before installation and on every cache reuse.
 - Electron runs with context isolation, renderer sandboxing, Node.js integration disabled, validated IPC payloads, and external navigation blocked.
 
-[Unreleased]: https://github.com/paralov/app-bloxbot-ai/compare/v0.6.6...HEAD
+[Unreleased]: https://github.com/paralov/app-bloxbot-ai/compare/v0.6.7...HEAD
+[0.6.7]: https://github.com/paralov/app-bloxbot-ai/compare/v0.6.6...v0.6.7
 [0.6.6]: https://github.com/paralov/app-bloxbot-ai/compare/v0.6.5...v0.6.6
 [0.6.5]: https://github.com/paralov/app-bloxbot-ai/compare/v0.6.4...v0.6.5
 [0.6.4]: https://github.com/paralov/app-bloxbot-ai/compare/v0.6.3...v0.6.4

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "bloxbot",
   "private": true,
-  "version": "0.6.6",
+  "version": "0.6.7",
   "description": "AI-assisted Roblox development from a secure desktop app",
   "type": "module",
   "main": "dist-electron/main/main.js",


### PR DESCRIPTION
## Release

- Ship the improved setup failure recovery from #57.
- Replace the raw startup stack trace with actionable restart/update guidance.
- Keep copyable diagnostics available behind a bounded **Technical details** disclosure.

## Verification

- `node scripts/release.ts validate`
- `node scripts/release-notes.ts 0.6.7`
- `pnpm test` — 138 Vitest tests and 8 release tests
- `pnpm typecheck`
- `pnpm build`
- `pnpm lint` — no errors; existing unrelated warnings only
- `git diff --check`

## After merge

Dispatch the Release workflow from `main`. It will rebuild all three platforms, verify the exact updater-safe asset set, and atomically publish v0.6.7.