### PR TITLE
Render readable update notifications

### DIFF
--- a/src/components/UpdateReleaseNotes.tsx
+++ b/src/components/UpdateReleaseNotes.tsx
@@ -1,0 +1,43 @@
+export interface ReleaseNoteSection {
+  title: string;
+  items: string[];
+}
+
+export function parseReleaseNotes(html: string | null): ReleaseNoteSection[] {
+  if (!html) return [];
+  const document = new DOMParser().parseFromString(html, "text/html");
+  return Array.from(document.querySelectorAll("h3"))
+    .map((heading) => {
+      const items: string[] = [];
+      let sibling = heading.nextElementSibling;
+      while (sibling && !/^H[1-6]$/.test(sibling.tagName)) {
+        for (const item of sibling.querySelectorAll("li")) {
+          const text = item.textContent?.replace(/\s+/g, " ").trim();
+          if (text) items.push(text);
+        }
+        sibling = sibling.nextElementSibling;
+      }
+      return { title: heading.textContent?.trim() ?? "", items };
+    })
+    .filter((section) => section.title && section.items.length > 0);
+}
+
+export function UpdateReleaseNotes({ body }: { body: string | null }) {
+  const sections = parseReleaseNotes(body);
+  if (sections.length === 0) return <span>A new version is ready to install.</span>;
+
+  return (
+    <div className="update-release-notes">
+      {sections.map((section) => (
+        <div key={section.title}>
+          <div className="update-release-notes-title">{section.title}</div>
+          <ul>
+            {section.items.map((item) => (
+              <li key={item}>{item}</li>
+            ))}
+          </ul>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/hooks/useUpdater.ts
+++ b/src/hooks/useUpdater.ts
@@ -1,6 +1,7 @@
-import { useEffect } from "react";
+import { createElement, useEffect } from "react";
 import { toast } from "sonner";
 
+import { UpdateReleaseNotes } from "@/components/UpdateReleaseNotes";
 import { desktop } from "@/lib/desktop";
 
 // ── Semver helpers ──────────────────────────────────────────────────────
@@ -62,7 +63,8 @@ export function useUpdater(): void {
           console.debug(`[updater] Prompting for update ${currentVersion} → ${update.version}`);
 
           toast(`BloxBot ${update.version} is available`, {
-            description: update.body ?? "A new version is ready to install.",
+            className: "update-available-toast",
+            description: createElement(UpdateReleaseNotes, { body: update.body }),
             duration: Number.POSITIVE_INFINITY,
             action: {
               label: "Install & Restart",

--- a/src/index.css
+++ b/src/index.css
@@ -656,6 +656,50 @@
   height: 16px;
 }
 
+/* Persistent updater prompt: compact release summary with a clear action. */
+[data-sonner-toaster] [data-sonner-toast].update-available-toast {
+  width: min(420px, calc(100vw - 32px));
+  align-items: flex-start;
+  flex-wrap: wrap;
+  gap: 12px 8px;
+  padding: 16px;
+}
+
+[data-sonner-toaster] [data-sonner-toast].update-available-toast [data-content] {
+  flex: 0 0 100%;
+  gap: 8px;
+}
+
+[data-sonner-toaster] [data-sonner-toast].update-available-toast [data-description] {
+  margin-top: 0;
+  color: var(--foreground);
+}
+
+.update-release-notes {
+  display: grid;
+  gap: 8px;
+}
+
+.update-release-notes-title {
+  margin-bottom: 3px;
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--muted-foreground);
+}
+
+.update-release-notes ul {
+  display: grid;
+  gap: 4px;
+  padding-left: 16px;
+  list-style: disc;
+}
+
+[data-sonner-toaster] [data-sonner-toast].update-available-toast [data-button] {
+  margin-left: 0;
+}
+
 /* Analytics consent is a small decision card, not a transient status toast. */
 [data-sonner-toaster] [data-sonner-toast].analytics-consent-toast {
   align-items: flex-start;

--- a/src/test/UpdateReleaseNotes.test.tsx
+++ b/src/test/UpdateReleaseNotes.test.tsx
@@ -1,0 +1,27 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { parseReleaseNotes, UpdateReleaseNotes } from "@/components/UpdateReleaseNotes";
+
+const releaseHtml = `
+  <h2>Download BloxBot</h2>
+  <ul><li><a href="https://example.com/app.dmg">macOS (.dmg)</a></li></ul>
+  <h3>Added</h3>
+  <ul><li>Coordinate work across multiple Studio places.</li></ul>
+`;
+
+describe("UpdateReleaseNotes", () => {
+  it("keeps changelog sections and omits download links", () => {
+    expect(parseReleaseNotes(releaseHtml)).toEqual([
+      { title: "Added", items: ["Coordinate work across multiple Studio places."] },
+    ]);
+  });
+
+  it("renders readable release notes instead of raw HTML", () => {
+    render(<UpdateReleaseNotes body={releaseHtml} />);
+    expect(screen.getByText("Added")).toBeVisible();
+    expect(screen.getByText("Coordinate work across multiple Studio places.")).toBeVisible();
+    expect(screen.queryByText(/<h2>/)).not.toBeInTheDocument();
+    expect(screen.queryByText("macOS (.dmg)")).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

- parse updater release-note HTML into safe heading and bullet text
- omit the redundant installer download links from the in-app prompt
- give persistent update notifications a compact, readable card layout
- keep the existing install-and-restart behavior

## Before

![Raw HTML update notification](https://github.com/user-attachments/assets/dc8852de-b9ef-47a8-b717-8534a355e913)

## After

![Readable update notification](https://github.com/user-attachments/assets/94ad78cc-364b-4d35-b1e9-25281f5315ee)

_The after image is rendered through the isolated Vite screenshot harness using the real toaster, styles, and release-note component._

## Validation

- `pnpm test` — 140 app tests and 8 release tests passed
- `pnpm typecheck`
- `pnpm build`
- Biome checks for changed TypeScript/TSX files
- `git diff --check`
