### PR TITLE
Prepare v0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+## [0.7.0] - 2026-07-26
+
+### Added
+
+- Added a suggested workflow for coordinating work across multiple open Roblox Studio places, with agent guidance to discover, select, and verify the intended place before place-specific actions.
+
 ## [0.6.7] - 2026-07-26
 
 ### Fixed
@@ -112,7 +118,8 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 - OpenCode downloads are restricted to official GitHub release assets and verified with SHA-256 digests before installation and on every cache reuse.
 - Electron runs with context isolation, renderer sandboxing, Node.js integration disabled, validated IPC payloads, and external navigation blocked.
 
-[Unreleased]: https://github.com/paralov/app-bloxbot-ai/compare/v0.6.7...HEAD
+[Unreleased]: https://github.com/paralov/app-bloxbot-ai/compare/v0.7.0...HEAD
+[0.7.0]: https://github.com/paralov/app-bloxbot-ai/compare/v0.6.7...v0.7.0
 [0.6.7]: https://github.com/paralov/app-bloxbot-ai/compare/v0.6.6...v0.6.7
 [0.6.6]: https://github.com/paralov/app-bloxbot-ai/compare/v0.6.5...v0.6.6
 [0.6.5]: https://github.com/paralov/app-bloxbot-ai/compare/v0.6.4...v0.6.5

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "bloxbot",
   "private": true,
-  "version": "0.6.7",
+  "version": "0.7.0",
   "description": "AI-assisted Roblox development from a secure desktop app",
   "type": "module",
   "main": "dist-electron/main/main.js",


### PR DESCRIPTION
## Summary

- bump BloxBot to 0.7.0
- document the multi-place Studio workflow
- update changelog comparison links

## Validation

- `node scripts/release.ts validate`
- `pnpm test` — 138 app tests and 8 release tests
- `pnpm typecheck`
- `pnpm build`
- `git diff --check`