### PR TITLE
Add agent-driven Explorer

### DIFF
--- a/electron/channels.ts
+++ b/electron/channels.ts
@@ -1,9 +1,11 @@
 export const channels = {
+  compileExplorerProgram: "explorer:compile-program",
   checkForUpdate: "app:check-for-update",
   getOpenCodeInfo: "opencode:get-info",
   openCodeStartupProgress: "opencode:startup-progress",
   getVersion: "app:get-version",
   installUpdate: "app:install-update",
+  invokeExplorerProgram: "explorer:invoke-program",
   loadConfig: "config:load",
   openUrl: "app:open-url",
   patchConfig: "config:patch",

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -13,9 +13,15 @@ import {
   DEFAULT_APP_CONFIG,
   type OpenCodeStartupProgress,
 } from "../src/types/desktop";
+import { ExplorerProgramEnvelopeSchema, ExplorerSnapshotSchema } from "../src/lib/explorer";
+import { GeneratedProgramArtifactSchema } from "../src/types/generatedProgram";
 import { handleLastWindowClosed } from "./appLifecycle";
 import { channels } from "./channels";
 import { makeOpenCodeLayer, OpenCode } from "./services/OpenCode";
+import {
+  GeneratedProgramRuntime,
+  GeneratedProgramRuntimeLive,
+} from "./services/GeneratedProgramRuntime";
 import { makeStudioMcpBrokerLayer } from "./services/StudioMcpBroker";
 
 const currentDirectory = dirname(fileURLToPath(import.meta.url));
@@ -30,8 +36,14 @@ class DesktopMainError extends Data.TaggedError("DesktopMainError")<{
   cause?: unknown;
 }> {}
 
+const studioMcpBrokerLayer = makeStudioMcpBrokerLayer({
+  workspace: join(app.getPath("home"), "BloxBot"),
+  localAppData: process.env.LOCALAPPDATA,
+});
+
 const openCodeRuntime = ManagedRuntime.make(
-  makeOpenCodeLayer({
+  Layer.merge(
+    makeOpenCodeLayer({
     binaryCacheDirectory: join(app.getPath("userData"), "opencode"),
     workspace: join(app.getPath("home"), "BloxBot"),
     onStartupProgress: (progress: OpenCodeStartupProgress) => {
@@ -39,14 +51,9 @@ const openCodeRuntime = ManagedRuntime.make(
         mainWindow.webContents.send(channels.openCodeStartupProgress, progress);
       }
     },
-  }).pipe(
-    Layer.provide(
-      makeStudioMcpBrokerLayer({
-        workspace: join(app.getPath("home"), "BloxBot"),
-        localAppData: process.env.LOCALAPPDATA,
-      }),
-    ),
-  ),
+    }),
+    GeneratedProgramRuntimeLive,
+  ).pipe(Layer.provide(studioMcpBrokerLayer)),
 );
 
 function isMissingFile(cause: unknown): boolean {
@@ -127,6 +134,15 @@ function patchConfig(input: unknown) {
 const runMain = <A, E>(effect: Effect.Effect<A, E>) => Effect.runPromise(effect);
 
 const registerIpcHandlers = Effect.sync(() => {
+  ipcMain.handle(channels.compileExplorerProgram, (_event, input: unknown) =>
+    openCodeRuntime.runPromise(
+      Effect.gen(function* () {
+        const program = yield* Schema.decodeUnknown(ExplorerProgramEnvelopeSchema)(input);
+        const runtime = yield* GeneratedProgramRuntime;
+        return yield* runtime.compile(program);
+      }),
+    ),
+  );
   ipcMain.handle(channels.getOpenCodeInfo, () =>
     openCodeRuntime.runPromise(
       OpenCode.pipe(Effect.flatMap((service) => service.info)),
@@ -177,6 +193,28 @@ const registerIpcHandlers = Effect.sync(() => {
             new DesktopMainError({ message: "Failed to download the update", cause }),
         });
         yield* Effect.sync(() => autoUpdater.quitAndInstall());
+      }),
+    ),
+  );
+  ipcMain.handle(channels.invokeExplorerProgram, (_event, input: unknown) =>
+    openCodeRuntime.runPromise(
+      Effect.gen(function* () {
+        const artifact = yield* Schema.decodeUnknown(GeneratedProgramArtifactSchema)(input);
+        if (
+          artifact.contract.name !== "explorer-snapshot" ||
+          artifact.contract.outputSchemaVersion !== "explorer-snapshot-v1"
+        ) {
+          return yield* Effect.fail(
+            new DesktopMainError({ message: "Explorer program contract is invalid" }),
+          );
+        }
+        const runtime = yield* GeneratedProgramRuntime;
+        const result = yield* runtime.invoke({ artifact, input: null });
+        return yield* Schema.decodeUnknown(ExplorerSnapshotSchema)(result.value).pipe(
+          Effect.mapError(
+            (cause) => new DesktopMainError({ message: "Explorer output is invalid", cause }),
+          ),
+        );
       }),
     ),
   );

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -4,6 +4,8 @@ import type { AppConfig, DesktopApi, OpenCodeStartupProgress } from "../src/type
 import { channels } from "./channels";
 
 const api: DesktopApi = {
+  compileExplorerProgram: (program) =>
+    ipcRenderer.invoke(channels.compileExplorerProgram, program),
   getOpenCodeInfo: () => ipcRenderer.invoke(channels.getOpenCodeInfo),
   onOpenCodeStartupProgress: (listener) => {
     const handleProgress = (_event: Electron.IpcRendererEvent, progress: OpenCodeStartupProgress) =>
@@ -17,6 +19,8 @@ const api: DesktopApi = {
   patchConfig: (patch: Partial<AppConfig>) => ipcRenderer.invoke(channels.patchConfig, patch),
   checkForUpdate: () => ipcRenderer.invoke(channels.checkForUpdate),
   installUpdate: () => ipcRenderer.invoke(channels.installUpdate),
+  invokeExplorerProgram: (artifact) =>
+    ipcRenderer.invoke(channels.invokeExplorerProgram, artifact),
   relaunch: () => ipcRenderer.invoke(channels.relaunch),
 };
 

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "effect": "^3.22.0",
     "electron-updater": "^6.8.9",
     "extract-zip": "^2.0.1",
+    "lucide-react": "^1.27.0",
     "posthog-js": "^1.363.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,9 @@ importers:
       extract-zip:
         specifier: ^2.0.1
         version: 2.0.1
+      lucide-react:
+        specifier: ^1.27.0
+        version: 1.27.0(react@18.3.1)
       posthog-js:
         specifier: ^1.363.1
         version: 1.363.1
@@ -2419,6 +2422,11 @@ packages:
   lru-cache@6.0.0:
     resolution: {integrity: sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==}
     engines: {node: '>=10'}
+
+  lucide-react@1.27.0:
+    resolution: {integrity: sha512-rJicGl/3Fly/E0rOH1YmPZ6e49JCnKknh1ox1vpHnkfjujAkKA6sqUZvH3MTAaXXjgexyUwgNwTJzTtYuAFYJw==}
+    peerDependencies:
+      react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   lz-string@1.5.0:
     resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
@@ -6166,6 +6174,10 @@ snapshots:
   lru-cache@6.0.0:
     dependencies:
       yallist: 4.0.0
+
+  lucide-react@1.27.0(react@18.3.1):
+    dependencies:
+      react: 18.3.1
 
   lz-string@1.5.0: {}
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,7 @@ import { ThemeProvider } from "@/components/theme-provider";
 import { Toaster } from "@/components/ui/sonner";
 import { useUpdater } from "@/hooks/useUpdater";
 import { ActiveSessionProvider } from "@/providers/ActiveSessionProvider";
+import { ExplorerReferenceProvider } from "@/providers/ExplorerReferenceProvider";
 import { OpenCodeClientProvider } from "@/providers/OpenCodeClientProvider";
 import { PreferencesProvider } from "@/providers/PreferencesProvider";
 import { QueryProvider } from "@/providers/QueryProvider";
@@ -33,7 +34,9 @@ function App() {
         <OpenCodeClientProvider activeSessionIdRef={activeSessionIdRef}>
           <ActiveSessionProvider activeSessionIdRef={activeSessionIdRef}>
             <PreferencesProvider>
-              <AppInner />
+              <ExplorerReferenceProvider>
+                <AppInner />
+              </ExplorerReferenceProvider>
             </PreferencesProvider>
           </ActiveSessionProvider>
         </OpenCodeClientProvider>

--- a/src/components/Chat.tsx
+++ b/src/components/Chat.tsx
@@ -167,6 +167,7 @@ function Chat() {
       studioConnection.state === "connected" ? (
         <Explorer
           collapsed={explorerCollapsed}
+          sessionBusy={isBusy}
           onToggle={() => setExplorerCollapsed((value) => !value)}
         />
       ) : null}

--- a/src/components/Chat.tsx
+++ b/src/components/Chat.tsx
@@ -4,6 +4,7 @@ import { lazy, Suspense, useCallback, useEffect, useState } from "react";
 import ChatInput from "@/components/ChatInput";
 import ChatMessages from "@/components/ChatMessages";
 import ChatSidebar from "@/components/ChatSidebar";
+import Explorer from "@/components/Explorer";
 import LoadingScreen from "@/components/LoadingScreen";
 import StudioSetup from "@/components/StudioSetup";
 import { useCreateSession } from "@/hooks/mutations/useCreateSession";
@@ -29,6 +30,7 @@ function Chat() {
   const activeSessionTitle = allSessions?.find((s) => s.id === activeSessionId)?.title ?? null;
 
   const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
+  const [explorerCollapsed, setExplorerCollapsed] = useState(false);
   const [showSettings, setShowSettings] = useState(false);
   const [showStudioSetup, setShowStudioSetup] = useState(false);
 
@@ -159,6 +161,15 @@ function Chat() {
           </div>
         )}
       </div>
+      {activeSessionId &&
+      !showSettings &&
+      !showStudioSetup &&
+      studioConnection.state === "connected" ? (
+        <Explorer
+          collapsed={explorerCollapsed}
+          onToggle={() => setExplorerCollapsed((value) => !value)}
+        />
+      ) : null}
     </div>
   );
 }

--- a/src/components/ChatInput.tsx
+++ b/src/components/ChatInput.tsx
@@ -7,6 +7,7 @@ import { useAllModels, useConnectedProviders } from "@/hooks/useProviders";
 import { useIsBusy } from "@/hooks/useSessionStatuses";
 import { splitModelKey } from "@/lib/splitModelKey";
 import { useActiveSession } from "@/providers/ActiveSessionProvider";
+import { useExplorerReference } from "@/providers/ExplorerReferenceProvider";
 import { usePreferences } from "@/providers/PreferencesProvider";
 import type { ModelInfo } from "@/types";
 
@@ -231,6 +232,7 @@ const StatusHint = memo(function StatusHint() {
 });
 
 function ChatInput() {
+  const { pendingReference, consumeReference } = useExplorerReference();
   const allModels = useAllModels();
   const connectedProviders = useConnectedProviders();
   const agents = useAgents();
@@ -272,6 +274,18 @@ function ChatInput() {
   const agentPickerRef = useRef<HTMLDivElement>(null);
   const dragCounterRef = useRef(0);
   const rejectTimerRef = useRef<ReturnType<typeof setTimeout>>();
+
+  useEffect(() => {
+    if (!pendingReference) return;
+    setText((current) => (current.trim() ? `${pendingReference}\n\n${current}` : pendingReference));
+    consumeReference();
+    requestAnimationFrame(() => {
+      if (!textareaRef.current) return;
+      textareaRef.current.style.height = "auto";
+      textareaRef.current.style.height = `${Math.min(textareaRef.current.scrollHeight, 160)}px`;
+      textareaRef.current.focus();
+    });
+  }, [pendingReference, consumeReference]);
 
   const triggerRejectShake = useCallback(() => {
     setRejectShake(true);

--- a/src/components/Explorer.tsx
+++ b/src/components/Explorer.tsx
@@ -1,0 +1,299 @@
+import { useMutation } from "@tanstack/react-query";
+import { memo, useCallback, useEffect, useMemo, useState } from "react";
+import { toast } from "sonner";
+import { createExplorerReference, type ExplorerNode, loadExplorerSnapshot } from "@/lib/explorer";
+import { splitModelKey } from "@/lib/splitModelKey";
+import { useExplorerReference } from "@/providers/ExplorerReferenceProvider";
+import { useOpenCodeClient } from "@/providers/OpenCodeClientProvider";
+import { usePreferences } from "@/providers/PreferencesProvider";
+
+interface ExplorerProps {
+  collapsed: boolean;
+  onToggle: () => void;
+}
+
+interface TreeRowProps {
+  node: ExplorerNode;
+  depth: number;
+  expanded: ReadonlySet<string>;
+  selectedPath: string | null;
+  onToggle: (path: string) => void;
+  onSelect: (node: ExplorerNode) => void;
+}
+
+const TreeRow = memo(function TreeRow({
+  node,
+  depth,
+  expanded,
+  selectedPath,
+  onToggle,
+  onSelect,
+}: TreeRowProps) {
+  const isExpanded = expanded.has(node.path);
+  const canExpand = node.hasChildren || node.children.length > 0;
+
+  return (
+    <>
+      <div
+        className={`group flex h-6 items-center pr-2 text-[11px] ${selectedPath === node.path ? "bg-accent text-foreground" : "text-muted-foreground hover:bg-accent/60 hover:text-foreground"}`}
+        style={{ paddingLeft: `${8 + depth * 14}px` }}
+      >
+        <button
+          type="button"
+          aria-label={`${isExpanded ? "Collapse" : "Expand"} ${node.name}`}
+          disabled={!canExpand}
+          onClick={() => onToggle(node.path)}
+          className="flex h-5 w-4 shrink-0 items-center justify-center disabled:opacity-0"
+        >
+          <svg
+            width="9"
+            height="9"
+            viewBox="0 0 12 12"
+            fill="none"
+            className={`transition-transform ${isExpanded ? "rotate-90" : ""}`}
+          >
+            <path d="m4 2.5 3.5 3.5L4 9.5" stroke="currentColor" strokeWidth="1.4" />
+          </svg>
+        </button>
+        <button
+          type="button"
+          onClick={() => onSelect(node)}
+          className="flex min-w-0 flex-1 items-center gap-1.5 text-left"
+          title={`${node.path} · ${node.className}`}
+        >
+          <span className="flex h-3.5 w-3.5 shrink-0 items-center justify-center rounded-[3px] bg-blue-500/10 text-[8px] font-bold text-blue-600 dark:text-blue-400">
+            {node.className.slice(0, 1).toUpperCase()}
+          </span>
+          <span className="truncate">{node.name}</span>
+        </button>
+      </div>
+      {isExpanded
+        ? node.children.map((child) => (
+            <TreeRow
+              key={child.path}
+              node={child}
+              depth={depth + 1}
+              expanded={expanded}
+              selectedPath={selectedPath}
+              onToggle={onToggle}
+              onSelect={onSelect}
+            />
+          ))
+        : null}
+    </>
+  );
+});
+
+export default function Explorer({ collapsed, onToggle }: ExplorerProps) {
+  const { client } = useOpenCodeClient();
+  const { selectedModel, selectedAgent } = usePreferences();
+  const { referenceObject } = useExplorerReference();
+  const [expanded, setExpanded] = useState<Set<string>>(() => new Set());
+  const [selected, setSelected] = useState<ExplorerNode | null>(null);
+
+  const model = useMemo(() => {
+    if (!selectedModel) return undefined;
+    const [providerID, modelID] = splitModelKey(selectedModel);
+    return providerID && modelID ? { providerID, modelID } : undefined;
+  }, [selectedModel]);
+
+  const snapshot = useMutation({
+    mutationFn: async () => {
+      if (!client) throw new Error("BloxBot is still connecting");
+      return loadExplorerSnapshot(client, model, selectedAgent);
+    },
+    onSuccess: (data) => {
+      setSelected(null);
+      setExpanded(new Set(data.roots.map((node) => node.path)));
+    },
+    onError: (error) => toast.error("Explorer couldn't refresh", { description: error.message }),
+  });
+
+  useEffect(() => {
+    if (client && !snapshot.data && !snapshot.isPending && !snapshot.isError) snapshot.mutate();
+  }, [client, snapshot]);
+
+  const toggleNode = useCallback((path: string) => {
+    setExpanded((current) => {
+      const next = new Set(current);
+      if (next.has(path)) next.delete(path);
+      else next.add(path);
+      return next;
+    });
+  }, []);
+
+  const selectNode = useCallback((node: ExplorerNode) => setSelected(node), []);
+  const handleReference = useCallback(() => {
+    if (!selected) return;
+    referenceObject(createExplorerReference(selected));
+    toast.success(`${selected.name} added to your message`);
+  }, [referenceObject, selected]);
+
+  if (collapsed) {
+    return (
+      <aside className="flex w-10 shrink-0 flex-col items-center border-l bg-sidebar py-2">
+        <button
+          type="button"
+          onClick={onToggle}
+          className="rounded-md p-2 text-muted-foreground hover:bg-accent hover:text-foreground"
+          title="Open Explorer"
+        >
+          <ExplorerIcon />
+        </button>
+      </aside>
+    );
+  }
+
+  return (
+    <aside className="flex w-64 shrink-0 flex-col border-l bg-sidebar">
+      <div className="flex h-10 shrink-0 items-center justify-between border-b px-3">
+        <div className="flex min-w-0 items-center gap-2">
+          <ExplorerIcon />
+          <div className="min-w-0">
+            <div className="text-[11px] font-semibold uppercase tracking-[0.12em]">Explorer</div>
+            {snapshot.data ? (
+              <div className="truncate text-[9px] text-muted-foreground">
+                {snapshot.data.placeName}
+              </div>
+            ) : null}
+          </div>
+        </div>
+        <div className="flex items-center gap-0.5">
+          <button
+            type="button"
+            onClick={() => snapshot.mutate()}
+            disabled={snapshot.isPending}
+            aria-label="Refresh Explorer"
+            className="rounded p-1.5 text-muted-foreground hover:bg-accent hover:text-foreground disabled:opacity-40"
+          >
+            <RefreshIcon spinning={snapshot.isPending} />
+          </button>
+          <button
+            type="button"
+            onClick={onToggle}
+            aria-label="Collapse Explorer"
+            className="rounded p-1.5 text-muted-foreground hover:bg-accent hover:text-foreground"
+          >
+            <svg
+              width="13"
+              height="13"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+            >
+              <path d="m15 18-6-6 6-6" />
+            </svg>
+          </button>
+        </div>
+      </div>
+
+      <div
+        className="min-h-0 flex-1 overflow-y-auto py-1"
+        role="tree"
+        aria-label="Instance hierarchy"
+      >
+        {snapshot.isPending ? <ExplorerLoading /> : null}
+        {snapshot.isError ? (
+          <div className="px-4 py-8 text-center text-xs text-muted-foreground">
+            <p>Couldn't read the place.</p>
+            <button
+              type="button"
+              onClick={() => snapshot.mutate()}
+              className="mt-2 font-medium text-foreground underline underline-offset-2"
+            >
+              Try again
+            </button>
+          </div>
+        ) : null}
+        {snapshot.data?.roots.map((node) => (
+          <TreeRow
+            key={node.path}
+            node={node}
+            depth={0}
+            expanded={expanded}
+            selectedPath={selected?.path ?? null}
+            onToggle={toggleNode}
+            onSelect={selectNode}
+          />
+        ))}
+      </div>
+
+      {selected ? (
+        <div className="shrink-0 border-t bg-card/60 p-3">
+          <div className="truncate text-xs font-medium">{selected.name}</div>
+          <div
+            className="mt-0.5 truncate font-mono text-[9px] text-muted-foreground"
+            title={selected.path}
+          >
+            {selected.path}
+          </div>
+          <div className="mt-2 flex items-center justify-between gap-2">
+            <span className="rounded bg-muted px-1.5 py-0.5 text-[9px] text-muted-foreground">
+              {selected.className}
+            </span>
+            <button
+              type="button"
+              onClick={handleReference}
+              className="rounded-md bg-foreground px-2 py-1 text-[10px] font-medium text-background hover:opacity-90"
+            >
+              Reference in chat
+            </button>
+          </div>
+        </div>
+      ) : (
+        <div className="shrink-0 border-t px-3 py-2 text-[9px] text-muted-foreground">
+          Select an object to reference it in chat.
+        </div>
+      )}
+    </aside>
+  );
+}
+
+function ExplorerIcon() {
+  return (
+    <svg
+      width="14"
+      height="14"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.8"
+    >
+      <rect x="3" y="3" width="7" height="7" rx="1" />
+      <rect x="14" y="3" width="7" height="7" rx="1" />
+      <rect x="3" y="14" width="7" height="7" rx="1" />
+      <rect x="14" y="14" width="7" height="7" rx="1" />
+    </svg>
+  );
+}
+
+function RefreshIcon({ spinning }: { spinning: boolean }) {
+  return (
+    <svg
+      width="13"
+      height="13"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      className={spinning ? "animate-spin" : ""}
+    >
+      <path d="M20 11a8.1 8.1 0 0 0-15.5-2M4 4v5h5M4 13a8.1 8.1 0 0 0 15.5 2M20 20v-5h-5" />
+    </svg>
+  );
+}
+
+function ExplorerLoading() {
+  return (
+    <div className="space-y-1.5 px-3 py-3">
+      {[78, 62, 85, 70, 58, 81].map((width, index) => (
+        <div
+          key={width}
+          className="h-4 animate-pulse rounded bg-muted"
+          style={{ width: `${width}%`, marginLeft: `${(index % 3) * 10}px` }}
+        />
+      ))}
+    </div>
+  );
+}

--- a/src/components/Explorer.tsx
+++ b/src/components/Explorer.tsx
@@ -1,11 +1,38 @@
-import { useMutation } from "@tanstack/react-query";
-import { memo, useCallback, useEffect, useMemo, useState } from "react";
+import {
+  Box,
+  Boxes,
+  Camera,
+  ChevronLeft,
+  ChevronRight,
+  CircleDot,
+  CloudSun,
+  Code2,
+  Database,
+  Folder,
+  Gamepad2,
+  type LucideIcon,
+  PanelTop,
+  ScrollText,
+  Server,
+  Sparkles,
+  Users,
+} from "lucide-react";
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
-import { createExplorerReference, type ExplorerNode, loadExplorerSnapshot } from "@/lib/explorer";
+import {
+  createExplorerReference,
+  type ExplorerCollection,
+  type ExplorerField,
+  type ExplorerNode,
+  generateExplorerCollection,
+  replayExplorerCollector,
+} from "@/lib/explorer";
 import { splitModelKey } from "@/lib/splitModelKey";
 import { useExplorerReference } from "@/providers/ExplorerReferenceProvider";
 import { useOpenCodeClient } from "@/providers/OpenCodeClientProvider";
 import { usePreferences } from "@/providers/PreferencesProvider";
+
+const SYNC_INTERVAL_MS = 20_000;
 
 interface ExplorerProps {
   collapsed: boolean;
@@ -21,6 +48,27 @@ interface TreeRowProps {
   onSelect: (node: ExplorerNode) => void;
 }
 
+const CLASS_ICONS: ReadonlyArray<[RegExp, LucideIcon]> = [
+  [/^(Workspace|WorldRoot)$/, Gamepad2],
+  [/^(Players|Player)$/, Users],
+  [/^(Lighting|Atmosphere|Sky|Clouds)$/, CloudSun],
+  [/^(ReplicatedStorage|ServerStorage|DataStoreService)$/, Database],
+  [/^(ServerScriptService|Script|LocalScript|ModuleScript)$/, Code2],
+  [/^(StarterGui|ScreenGui|SurfaceGui|BillboardGui|GuiObject|Frame)$/, PanelTop],
+  [/^(Folder|Configuration)$/, Folder],
+  [/^(Model|PVInstance)$/, Boxes],
+  [/^(Part|MeshPart|UnionOperation|SpawnLocation|BasePart)$/, Box],
+  [/^(Camera)$/, Camera],
+  [/^(ParticleEmitter|Beam|Trail|Highlight)$/, Sparkles],
+  [/^(RemoteEvent|RemoteFunction|BindableEvent|BindableFunction)$/, Server],
+  [/^(StringValue|NumberValue|BoolValue|ObjectValue|ValueBase)$/, CircleDot],
+  [/^(TextLabel|TextButton|TextBox)$/, ScrollText],
+];
+
+function iconForClass(className: string): LucideIcon {
+  return CLASS_ICONS.find(([pattern]) => pattern.test(className))?.[1] ?? Box;
+}
+
 const TreeRow = memo(function TreeRow({
   node,
   depth,
@@ -31,10 +79,15 @@ const TreeRow = memo(function TreeRow({
 }: TreeRowProps) {
   const isExpanded = expanded.has(node.path);
   const canExpand = node.hasChildren || node.children.length > 0;
+  const InstanceIcon = iconForClass(node.className);
 
   return (
     <>
       <div
+        role="treeitem"
+        tabIndex={0}
+        aria-selected={selectedPath === node.path}
+        aria-expanded={canExpand ? isExpanded : undefined}
         className={`group flex h-6 items-center pr-2 text-[11px] ${selectedPath === node.path ? "bg-accent text-foreground" : "text-muted-foreground hover:bg-accent/60 hover:text-foreground"}`}
         style={{ paddingLeft: `${8 + depth * 14}px` }}
       >
@@ -45,15 +98,10 @@ const TreeRow = memo(function TreeRow({
           onClick={() => onToggle(node.path)}
           className="flex h-5 w-4 shrink-0 items-center justify-center disabled:opacity-0"
         >
-          <svg
-            width="9"
-            height="9"
-            viewBox="0 0 12 12"
-            fill="none"
+          <ChevronRight
+            size={10}
             className={`transition-transform ${isExpanded ? "rotate-90" : ""}`}
-          >
-            <path d="m4 2.5 3.5 3.5L4 9.5" stroke="currentColor" strokeWidth="1.4" />
-          </svg>
+          />
         </button>
         <button
           type="button"
@@ -61,9 +109,11 @@ const TreeRow = memo(function TreeRow({
           className="flex min-w-0 flex-1 items-center gap-1.5 text-left"
           title={`${node.path} · ${node.className}`}
         >
-          <span className="flex h-3.5 w-3.5 shrink-0 items-center justify-center rounded-[3px] bg-blue-500/10 text-[8px] font-bold text-blue-600 dark:text-blue-400">
-            {node.className.slice(0, 1).toUpperCase()}
-          </span>
+          <InstanceIcon
+            size={13}
+            strokeWidth={1.8}
+            className="shrink-0 text-blue-600 dark:text-blue-400"
+          />
           <span className="truncate">{node.name}</span>
         </button>
       </div>
@@ -84,12 +134,36 @@ const TreeRow = memo(function TreeRow({
   );
 });
 
+function findNode(nodes: readonly ExplorerNode[], path: string): ExplorerNode | null {
+  for (const node of nodes) {
+    if (node.path === path) return node;
+    const child = findNode(node.children, path);
+    if (child) return child;
+  }
+  return null;
+}
+
+function freshnessLabel(capturedAt: string, now: number): string {
+  const elapsed = Math.max(0, now - Date.parse(capturedAt));
+  if (!Number.isFinite(elapsed) || elapsed < 10_000) return "Just synced";
+  if (elapsed < 60_000) return `${Math.floor(elapsed / 1_000)}s ago`;
+  return `${Math.floor(elapsed / 60_000)}m ago`;
+}
+
 export default function Explorer({ collapsed, onToggle }: ExplorerProps) {
   const { client } = useOpenCodeClient();
   const { selectedModel, selectedAgent } = usePreferences();
   const { referenceObject } = useExplorerReference();
+  const [collection, setCollection] = useState<ExplorerCollection | null>(null);
+  const collectionRef = useRef<ExplorerCollection | null>(null);
+  const syncingRef = useRef(false);
+  const resyncRequestedRef = useRef(false);
+  const syncLatestRef = useRef<() => void>(() => undefined);
+  const [syncing, setSyncing] = useState(false);
+  const [syncError, setSyncError] = useState<string | null>(null);
+  const [now, setNow] = useState(() => Date.now());
   const [expanded, setExpanded] = useState<Set<string>>(() => new Set());
-  const [selected, setSelected] = useState<ExplorerNode | null>(null);
+  const [selectedPath, setSelectedPath] = useState<string | null>(null);
 
   const model = useMemo(() => {
     if (!selectedModel) return undefined;
@@ -97,21 +171,71 @@ export default function Explorer({ collapsed, onToggle }: ExplorerProps) {
     return providerID && modelID ? { providerID, modelID } : undefined;
   }, [selectedModel]);
 
-  const snapshot = useMutation({
-    mutationFn: async () => {
-      if (!client) throw new Error("BloxBot is still connecting");
-      return loadExplorerSnapshot(client, model, selectedAgent);
-    },
-    onSuccess: (data) => {
-      setSelected(null);
-      setExpanded(new Set(data.roots.map((node) => node.path)));
-    },
-    onError: (error) => toast.error("Explorer couldn't refresh", { description: error.message }),
-  });
-
   useEffect(() => {
-    if (client && !snapshot.data && !snapshot.isPending && !snapshot.isError) snapshot.mutate();
-  }, [client, snapshot]);
+    if (!client || collapsed) return;
+    const activeClient = client;
+    let cancelled = false;
+
+    async function sync() {
+      if (syncingRef.current) {
+        resyncRequestedRef.current = true;
+        return;
+      }
+      if (document.visibilityState === "hidden") return;
+      syncingRef.current = true;
+      setSyncing(true);
+      setSyncError(null);
+
+      try {
+        const current = collectionRef.current;
+        let next: ExplorerCollection;
+        if (current) {
+          try {
+            const snapshot = await replayExplorerCollector(
+              activeClient,
+              current.collector,
+              model,
+              selectedAgent,
+            );
+            next = { collector: current.collector, snapshot };
+          } catch {
+            next = await generateExplorerCollection(activeClient, model, selectedAgent);
+          }
+        } else {
+          next = await generateExplorerCollection(activeClient, model, selectedAgent);
+        }
+
+        if (cancelled) return;
+        collectionRef.current = next;
+        setCollection(next);
+        setNow(Date.now());
+        setExpanded((currentExpanded) =>
+          currentExpanded.size > 0
+            ? currentExpanded
+            : new Set(next.snapshot.roots.map((node) => node.path)),
+        );
+      } catch (error) {
+        if (!cancelled) setSyncError(error instanceof Error ? error.message : String(error));
+      } finally {
+        syncingRef.current = false;
+        if (!cancelled) setSyncing(false);
+        if (resyncRequestedRef.current) {
+          resyncRequestedRef.current = false;
+          queueMicrotask(() => syncLatestRef.current());
+        }
+      }
+    }
+
+    syncLatestRef.current = () => void sync();
+    void sync();
+    const interval = window.setInterval(() => void sync(), SYNC_INTERVAL_MS);
+    const freshness = window.setInterval(() => setNow(Date.now()), 10_000);
+    return () => {
+      cancelled = true;
+      window.clearInterval(interval);
+      window.clearInterval(freshness);
+    };
+  }, [client, collapsed, model, selectedAgent]);
 
   const toggleNode = useCallback((path: string) => {
     setExpanded((current) => {
@@ -122,7 +246,11 @@ export default function Explorer({ collapsed, onToggle }: ExplorerProps) {
     });
   }, []);
 
-  const selectNode = useCallback((node: ExplorerNode) => setSelected(node), []);
+  const selected = useMemo(
+    () => (selectedPath && collection ? findNode(collection.snapshot.roots, selectedPath) : null),
+    [collection, selectedPath],
+  );
+
   const handleReference = useCallback(() => {
     if (!selected) return;
     referenceObject(createExplorerReference(selected));
@@ -138,54 +266,45 @@ export default function Explorer({ collapsed, onToggle }: ExplorerProps) {
           className="rounded-md p-2 text-muted-foreground hover:bg-accent hover:text-foreground"
           title="Open Explorer"
         >
-          <ExplorerIcon />
+          <Boxes size={15} />
         </button>
       </aside>
     );
   }
 
   return (
-    <aside className="flex w-64 shrink-0 flex-col border-l bg-sidebar">
+    <aside className="flex w-72 shrink-0 flex-col border-l bg-sidebar">
       <div className="flex h-10 shrink-0 items-center justify-between border-b px-3">
         <div className="flex min-w-0 items-center gap-2">
-          <ExplorerIcon />
+          <Boxes size={14} />
           <div className="min-w-0">
             <div className="text-[11px] font-semibold uppercase tracking-[0.12em]">Explorer</div>
-            {snapshot.data ? (
-              <div className="truncate text-[9px] text-muted-foreground">
-                {snapshot.data.placeName}
-              </div>
-            ) : null}
+            <div className="flex items-center gap-1.5 text-[9px] text-muted-foreground">
+              <span
+                className={`h-1.5 w-1.5 rounded-full ${syncError ? "bg-amber-500" : syncing ? "animate-pulse bg-blue-500" : "bg-emerald-500"}`}
+              />
+              <span className="truncate">
+                {syncing && !collection
+                  ? "Building collector…"
+                  : syncing
+                    ? "Syncing…"
+                    : syncError
+                      ? "Retrying automatically"
+                      : collection
+                        ? freshnessLabel(collection.snapshot.capturedAt, now)
+                        : "Waiting to sync"}
+              </span>
+            </div>
           </div>
         </div>
-        <div className="flex items-center gap-0.5">
-          <button
-            type="button"
-            onClick={() => snapshot.mutate()}
-            disabled={snapshot.isPending}
-            aria-label="Refresh Explorer"
-            className="rounded p-1.5 text-muted-foreground hover:bg-accent hover:text-foreground disabled:opacity-40"
-          >
-            <RefreshIcon spinning={snapshot.isPending} />
-          </button>
-          <button
-            type="button"
-            onClick={onToggle}
-            aria-label="Collapse Explorer"
-            className="rounded p-1.5 text-muted-foreground hover:bg-accent hover:text-foreground"
-          >
-            <svg
-              width="13"
-              height="13"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="2"
-            >
-              <path d="m15 18-6-6 6-6" />
-            </svg>
-          </button>
-        </div>
+        <button
+          type="button"
+          onClick={onToggle}
+          aria-label="Collapse Explorer"
+          className="rounded p-1.5 text-muted-foreground hover:bg-accent hover:text-foreground"
+        >
+          <ChevronLeft size={13} />
+        </button>
       </div>
 
       <div
@@ -193,94 +312,91 @@ export default function Explorer({ collapsed, onToggle }: ExplorerProps) {
         role="tree"
         aria-label="Instance hierarchy"
       >
-        {snapshot.isPending ? <ExplorerLoading /> : null}
-        {snapshot.isError ? (
+        {!collection && syncing ? <ExplorerLoading /> : null}
+        {!collection && syncError ? (
           <div className="px-4 py-8 text-center text-xs text-muted-foreground">
-            <p>Couldn't read the place.</p>
-            <button
-              type="button"
-              onClick={() => snapshot.mutate()}
-              className="mt-2 font-medium text-foreground underline underline-offset-2"
-            >
-              Try again
-            </button>
+            Explorer will retry when Studio is available.
           </div>
         ) : null}
-        {snapshot.data?.roots.map((node) => (
+        {collection?.snapshot.roots.map((node) => (
           <TreeRow
             key={node.path}
             node={node}
             depth={0}
             expanded={expanded}
-            selectedPath={selected?.path ?? null}
+            selectedPath={selectedPath}
             onToggle={toggleNode}
-            onSelect={selectNode}
+            onSelect={(next) => setSelectedPath(next.path)}
           />
         ))}
       </div>
 
       {selected ? (
-        <div className="shrink-0 border-t bg-card/60 p-3">
-          <div className="truncate text-xs font-medium">{selected.name}</div>
-          <div
-            className="mt-0.5 truncate font-mono text-[9px] text-muted-foreground"
-            title={selected.path}
-          >
-            {selected.path}
-          </div>
-          <div className="mt-2 flex items-center justify-between gap-2">
-            <span className="rounded bg-muted px-1.5 py-0.5 text-[9px] text-muted-foreground">
-              {selected.className}
-            </span>
-            <button
-              type="button"
-              onClick={handleReference}
-              className="rounded-md bg-foreground px-2 py-1 text-[10px] font-medium text-background hover:opacity-90"
-            >
-              Reference in chat
-            </button>
-          </div>
-        </div>
+        <Inspector node={selected} onReference={handleReference} />
       ) : (
         <div className="shrink-0 border-t px-3 py-2 text-[9px] text-muted-foreground">
-          Select an object to reference it in chat.
+          Select an object to inspect and reference it.
         </div>
       )}
     </aside>
   );
 }
 
-function ExplorerIcon() {
+function Inspector({ node, onReference }: { node: ExplorerNode; onReference: () => void }) {
+  const InstanceIcon = iconForClass(node.className);
   return (
-    <svg
-      width="14"
-      height="14"
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="1.8"
-    >
-      <rect x="3" y="3" width="7" height="7" rx="1" />
-      <rect x="14" y="3" width="7" height="7" rx="1" />
-      <rect x="3" y="14" width="7" height="7" rx="1" />
-      <rect x="14" y="14" width="7" height="7" rx="1" />
-    </svg>
+    <div className="max-h-[42%] shrink-0 overflow-y-auto border-t bg-card/60">
+      <div className="sticky top-0 border-b bg-card/95 p-3 backdrop-blur-sm">
+        <div className="flex items-start gap-2">
+          <InstanceIcon size={15} className="mt-0.5 shrink-0 text-blue-600 dark:text-blue-400" />
+          <div className="min-w-0 flex-1">
+            <div className="truncate text-xs font-medium">{node.name}</div>
+            <div className="truncate font-mono text-[9px] text-muted-foreground" title={node.path}>
+              {node.path}
+            </div>
+          </div>
+          <button
+            type="button"
+            onClick={onReference}
+            className="shrink-0 rounded-md bg-foreground px-2 py-1 text-[9px] font-medium text-background hover:opacity-90"
+          >
+            Reference
+          </button>
+        </div>
+      </div>
+      <FieldSection
+        title="Properties"
+        fields={[{ name: "ClassName", value: node.className }, ...node.properties]}
+      />
+      {node.attributes.length > 0 ? (
+        <FieldSection title="Attributes" fields={node.attributes} />
+      ) : null}
+    </div>
   );
 }
 
-function RefreshIcon({ spinning }: { spinning: boolean }) {
+function FieldSection({ title, fields }: { title: string; fields: readonly ExplorerField[] }) {
   return (
-    <svg
-      width="13"
-      height="13"
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2"
-      className={spinning ? "animate-spin" : ""}
-    >
-      <path d="M20 11a8.1 8.1 0 0 0-15.5-2M4 4v5h5M4 13a8.1 8.1 0 0 0 15.5 2M20 20v-5h-5" />
-    </svg>
+    <section className="border-b px-3 py-2 last:border-b-0">
+      <h4 className="mb-1.5 text-[9px] font-semibold uppercase tracking-wider text-muted-foreground">
+        {title}
+      </h4>
+      <dl className="space-y-1">
+        {fields.map((field) => (
+          <div
+            key={`${field.name}-${field.value}`}
+            className="grid grid-cols-[minmax(0,0.8fr)_minmax(0,1.2fr)] gap-2 text-[10px]"
+          >
+            <dt className="truncate text-muted-foreground" title={field.name}>
+              {field.name}
+            </dt>
+            <dd className="break-words font-mono text-foreground" title={field.value}>
+              {field.value}
+            </dd>
+          </div>
+        ))}
+      </dl>
+    </section>
   );
 }
 

--- a/src/components/Explorer.tsx
+++ b/src/components/Explorer.tsx
@@ -262,7 +262,7 @@ export default function Explorer({ collapsed, onToggle }: ExplorerProps) {
 
   return (
     <aside className="flex w-72 shrink-0 flex-col border-l bg-sidebar">
-      <header className="flex min-h-[81px] shrink-0 items-start justify-between border-b px-5 py-4">
+      <header className="flex min-h-[81px] shrink-0 items-start justify-between px-5 py-4">
         <div>
           <h2 className="font-serif text-xl italic">Explorer</h2>
         </div>

--- a/src/components/Explorer.tsx
+++ b/src/components/Explorer.tsx
@@ -16,8 +16,10 @@ import {
   Sparkles,
   Users,
 } from "lucide-react";
+import posthog from "posthog-js/dist/module.full.no-external.js";
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
+import { explorerAnalyticsProperties } from "@/lib/analytics";
 import {
   createExplorerReference,
   type ExplorerCollection,
@@ -142,6 +144,10 @@ function findNode(nodes: readonly ExplorerNode[], path: string): ExplorerNode | 
   return null;
 }
 
+function countNodes(nodes: readonly ExplorerNode[]): number {
+  return nodes.reduce((total, node) => total + 1 + countNodes(node.children), 0);
+}
+
 export default function Explorer({ collapsed, onToggle }: ExplorerProps) {
   const { client } = useOpenCodeClient();
   const { selectedModel, selectedAgent } = usePreferences();
@@ -155,12 +161,17 @@ export default function Explorer({ collapsed, onToggle }: ExplorerProps) {
   const [syncError, setSyncError] = useState<string | null>(null);
   const [expanded, setExpanded] = useState<Set<string>>(() => new Set());
   const [selectedPath, setSelectedPath] = useState<string | null>(null);
+  const telemetryRef = useRef({ firstSyncReported: false, hadFailure: false });
 
   const model = useMemo(() => {
     if (!selectedModel) return undefined;
     const [providerID, modelID] = splitModelKey(selectedModel);
     return providerID && modelID ? { providerID, modelID } : undefined;
   }, [selectedModel]);
+
+  useEffect(() => {
+    posthog.capture(collapsed ? "explorer_closed" : "explorer_opened");
+  }, [collapsed]);
 
   useEffect(() => {
     if (!client || collapsed) return;
@@ -176,6 +187,43 @@ export default function Explorer({ collapsed, onToggle }: ExplorerProps) {
       syncingRef.current = true;
       setSyncing(true);
       setSyncError(null);
+      const syncStartedAt = performance.now();
+      const isFirstSync = !telemetryRef.current.firstSyncReported;
+      if (isFirstSync) {
+        posthog.capture("sync_started", { source: "initial" });
+      }
+
+      async function generate(reason: "initial" | "contract_recovery") {
+        const startedAt = performance.now();
+        posthog.capture("collector_generation_started", {
+          model_mediated: true,
+          reason,
+        });
+        try {
+          const generated = await generateExplorerCollection(activeClient, model, selectedAgent);
+          posthog.capture(
+            "collector_generation_succeeded",
+            explorerAnalyticsProperties({
+              duration_ms: Math.round(performance.now() - startedAt),
+              model_mediated: true,
+              reason,
+              root_count: generated.snapshot.roots.length,
+              node_count: countNodes(generated.snapshot.roots),
+            }),
+          );
+          return generated;
+        } catch (error) {
+          posthog.capture(
+            "collector_generation_failed",
+            explorerAnalyticsProperties({
+              duration_ms: Math.round(performance.now() - startedAt),
+              model_mediated: true,
+              reason,
+            }),
+          );
+          throw error;
+        }
+      }
 
       try {
         const current = collectionRef.current;
@@ -190,10 +238,12 @@ export default function Explorer({ collapsed, onToggle }: ExplorerProps) {
             );
             next = { collector: current.collector, snapshot };
           } catch {
-            next = await generateExplorerCollection(activeClient, model, selectedAgent);
+            telemetryRef.current.hadFailure = true;
+            posthog.capture("sync_failed", { reason: "collector_replay" });
+            next = await generate("contract_recovery");
           }
         } else {
-          next = await generateExplorerCollection(activeClient, model, selectedAgent);
+          next = await generate("initial");
         }
 
         if (cancelled) return;
@@ -204,7 +254,28 @@ export default function Explorer({ collapsed, onToggle }: ExplorerProps) {
             ? currentExpanded
             : new Set(next.snapshot.roots.map((node) => node.path)),
         );
+        if (isFirstSync || telemetryRef.current.hadFailure) {
+          posthog.capture(
+            "sync_succeeded",
+            explorerAnalyticsProperties({
+              duration_ms: Math.round(performance.now() - syncStartedAt),
+              source: telemetryRef.current.hadFailure ? "recovery" : "initial",
+              root_count: next.snapshot.roots.length,
+              node_count: countNodes(next.snapshot.roots),
+            }),
+          );
+          telemetryRef.current.firstSyncReported = true;
+          telemetryRef.current.hadFailure = false;
+        }
       } catch (error) {
+        telemetryRef.current.hadFailure = true;
+        posthog.capture(
+          "sync_failed",
+          explorerAnalyticsProperties({
+            duration_ms: Math.round(performance.now() - syncStartedAt),
+            reason: collectionRef.current ? "recovery_failed" : "initial_failed",
+          }),
+        );
         if (!cancelled) setSyncError(error instanceof Error ? error.message : String(error));
       } finally {
         syncingRef.current = false;
@@ -242,6 +313,13 @@ export default function Explorer({ collapsed, onToggle }: ExplorerProps) {
   const handleReference = useCallback(() => {
     if (!selected) return;
     referenceObject(createExplorerReference(selected));
+    posthog.capture(
+      "reference_added",
+      explorerAnalyticsProperties({
+        class_category: iconForClass(selected.className) === Box ? "generic" : "known",
+        has_attributes: selected.attributes.length > 0,
+      }),
+    );
     toast.success(`${selected.name} added to your message`);
   }, [referenceObject, selected]);
 
@@ -262,9 +340,9 @@ export default function Explorer({ collapsed, onToggle }: ExplorerProps) {
 
   return (
     <aside className="flex w-72 shrink-0 flex-col border-l bg-sidebar">
-      <header className="flex min-h-[81px] shrink-0 items-start justify-between px-5 py-4">
+      <header className="flex h-16 shrink-0 items-center justify-between border-b px-5">
         <div>
-          <h2 className="font-serif text-xl italic">Explorer</h2>
+          <h2 className="font-serif text-xl">Explorer</h2>
         </div>
         <button
           type="button"

--- a/src/components/Explorer.tsx
+++ b/src/components/Explorer.tsx
@@ -2,7 +2,6 @@ import {
   Box,
   Boxes,
   Camera,
-  ChevronLeft,
   ChevronRight,
   CircleDot,
   CloudSun,
@@ -143,13 +142,6 @@ function findNode(nodes: readonly ExplorerNode[], path: string): ExplorerNode | 
   return null;
 }
 
-function freshnessLabel(capturedAt: string, now: number): string {
-  const elapsed = Math.max(0, now - Date.parse(capturedAt));
-  if (!Number.isFinite(elapsed) || elapsed < 10_000) return "Just synced";
-  if (elapsed < 60_000) return `${Math.floor(elapsed / 1_000)}s ago`;
-  return `${Math.floor(elapsed / 60_000)}m ago`;
-}
-
 export default function Explorer({ collapsed, onToggle }: ExplorerProps) {
   const { client } = useOpenCodeClient();
   const { selectedModel, selectedAgent } = usePreferences();
@@ -161,7 +153,6 @@ export default function Explorer({ collapsed, onToggle }: ExplorerProps) {
   const syncLatestRef = useRef<() => void>(() => undefined);
   const [syncing, setSyncing] = useState(false);
   const [syncError, setSyncError] = useState<string | null>(null);
-  const [now, setNow] = useState(() => Date.now());
   const [expanded, setExpanded] = useState<Set<string>>(() => new Set());
   const [selectedPath, setSelectedPath] = useState<string | null>(null);
 
@@ -208,7 +199,6 @@ export default function Explorer({ collapsed, onToggle }: ExplorerProps) {
         if (cancelled) return;
         collectionRef.current = next;
         setCollection(next);
-        setNow(Date.now());
         setExpanded((currentExpanded) =>
           currentExpanded.size > 0
             ? currentExpanded
@@ -229,11 +219,9 @@ export default function Explorer({ collapsed, onToggle }: ExplorerProps) {
     syncLatestRef.current = () => void sync();
     void sync();
     const interval = window.setInterval(() => void sync(), SYNC_INTERVAL_MS);
-    const freshness = window.setInterval(() => setNow(Date.now()), 10_000);
     return () => {
       cancelled = true;
       window.clearInterval(interval);
-      window.clearInterval(freshness);
     };
   }, [client, collapsed, model, selectedAgent]);
 
@@ -274,38 +262,25 @@ export default function Explorer({ collapsed, onToggle }: ExplorerProps) {
 
   return (
     <aside className="flex w-72 shrink-0 flex-col border-l bg-sidebar">
-      <div className="flex h-10 shrink-0 items-center justify-between border-b px-3">
-        <div className="flex min-w-0 items-center gap-2">
-          <Boxes size={14} />
-          <div className="min-w-0">
-            <div className="text-[11px] font-semibold uppercase tracking-[0.12em]">Explorer</div>
-            <div className="flex items-center gap-1.5 text-[9px] text-muted-foreground">
-              <span
-                className={`h-1.5 w-1.5 rounded-full ${syncError ? "bg-amber-500" : syncing ? "animate-pulse bg-blue-500" : "bg-emerald-500"}`}
-              />
-              <span className="truncate">
-                {syncing && !collection
-                  ? "Building collector…"
-                  : syncing
-                    ? "Syncing…"
-                    : syncError
-                      ? "Retrying automatically"
-                      : collection
-                        ? freshnessLabel(collection.snapshot.capturedAt, now)
-                        : "Waiting to sync"}
-              </span>
-            </div>
-          </div>
+      <header className="flex min-h-[81px] shrink-0 items-start justify-between border-b px-5 py-4">
+        <div>
+          <h2 className="font-serif text-xl italic">Explorer</h2>
         </div>
         <button
           type="button"
           onClick={onToggle}
-          aria-label="Collapse Explorer"
-          className="rounded p-1.5 text-muted-foreground hover:bg-accent hover:text-foreground"
+          className="rounded-md px-2 py-1 text-lg text-muted-foreground hover:bg-accent hover:text-foreground"
+          aria-label="Close explorer"
         >
-          <ChevronLeft size={13} />
+          ×
         </button>
-      </div>
+      </header>
+
+      {syncError ? (
+        <div className="shrink-0 border-b border-amber-200 bg-amber-50 px-4 py-2 text-[10px] text-amber-800 dark:border-amber-900 dark:bg-amber-950/30 dark:text-amber-300">
+          Reconnect Studio if needed; Explorer will retry automatically.
+        </div>
+      ) : null}
 
       <div
         className="min-h-0 flex-1 overflow-y-auto py-1"
@@ -313,11 +288,6 @@ export default function Explorer({ collapsed, onToggle }: ExplorerProps) {
         aria-label="Instance hierarchy"
       >
         {!collection && syncing ? <ExplorerLoading /> : null}
-        {!collection && syncError ? (
-          <div className="px-4 py-8 text-center text-xs text-muted-foreground">
-            Explorer will retry when Studio is available.
-          </div>
-        ) : null}
         {collection?.snapshot.roots.map((node) => (
           <TreeRow
             key={node.path}

--- a/src/components/Explorer.tsx
+++ b/src/components/Explorer.tsx
@@ -20,23 +20,26 @@ import posthog from "posthog-js/dist/module.full.no-external.js";
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
 import { explorerAnalyticsProperties } from "@/lib/analytics";
+import { desktop } from "@/lib/desktop";
 import {
   createExplorerReference,
   type ExplorerCollection,
   type ExplorerField,
   type ExplorerNode,
-  generateExplorerCollection,
-  replayExplorerCollector,
+  generateExplorerProgram,
 } from "@/lib/explorer";
 import { splitModelKey } from "@/lib/splitModelKey";
 import { useExplorerReference } from "@/providers/ExplorerReferenceProvider";
 import { useOpenCodeClient } from "@/providers/OpenCodeClientProvider";
 import { usePreferences } from "@/providers/PreferencesProvider";
 
-const SYNC_INTERVAL_MS = 20_000;
+const ACTIVE_SYNC_MS = 2_500;
+const IDLE_SYNC_MS = 5_000;
+const MAX_UNCHANGED_SYNC_MS = 30_000;
 
 interface ExplorerProps {
   collapsed: boolean;
+  sessionBusy: boolean;
   onToggle: () => void;
 }
 
@@ -148,7 +151,7 @@ function countNodes(nodes: readonly ExplorerNode[]): number {
   return nodes.reduce((total, node) => total + 1 + countNodes(node.children), 0);
 }
 
-export default function Explorer({ collapsed, onToggle }: ExplorerProps) {
+export default function Explorer({ collapsed, sessionBusy, onToggle }: ExplorerProps) {
   const { client } = useOpenCodeClient();
   const { selectedModel, selectedAgent } = usePreferences();
   const { referenceObject } = useExplorerReference();
@@ -177,13 +180,25 @@ export default function Explorer({ collapsed, onToggle }: ExplorerProps) {
     if (!client || collapsed) return;
     const activeClient = client;
     let cancelled = false;
+    let timer: number | undefined;
+    let unchangedPolls = 0;
+
+    function scheduleNext() {
+      if (cancelled) return;
+      const baseDelay = sessionBusy ? ACTIVE_SYNC_MS : IDLE_SYNC_MS;
+      const delay = Math.min(baseDelay * 2 ** Math.min(unchangedPolls, 3), MAX_UNCHANGED_SYNC_MS);
+      timer = window.setTimeout(() => void sync(), delay);
+    }
 
     async function sync() {
       if (syncingRef.current) {
         resyncRequestedRef.current = true;
         return;
       }
-      if (document.visibilityState === "hidden") return;
+      if (document.visibilityState === "hidden" || !document.hasFocus()) {
+        scheduleNext();
+        return;
+      }
       syncingRef.current = true;
       setSyncing(true);
       setSyncError(null);
@@ -200,7 +215,10 @@ export default function Explorer({ collapsed, onToggle }: ExplorerProps) {
           reason,
         });
         try {
-          const generated = await generateExplorerCollection(activeClient, model, selectedAgent);
+          const program = await generateExplorerProgram(activeClient, model, selectedAgent);
+          const artifact = await desktop.compileExplorerProgram(program);
+          const snapshot = await desktop.invokeExplorerProgram(artifact);
+          const generated: ExplorerCollection = { program, artifact, snapshot };
           posthog.capture(
             "collector_generation_succeeded",
             explorerAnalyticsProperties({
@@ -230,16 +248,11 @@ export default function Explorer({ collapsed, onToggle }: ExplorerProps) {
         let next: ExplorerCollection;
         if (current) {
           try {
-            const snapshot = await replayExplorerCollector(
-              activeClient,
-              current.collector,
-              model,
-              selectedAgent,
-            );
-            next = { collector: current.collector, snapshot };
+            const snapshot = await desktop.invokeExplorerProgram(current.artifact);
+            next = { ...current, snapshot };
           } catch {
             telemetryRef.current.hadFailure = true;
-            posthog.capture("sync_failed", { reason: "collector_replay" });
+            posthog.capture("sync_failed", { reason: "collector_runtime" });
             next = await generate("contract_recovery");
           }
         } else {
@@ -247,6 +260,14 @@ export default function Explorer({ collapsed, onToggle }: ExplorerProps) {
         }
 
         if (cancelled) return;
+        const previousComparable = current
+          ? JSON.stringify({ placeName: current.snapshot.placeName, roots: current.snapshot.roots })
+          : null;
+        const nextComparable = JSON.stringify({
+          placeName: next.snapshot.placeName,
+          roots: next.snapshot.roots,
+        });
+        unchangedPolls = previousComparable === nextComparable ? unchangedPolls + 1 : 0;
         collectionRef.current = next;
         setCollection(next);
         setExpanded((currentExpanded) =>
@@ -283,18 +304,27 @@ export default function Explorer({ collapsed, onToggle }: ExplorerProps) {
         if (resyncRequestedRef.current) {
           resyncRequestedRef.current = false;
           queueMicrotask(() => syncLatestRef.current());
-        }
+        } else scheduleNext();
       }
     }
 
     syncLatestRef.current = () => void sync();
     void sync();
-    const interval = window.setInterval(() => void sync(), SYNC_INTERVAL_MS);
+    const resume = () => {
+      if (document.visibilityState === "visible" && document.hasFocus()) {
+        if (timer !== undefined) window.clearTimeout(timer);
+        void sync();
+      }
+    };
+    document.addEventListener("visibilitychange", resume);
+    window.addEventListener("focus", resume);
     return () => {
       cancelled = true;
-      window.clearInterval(interval);
+      if (timer !== undefined) window.clearTimeout(timer);
+      document.removeEventListener("visibilitychange", resume);
+      window.removeEventListener("focus", resume);
     };
-  }, [client, collapsed, model, selectedAgent]);
+  }, [client, collapsed, model, selectedAgent, sessionBusy]);
 
   const toggleNode = useCallback((path: string) => {
     setExpanded((current) => {

--- a/src/hooks/useSessions.ts
+++ b/src/hooks/useSessions.ts
@@ -2,6 +2,7 @@ import type { Session } from "@opencode-ai/sdk/v2/client";
 import { useQuery } from "@tanstack/react-query";
 
 import { qk } from "@/lib/queryKeys";
+import { isVisibleSession } from "@/lib/sessionVisibility";
 import { useOpenCodeClient } from "@/providers/OpenCodeClientProvider";
 
 export function useSessions() {
@@ -13,7 +14,7 @@ export function useSessions() {
       if (!client) return [];
       const res = await client.session.list({}, { throwOnError: true });
       if (!res.data) return [];
-      return [...res.data].sort((a, b) => b.time.created - a.time.created);
+      return res.data.filter(isVisibleSession).sort((a, b) => b.time.created - a.time.created);
     },
     enabled: ready && !!client,
   });

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -20,3 +20,24 @@ export function captureDetailedAnalytics(
 ): void {
   if (detailedAnalyticsEnabled) posthog.capture(event, properties);
 }
+
+const EXPLORER_ANALYTICS_KEYS = new Set([
+  "class_category",
+  "duration_ms",
+  "has_attributes",
+  "model_mediated",
+  "node_count",
+  "reason",
+  "root_count",
+  "source",
+]);
+
+export function explorerAnalyticsProperties(properties: Properties): Properties {
+  return Object.fromEntries(
+    Object.entries(properties).filter(
+      ([key, value]) =>
+        EXPLORER_ANALYTICS_KEYS.has(key) &&
+        (typeof value === "string" || typeof value === "number" || typeof value === "boolean"),
+    ),
+  );
+}

--- a/src/lib/desktop.ts
+++ b/src/lib/desktop.ts
@@ -1,4 +1,5 @@
 import { Data, Effect, Schema } from "effect";
+import { ExplorerSnapshotSchema } from "@/lib/explorer";
 import {
   type AppConfig,
   AppConfigPatchSchema,
@@ -11,6 +12,7 @@ import {
   type UpdateInfo,
   UpdateInfoSchema,
 } from "@/types/desktop";
+import { GeneratedProgramArtifactSchema } from "@/types/generatedProgram";
 
 const CONFIG_KEY = "bloxbot-config";
 const DEFAULT_CONFIG: AppConfig = DEFAULT_APP_CONFIG;
@@ -21,6 +23,16 @@ export class DesktopError extends Data.TaggedError("DesktopError")<{
 }> {}
 
 interface DesktopEffects {
+  readonly compileExplorerProgram: DesktopApi["compileExplorerProgram"] extends (
+    input: infer Input,
+  ) => Promise<infer Output>
+    ? (input: Input) => Effect.Effect<Output, DesktopError>
+    : never;
+  readonly invokeExplorerProgram: DesktopApi["invokeExplorerProgram"] extends (
+    input: infer Input,
+  ) => Promise<infer Output>
+    ? (input: Input) => Effect.Effect<Output, DesktopError>
+    : never;
   readonly getOpenCodeInfo: Effect.Effect<OpenCodeInfo, DesktopError>;
   readonly getVersion: Effect.Effect<string, DesktopError>;
   readonly openUrl: (url: string) => Effect.Effect<void, DesktopError>;
@@ -53,6 +65,8 @@ const loadBrowserConfig = Effect.gen(function* () {
 }).pipe(Effect.catchAll(() => Effect.succeed(DEFAULT_CONFIG)));
 
 const browserEffects: DesktopEffects = {
+  compileExplorerProgram: () =>
+    Effect.fail(new DesktopError({ message: "Explorer requires the desktop app." })),
   getOpenCodeInfo: Effect.fail(
     new DesktopError({
       message: "The desktop service is unavailable. Start BloxBot with pnpm dev.",
@@ -81,6 +95,8 @@ const browserEffects: DesktopEffects = {
   installUpdate: Effect.fail(
     new DesktopError({ message: "Updates are only available in the desktop app." }),
   ),
+  invokeExplorerProgram: () =>
+    Effect.fail(new DesktopError({ message: "Explorer requires the desktop app." })),
   relaunch: Effect.sync(() => window.location.reload()),
 };
 
@@ -106,6 +122,10 @@ const decodeBridgeValue =
 
 function makeBridgeEffects(api: DesktopApi): DesktopEffects {
   return {
+    compileExplorerProgram: (program) =>
+      invoke("Failed to compile Explorer program", () => api.compileExplorerProgram(program)).pipe(
+        decodeBridgeValue("Explorer program artifact is invalid", GeneratedProgramArtifactSchema),
+      ),
     getOpenCodeInfo: invoke("Failed to get OpenCode connection details", () =>
       api.getOpenCodeInfo(),
     ).pipe(decodeBridgeValue("OpenCode connection details are invalid", OpenCodeInfoSchema)),
@@ -121,6 +141,10 @@ function makeBridgeEffects(api: DesktopApi): DesktopEffects {
       decodeBridgeValue("Update information is invalid", Schema.NullOr(UpdateInfoSchema)),
     ),
     installUpdate: invoke("Failed to install the update", () => api.installUpdate()),
+    invokeExplorerProgram: (artifact) =>
+      invoke("Failed to invoke Explorer program", () => api.invokeExplorerProgram(artifact)).pipe(
+        decodeBridgeValue("Explorer snapshot is invalid", ExplorerSnapshotSchema),
+      ),
     relaunch: invoke("Failed to relaunch the app", () => api.relaunch()),
   };
 }
@@ -134,6 +158,7 @@ const runPromise = <A>(effect: Effect.Effect<A, DesktopError>): Promise<A> =>
 
 /** Promise-only adapter consumed by React and exposed by the Electron bridge contract. */
 export const desktop: DesktopApi = {
+  compileExplorerProgram: (program) => runPromise(desktopEffects.compileExplorerProgram(program)),
   getOpenCodeInfo: () => runPromise(desktopEffects.getOpenCodeInfo),
   onOpenCodeStartupProgress: (listener: StartupProgressListener) =>
     window.bloxbot?.onOpenCodeStartupProgress(listener) ?? (() => {}),
@@ -143,5 +168,6 @@ export const desktop: DesktopApi = {
   patchConfig: (patch) => runPromise(desktopEffects.patchConfig(patch)),
   checkForUpdate: () => runPromise(desktopEffects.checkForUpdate),
   installUpdate: () => runPromise(desktopEffects.installUpdate),
+  invokeExplorerProgram: (artifact) => runPromise(desktopEffects.invokeExplorerProgram(artifact)),
   relaunch: () => runPromise(desktopEffects.relaunch),
 };

--- a/src/lib/explorer.ts
+++ b/src/lib/explorer.ts
@@ -1,5 +1,6 @@
 import type { OpencodeClient } from "@opencode-ai/sdk/v2/client";
 import { Effect, Schema } from "effect";
+import type { GeneratedProgramArtifact, GeneratedProgramEnvelope } from "../types/generatedProgram";
 
 export const ExplorerFieldSchema = Schema.Struct({
   name: Schema.String,
@@ -36,12 +37,31 @@ export const ExplorerSnapshotSchema = Schema.Struct({
 
 export type ExplorerSnapshot = typeof ExplorerSnapshotSchema.Type;
 
-export const ExplorerCollectionSchema = Schema.Struct({
-  collector: Schema.String.pipe(Schema.minLength(1), Schema.maxLength(12_000)),
-  snapshot: ExplorerSnapshotSchema,
+export const EXPLORER_CONTRACT = {
+  name: "explorer-snapshot",
+  version: "1",
+  inputSchemaVersion: "explorer-input-v1",
+  outputSchemaVersion: "explorer-snapshot-v1",
+} as const;
+
+export const ExplorerProgramEnvelopeSchema = Schema.Struct({
+  version: Schema.Literal(1),
+  contract: Schema.Struct({
+    name: Schema.Literal(EXPLORER_CONTRACT.name),
+    version: Schema.Literal(EXPLORER_CONTRACT.version),
+    inputSchemaVersion: Schema.Literal(EXPLORER_CONTRACT.inputSchemaVersion),
+    outputSchemaVersion: Schema.Literal(EXPLORER_CONTRACT.outputSchemaVersion),
+  }),
+  source: Schema.String.pipe(Schema.minLength(1), Schema.maxLength(100_000)),
 });
 
-export type ExplorerCollection = typeof ExplorerCollectionSchema.Type;
+export type ExplorerProgramEnvelope = typeof ExplorerProgramEnvelopeSchema.Type;
+
+export interface ExplorerCollection {
+  readonly program: GeneratedProgramEnvelope;
+  readonly artifact: GeneratedProgramArtifact;
+  readonly snapshot: ExplorerSnapshot;
+}
 
 const FIELD_JSON_SCHEMA = {
   type: "object",
@@ -71,20 +91,25 @@ const SNAPSHOT_PROPERTIES = {
   roots: { type: "array", items: { $ref: "#/$defs/node" } },
 } as const;
 
-export const EXPLORER_COLLECTION_OUTPUT_SCHEMA = {
+export const EXPLORER_PROGRAM_OUTPUT_SCHEMA = {
   type: "object",
   additionalProperties: false,
-  required: ["collector", "snapshot"],
+  required: ["version", "contract", "source"],
   properties: {
-    collector: { type: "string", minLength: 1, maxLength: 12_000 },
-    snapshot: {
+    version: { const: 1 },
+    contract: {
       type: "object",
       additionalProperties: false,
-      required: ["placeName", "capturedAt", "roots"],
-      properties: SNAPSHOT_PROPERTIES,
+      required: ["name", "version", "inputSchemaVersion", "outputSchemaVersion"],
+      properties: {
+        name: { const: EXPLORER_CONTRACT.name },
+        version: { const: EXPLORER_CONTRACT.version },
+        inputSchemaVersion: { const: EXPLORER_CONTRACT.inputSchemaVersion },
+        outputSchemaVersion: { const: EXPLORER_CONTRACT.outputSchemaVersion },
+      },
     },
+    source: { type: "string", minLength: 1, maxLength: 100_000 },
   },
-  $defs: { node: NODE_JSON_SCHEMA },
 } as const;
 
 export const EXPLORER_SNAPSHOT_OUTPUT_SCHEMA = {
@@ -95,17 +120,13 @@ export const EXPLORER_SNAPSHOT_OUTPUT_SCHEMA = {
   $defs: { node: NODE_JSON_SCHEMA },
 } as const;
 
-const INITIAL_SYSTEM_PROMPT = `You are the private data provider for BloxBot's Explorer panel.
-Discover the currently available capabilities and design a deterministic, read-only collector that can be rerun verbatim to inspect the connected Roblox Studio place.
-The collector may be a small program or precise execution instructions. It must contain everything a future agent needs to rerun it without rediscovering or replanning, and it must never modify the place.
-Run the collector now and return both the exact collector and a snapshot. Do not rely on earlier conversation context.
+const INITIAL_SYSTEM_PROMPT = `You generate the private TypeScript data provider for BloxBot's Explorer panel.
+Discover the currently available Studio MCP tools and return an import-free deterministic read-only TypeScript program.
+The source must define async function run({ input, callTool }) and return an Explorer snapshot matching the requested output contract. Use callTool directly with the exact discovered tool names and arguments. It must never modify the place.
+Do not run a recurring model-mediated replay. The app will compile this source once and invoke it directly for every refresh.
 For every object include a compact set of useful, readable properties and all available attributes. Stringify values safely.
 Paths are dot-separated human-readable hints, not durable identifiers. Keep children in Studio order.
 Return only the requested structured output.`;
-
-const REPLAY_SYSTEM_PROMPT = `You are the private data provider for BloxBot's Explorer panel.
-Rerun the supplied collector exactly as written against the currently connected place. Do not rediscover capabilities, redesign the collector, or modify the place.
-Return a fresh snapshot only. Paths are hints, not durable identifiers. Return only the requested structured output.`;
 
 interface ExplorerModel {
   providerID: string;
@@ -132,11 +153,11 @@ async function withPrivateSession<T>(
   }
 }
 
-export async function generateExplorerCollection(
+export async function generateExplorerProgram(
   client: OpencodeClient,
   model?: ExplorerModel,
   agent?: string | null,
-): Promise<ExplorerCollection> {
+): Promise<ExplorerProgramEnvelope> {
   return withPrivateSession(client, async (sessionID) => {
     const response = await client.session.prompt(
       {
@@ -144,11 +165,11 @@ export async function generateExplorerCollection(
         model,
         agent: agent ?? undefined,
         system: INITIAL_SYSTEM_PROMPT,
-        format: { type: "json_schema", schema: EXPLORER_COLLECTION_OUTPUT_SCHEMA, retryCount: 2 },
+        format: { type: "json_schema", schema: EXPLORER_PROGRAM_OUTPUT_SCHEMA, retryCount: 2 },
         parts: [
           {
             type: "text",
-            text: "Discover a safe read-only collection method, retain it as the collector, and run it for the initial Explorer snapshot.",
+            text: "Discover the read-only Studio tools and generate the reusable TypeScript Explorer program.",
           },
         ],
       },
@@ -156,37 +177,7 @@ export async function generateExplorerCollection(
     );
 
     return Effect.runPromise(
-      Schema.decodeUnknown(ExplorerCollectionSchema)(response.data.info.structured),
-    );
-  });
-}
-
-export async function replayExplorerCollector(
-  client: OpencodeClient,
-  collector: string,
-  model?: ExplorerModel,
-  agent?: string | null,
-): Promise<ExplorerSnapshot> {
-  return withPrivateSession(client, async (sessionID) => {
-    const response = await client.session.prompt(
-      {
-        sessionID,
-        model,
-        agent: agent ?? undefined,
-        system: REPLAY_SYSTEM_PROMPT,
-        format: { type: "json_schema", schema: EXPLORER_SNAPSHOT_OUTPUT_SCHEMA, retryCount: 1 },
-        parts: [
-          {
-            type: "text",
-            text: `Rerun this exact read-only collector:\n\n<collector>\n${collector}\n</collector>`,
-          },
-        ],
-      },
-      { throwOnError: true },
-    );
-
-    return Effect.runPromise(
-      Schema.decodeUnknown(ExplorerSnapshotSchema)(response.data.info.structured),
+      Schema.decodeUnknown(ExplorerProgramEnvelopeSchema)(response.data.info.structured),
     );
   });
 }

--- a/src/lib/explorer.ts
+++ b/src/lib/explorer.ts
@@ -1,11 +1,20 @@
 import type { OpencodeClient } from "@opencode-ai/sdk/v2/client";
 import { Effect, Schema } from "effect";
 
+export const ExplorerFieldSchema = Schema.Struct({
+  name: Schema.String,
+  value: Schema.String,
+});
+
+export type ExplorerField = typeof ExplorerFieldSchema.Type;
+
 export const ExplorerNodeSchema = Schema.Struct({
   name: Schema.String,
   className: Schema.String,
   path: Schema.String,
   hasChildren: Schema.Boolean,
+  properties: Schema.Array(ExplorerFieldSchema),
+  attributes: Schema.Array(ExplorerFieldSchema),
   children: Schema.Array(Schema.suspend((): Schema.Schema<ExplorerNode> => ExplorerNodeSchema)),
 });
 
@@ -14,6 +23,8 @@ export interface ExplorerNode {
   readonly className: string;
   readonly path: string;
   readonly hasChildren: boolean;
+  readonly properties: readonly ExplorerField[];
+  readonly attributes: readonly ExplorerField[];
   readonly children: readonly ExplorerNode[];
 }
 
@@ -25,50 +36,89 @@ export const ExplorerSnapshotSchema = Schema.Struct({
 
 export type ExplorerSnapshot = typeof ExplorerSnapshotSchema.Type;
 
-export const EXPLORER_OUTPUT_SCHEMA = {
+export const ExplorerCollectionSchema = Schema.Struct({
+  collector: Schema.String.pipe(Schema.minLength(1), Schema.maxLength(12_000)),
+  snapshot: ExplorerSnapshotSchema,
+});
+
+export type ExplorerCollection = typeof ExplorerCollectionSchema.Type;
+
+const FIELD_JSON_SCHEMA = {
   type: "object",
   additionalProperties: false,
-  required: ["placeName", "capturedAt", "roots"],
+  required: ["name", "value"],
+  properties: { name: { type: "string" }, value: { type: "string" } },
+} as const;
+
+const NODE_JSON_SCHEMA = {
+  type: "object",
+  additionalProperties: false,
+  required: ["name", "className", "path", "hasChildren", "properties", "attributes", "children"],
   properties: {
-    placeName: { type: "string" },
-    capturedAt: { type: "string" },
-    roots: {
-      type: "array",
-      items: { $ref: "#/$defs/node" },
-    },
-  },
-  $defs: {
-    node: {
-      type: "object",
-      additionalProperties: false,
-      required: ["name", "className", "path", "hasChildren", "children"],
-      properties: {
-        name: { type: "string" },
-        className: { type: "string" },
-        path: { type: "string" },
-        hasChildren: { type: "boolean" },
-        children: { type: "array", items: { $ref: "#/$defs/node" } },
-      },
-    },
+    name: { type: "string" },
+    className: { type: "string" },
+    path: { type: "string" },
+    hasChildren: { type: "boolean" },
+    properties: { type: "array", items: FIELD_JSON_SCHEMA, maxItems: 16 },
+    attributes: { type: "array", items: FIELD_JSON_SCHEMA, maxItems: 24 },
+    children: { type: "array", items: { $ref: "#/$defs/node" } },
   },
 } as const;
 
-const EXPLORER_SYSTEM_PROMPT = `You are the private data provider for BloxBot's Explorer panel.
-Inspect the currently connected Roblox Studio place using the capabilities available to you.
-Return a fresh instance hierarchy, including common top-level services and their descendants.
-Do not change the place. Do not rely on earlier conversation context. Discover the active place now.
-Paths are dot-separated human-readable hints, not durable identifiers. Keep each node's children in Studio order.
-Set hasChildren true when the object has descendants, even if a safety limit prevents returning all of them.
+const SNAPSHOT_PROPERTIES = {
+  placeName: { type: "string" },
+  capturedAt: { type: "string" },
+  roots: { type: "array", items: { $ref: "#/$defs/node" } },
+} as const;
+
+export const EXPLORER_COLLECTION_OUTPUT_SCHEMA = {
+  type: "object",
+  additionalProperties: false,
+  required: ["collector", "snapshot"],
+  properties: {
+    collector: { type: "string", minLength: 1, maxLength: 12_000 },
+    snapshot: {
+      type: "object",
+      additionalProperties: false,
+      required: ["placeName", "capturedAt", "roots"],
+      properties: SNAPSHOT_PROPERTIES,
+    },
+  },
+  $defs: { node: NODE_JSON_SCHEMA },
+} as const;
+
+export const EXPLORER_SNAPSHOT_OUTPUT_SCHEMA = {
+  type: "object",
+  additionalProperties: false,
+  required: ["placeName", "capturedAt", "roots"],
+  properties: SNAPSHOT_PROPERTIES,
+  $defs: { node: NODE_JSON_SCHEMA },
+} as const;
+
+const INITIAL_SYSTEM_PROMPT = `You are the private data provider for BloxBot's Explorer panel.
+Discover the currently available capabilities and design a deterministic, read-only collector that can be rerun verbatim to inspect the connected Roblox Studio place.
+The collector may be a small program or precise execution instructions. It must contain everything a future agent needs to rerun it without rediscovering or replanning, and it must never modify the place.
+Run the collector now and return both the exact collector and a snapshot. Do not rely on earlier conversation context.
+For every object include a compact set of useful, readable properties and all available attributes. Stringify values safely.
+Paths are dot-separated human-readable hints, not durable identifiers. Keep children in Studio order.
 Return only the requested structured output.`;
 
-export async function loadExplorerSnapshot(
+const REPLAY_SYSTEM_PROMPT = `You are the private data provider for BloxBot's Explorer panel.
+Rerun the supplied collector exactly as written against the currently connected place. Do not rediscover capabilities, redesign the collector, or modify the place.
+Return a fresh snapshot only. Paths are hints, not durable identifiers. Return only the requested structured output.`;
+
+interface ExplorerModel {
+  providerID: string;
+  modelID: string;
+}
+
+async function withPrivateSession<T>(
   client: OpencodeClient,
-  model?: { providerID: string; modelID: string },
-  agent?: string | null,
-): Promise<ExplorerSnapshot> {
+  run: (sessionID: string) => Promise<T>,
+): Promise<T> {
   const created = await client.session.create(
     {
-      title: "BloxBot Explorer refresh",
+      title: "BloxBot Explorer sync",
       metadata: { bloxbotHidden: true, purpose: "explorer" },
     },
     { throwOnError: true },
@@ -76,29 +126,69 @@ export async function loadExplorerSnapshot(
   const sessionID = created.data.id;
 
   try {
+    return await run(sessionID);
+  } finally {
+    await client.session.delete({ sessionID }, { throwOnError: true }).catch(() => undefined);
+  }
+}
+
+export async function generateExplorerCollection(
+  client: OpencodeClient,
+  model?: ExplorerModel,
+  agent?: string | null,
+): Promise<ExplorerCollection> {
+  return withPrivateSession(client, async (sessionID) => {
     const response = await client.session.prompt(
       {
         sessionID,
         model,
         agent: agent ?? undefined,
-        system: EXPLORER_SYSTEM_PROMPT,
-        format: { type: "json_schema", schema: EXPLORER_OUTPUT_SCHEMA, retryCount: 2 },
+        system: INITIAL_SYSTEM_PROMPT,
+        format: { type: "json_schema", schema: EXPLORER_COLLECTION_OUTPUT_SCHEMA, retryCount: 2 },
         parts: [
           {
             type: "text",
-            text: "Read the connected place and produce the Explorer snapshot now.",
+            text: "Discover a safe read-only collection method, retain it as the collector, and run it for the initial Explorer snapshot.",
           },
         ],
       },
       { throwOnError: true },
     );
 
-    return await Effect.runPromise(
+    return Effect.runPromise(
+      Schema.decodeUnknown(ExplorerCollectionSchema)(response.data.info.structured),
+    );
+  });
+}
+
+export async function replayExplorerCollector(
+  client: OpencodeClient,
+  collector: string,
+  model?: ExplorerModel,
+  agent?: string | null,
+): Promise<ExplorerSnapshot> {
+  return withPrivateSession(client, async (sessionID) => {
+    const response = await client.session.prompt(
+      {
+        sessionID,
+        model,
+        agent: agent ?? undefined,
+        system: REPLAY_SYSTEM_PROMPT,
+        format: { type: "json_schema", schema: EXPLORER_SNAPSHOT_OUTPUT_SCHEMA, retryCount: 1 },
+        parts: [
+          {
+            type: "text",
+            text: `Rerun this exact read-only collector:\n\n<collector>\n${collector}\n</collector>`,
+          },
+        ],
+      },
+      { throwOnError: true },
+    );
+
+    return Effect.runPromise(
       Schema.decodeUnknown(ExplorerSnapshotSchema)(response.data.info.structured),
     );
-  } finally {
-    await client.session.delete({ sessionID }, { throwOnError: true }).catch(() => undefined);
-  }
+  });
 }
 
 export function createExplorerReference(node: ExplorerNode): string {

--- a/src/lib/explorer.ts
+++ b/src/lib/explorer.ts
@@ -1,0 +1,109 @@
+import type { OpencodeClient } from "@opencode-ai/sdk/v2/client";
+import { Effect, Schema } from "effect";
+
+export const ExplorerNodeSchema = Schema.Struct({
+  name: Schema.String,
+  className: Schema.String,
+  path: Schema.String,
+  hasChildren: Schema.Boolean,
+  children: Schema.Array(Schema.suspend((): Schema.Schema<ExplorerNode> => ExplorerNodeSchema)),
+});
+
+export interface ExplorerNode {
+  readonly name: string;
+  readonly className: string;
+  readonly path: string;
+  readonly hasChildren: boolean;
+  readonly children: readonly ExplorerNode[];
+}
+
+export const ExplorerSnapshotSchema = Schema.Struct({
+  placeName: Schema.String,
+  capturedAt: Schema.String,
+  roots: Schema.Array(ExplorerNodeSchema),
+});
+
+export type ExplorerSnapshot = typeof ExplorerSnapshotSchema.Type;
+
+export const EXPLORER_OUTPUT_SCHEMA = {
+  type: "object",
+  additionalProperties: false,
+  required: ["placeName", "capturedAt", "roots"],
+  properties: {
+    placeName: { type: "string" },
+    capturedAt: { type: "string" },
+    roots: {
+      type: "array",
+      items: { $ref: "#/$defs/node" },
+    },
+  },
+  $defs: {
+    node: {
+      type: "object",
+      additionalProperties: false,
+      required: ["name", "className", "path", "hasChildren", "children"],
+      properties: {
+        name: { type: "string" },
+        className: { type: "string" },
+        path: { type: "string" },
+        hasChildren: { type: "boolean" },
+        children: { type: "array", items: { $ref: "#/$defs/node" } },
+      },
+    },
+  },
+} as const;
+
+const EXPLORER_SYSTEM_PROMPT = `You are the private data provider for BloxBot's Explorer panel.
+Inspect the currently connected Roblox Studio place using the capabilities available to you.
+Return a fresh instance hierarchy, including common top-level services and their descendants.
+Do not change the place. Do not rely on earlier conversation context. Discover the active place now.
+Paths are dot-separated human-readable hints, not durable identifiers. Keep each node's children in Studio order.
+Set hasChildren true when the object has descendants, even if a safety limit prevents returning all of them.
+Return only the requested structured output.`;
+
+export async function loadExplorerSnapshot(
+  client: OpencodeClient,
+  model?: { providerID: string; modelID: string },
+  agent?: string | null,
+): Promise<ExplorerSnapshot> {
+  const created = await client.session.create(
+    {
+      title: "BloxBot Explorer refresh",
+      metadata: { bloxbotHidden: true, purpose: "explorer" },
+    },
+    { throwOnError: true },
+  );
+  const sessionID = created.data.id;
+
+  try {
+    const response = await client.session.prompt(
+      {
+        sessionID,
+        model,
+        agent: agent ?? undefined,
+        system: EXPLORER_SYSTEM_PROMPT,
+        format: { type: "json_schema", schema: EXPLORER_OUTPUT_SCHEMA, retryCount: 2 },
+        parts: [
+          {
+            type: "text",
+            text: "Read the connected place and produce the Explorer snapshot now.",
+          },
+        ],
+      },
+      { throwOnError: true },
+    );
+
+    return await Effect.runPromise(
+      Schema.decodeUnknown(ExplorerSnapshotSchema)(response.data.info.structured),
+    );
+  } finally {
+    await client.session.delete({ sessionID }, { throwOnError: true }).catch(() => undefined);
+  }
+}
+
+export function createExplorerReference(node: ExplorerNode): string {
+  return (
+    `Regarding the ${node.className} at \`${node.path}\`: ` +
+    "treat this path only as a hint. Rediscover the object in the connected place and verify its identity and current state immediately before taking any action."
+  );
+}

--- a/src/lib/sessionVisibility.ts
+++ b/src/lib/sessionVisibility.ts
@@ -1,0 +1,5 @@
+import type { Session } from "@opencode-ai/sdk/v2/client";
+
+export function isVisibleSession(session: Session): boolean {
+  return session.metadata?.bloxbotHidden !== true;
+}

--- a/src/lib/sseDispatch.ts
+++ b/src/lib/sseDispatch.ts
@@ -10,6 +10,7 @@ import type { QueryClient } from "@tanstack/react-query";
 import { Data, Effect, Schema } from "effect";
 import type { ModelError } from "@/lib/modelError";
 import { qk } from "@/lib/queryKeys";
+import { isVisibleSession } from "@/lib/sessionVisibility";
 import type { MessageWithParts } from "@/types";
 
 export interface MessagesCache {
@@ -92,6 +93,7 @@ function dispatchEvent(
   switch (event.type) {
     case "session.created": {
       const { info } = event.properties;
+      if (!isVisibleSession(info)) break;
       queryClient.setQueryData<Session[]>(qk.sessions, (prev) => {
         if (!prev) return [info];
         if (prev.some((s) => s.id === info.id)) return prev;

--- a/src/providers/ExplorerReferenceProvider.tsx
+++ b/src/providers/ExplorerReferenceProvider.tsx
@@ -1,0 +1,29 @@
+import { createContext, type ReactNode, useCallback, useContext, useMemo, useState } from "react";
+
+interface ExplorerReferenceContextValue {
+  pendingReference: string | null;
+  referenceObject: (prompt: string) => void;
+  consumeReference: () => void;
+}
+
+const ExplorerReferenceContext = createContext<ExplorerReferenceContextValue | null>(null);
+
+export function ExplorerReferenceProvider({ children }: { children: ReactNode }) {
+  const [pendingReference, setPendingReference] = useState<string | null>(null);
+  const referenceObject = useCallback((prompt: string) => setPendingReference(prompt), []);
+  const consumeReference = useCallback(() => setPendingReference(null), []);
+  const value = useMemo(
+    () => ({ pendingReference, referenceObject, consumeReference }),
+    [pendingReference, referenceObject, consumeReference],
+  );
+
+  return (
+    <ExplorerReferenceContext.Provider value={value}>{children}</ExplorerReferenceContext.Provider>
+  );
+}
+
+export function useExplorerReference() {
+  const value = useContext(ExplorerReferenceContext);
+  if (!value) throw new Error("useExplorerReference must be used inside ExplorerReferenceProvider");
+  return value;
+}

--- a/src/test/ChatInput.test.tsx
+++ b/src/test/ChatInput.test.tsx
@@ -16,6 +16,7 @@ import { Toaster } from "@/components/ui/sonner";
 import { qk } from "@/lib/queryKeys";
 import type { MessagesCache } from "@/lib/sseDispatch";
 import { ActiveSessionContext } from "@/providers/ActiveSessionProvider";
+import { ExplorerReferenceProvider } from "@/providers/ExplorerReferenceProvider";
 import { OpenCodeClientContext } from "@/providers/OpenCodeClientProvider";
 import { PreferencesProvider } from "@/providers/PreferencesProvider";
 
@@ -153,8 +154,10 @@ function TestChatInput({
             }}
           >
             <PreferencesProvider>
-              <ChatInput />
-              <Toaster />
+              <ExplorerReferenceProvider>
+                <ChatInput />
+                <Toaster />
+              </ExplorerReferenceProvider>
             </PreferencesProvider>
           </ActiveSessionContext.Provider>
         </OpenCodeClientContext.Provider>

--- a/src/test/analytics.test.ts
+++ b/src/test/analytics.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   captureDetailedAnalytics,
   detailedAnalyticsProperties,
+  explorerAnalyticsProperties,
   setDetailedAnalyticsEnabled,
 } from "@/lib/analytics";
 
@@ -39,5 +40,26 @@ describe("PostHog analytics", () => {
 
     expect(posthog.capture).toHaveBeenCalledOnce();
     expect(posthog.capture).toHaveBeenCalledWith("model_usage", usage);
+  });
+
+  it("keeps Explorer analytics coarse and strips object content", () => {
+    expect(
+      explorerAnalyticsProperties({
+        duration_ms: 42,
+        node_count: 8,
+        source: "initial",
+        class_category: "known",
+        path: "game.Workspace.Secret",
+        name: "Secret",
+        placeName: "Private place",
+        properties: "Position=1,2,3",
+        attributes: "Owner=Oscar",
+      }),
+    ).toEqual({
+      duration_ms: 42,
+      node_count: 8,
+      source: "initial",
+      class_category: "known",
+    });
   });
 });

--- a/src/test/app.test.tsx
+++ b/src/test/app.test.tsx
@@ -19,6 +19,7 @@ import { desktop } from "@/lib/desktop";
 import { qk } from "@/lib/queryKeys";
 import { type MessagesCache, sseDispatch } from "@/lib/sseDispatch";
 import { ActiveSessionProvider } from "@/providers/ActiveSessionProvider";
+import { ExplorerReferenceProvider } from "@/providers/ExplorerReferenceProvider";
 import { OpenCodeClientContext } from "@/providers/OpenCodeClientProvider";
 import { PreferencesProvider } from "@/providers/PreferencesProvider";
 
@@ -80,7 +81,9 @@ function TestApp({
         >
           <ActiveSessionProvider activeSessionIdRef={activeSessionIdRef}>
             <PreferencesProvider>
-              <ChatWithSonner />
+              <ExplorerReferenceProvider>
+                <ChatWithSonner />
+              </ExplorerReferenceProvider>
             </PreferencesProvider>
           </ActiveSessionProvider>
         </OpenCodeClientContext.Provider>

--- a/src/test/explorer.test.ts
+++ b/src/test/explorer.test.ts
@@ -2,8 +2,10 @@ import { Effect, Schema } from "effect";
 import { describe, expect, it, vi } from "vitest";
 import {
   createExplorerReference,
+  ExplorerCollectionSchema,
   ExplorerSnapshotSchema,
-  loadExplorerSnapshot,
+  generateExplorerCollection,
+  replayExplorerCollector,
 } from "@/lib/explorer";
 import { isVisibleSession } from "@/lib/sessionVisibility";
 
@@ -16,12 +18,19 @@ const snapshot = {
       className: "Workspace",
       path: "game.Workspace",
       hasChildren: true,
+      properties: [{ name: "StreamingEnabled", value: "false" }],
+      attributes: [],
       children: [
         {
           name: "SpawnLocation",
           className: "SpawnLocation",
           path: "game.Workspace.SpawnLocation",
           hasChildren: false,
+          properties: [
+            { name: "Position", value: "0, 4, 0" },
+            { name: "Anchored", value: "true" },
+          ],
+          attributes: [{ name: "Team", value: "Lobby" }],
           children: [],
         },
       ],
@@ -50,19 +59,20 @@ describe("Explorer data boundary", () => {
     ).rejects.toBeDefined();
   });
 
-  it("uses a disposable private session and structured SDK output", async () => {
+  it("generates a collector and initial snapshot in a disposable private session", async () => {
     const create = vi.fn().mockResolvedValue({ data: { id: "hidden-session" } });
-    const prompt = vi.fn().mockResolvedValue({ data: { info: { structured: snapshot } } });
+    const structured = { collector: "READ_ONLY_COLLECTOR", snapshot };
+    const prompt = vi.fn().mockResolvedValue({ data: { info: { structured } } });
     const remove = vi.fn().mockResolvedValue({ data: true });
     const client = { session: { create, prompt, delete: remove } };
 
     await expect(
-      loadExplorerSnapshot(
+      generateExplorerCollection(
         client as never,
         { providerID: "anthropic", modelID: "claude" },
         "build",
       ),
-    ).resolves.toEqual(snapshot);
+    ).resolves.toEqual(structured);
 
     expect(create).toHaveBeenCalledWith(
       expect.objectContaining({ metadata: { bloxbotHidden: true, purpose: "explorer" } }),
@@ -76,6 +86,33 @@ describe("Explorer data boundary", () => {
       { throwOnError: true },
     );
     expect(remove).toHaveBeenCalledWith({ sessionID: "hidden-session" }, { throwOnError: true });
+  });
+
+  it("replays the retained collector verbatim without asking for a new plan", async () => {
+    const prompt = vi.fn().mockResolvedValue({ data: { info: { structured: snapshot } } });
+    const client = {
+      session: {
+        create: vi.fn().mockResolvedValue({ data: { id: "replay-session" } }),
+        prompt,
+        delete: vi.fn().mockResolvedValue({ data: true }),
+      },
+    };
+
+    await expect(replayExplorerCollector(client as never, "EXACT COLLECTOR")).resolves.toEqual(
+      snapshot,
+    );
+    const request = prompt.mock.calls[0][0];
+    expect(request.parts[0].text).toContain("<collector>\nEXACT COLLECTOR\n</collector>");
+    expect(request.parts[0].text).not.toContain("design");
+    expect(request.format).toMatchObject({ type: "json_schema", retryCount: 1 });
+  });
+
+  it("rejects invalid collectors before they can be retained", async () => {
+    await expect(
+      Effect.runPromise(
+        Schema.decodeUnknown(ExplorerCollectionSchema)({ collector: "", snapshot }),
+      ),
+    ).rejects.toBeDefined();
   });
 
   it("makes paths non-authoritative when inserting an object into chat", () => {

--- a/src/test/explorer.test.ts
+++ b/src/test/explorer.test.ts
@@ -2,10 +2,9 @@ import { Effect, Schema } from "effect";
 import { describe, expect, it, vi } from "vitest";
 import {
   createExplorerReference,
-  ExplorerCollectionSchema,
+  ExplorerProgramEnvelopeSchema,
   ExplorerSnapshotSchema,
-  generateExplorerCollection,
-  replayExplorerCollector,
+  generateExplorerProgram,
 } from "@/lib/explorer";
 import { isVisibleSession } from "@/lib/sessionVisibility";
 
@@ -59,15 +58,24 @@ describe("Explorer data boundary", () => {
     ).rejects.toBeDefined();
   });
 
-  it("generates a collector and initial snapshot in a disposable private session", async () => {
+  it("generates a reusable TypeScript program in a disposable private session", async () => {
     const create = vi.fn().mockResolvedValue({ data: { id: "hidden-session" } });
-    const structured = { collector: "READ_ONLY_COLLECTOR", snapshot };
+    const structured = {
+      version: 1,
+      contract: {
+        name: "explorer-snapshot",
+        version: "1",
+        inputSchemaVersion: "explorer-input-v1",
+        outputSchemaVersion: "explorer-snapshot-v1",
+      },
+      source: "async function run({ callTool }) { return callTool('inspect_place', {}); }",
+    };
     const prompt = vi.fn().mockResolvedValue({ data: { info: { structured } } });
     const remove = vi.fn().mockResolvedValue({ data: true });
     const client = { session: { create, prompt, delete: remove } };
 
     await expect(
-      generateExplorerCollection(
+      generateExplorerProgram(
         client as never,
         { providerID: "anthropic", modelID: "claude" },
         "build",
@@ -86,31 +94,23 @@ describe("Explorer data boundary", () => {
       { throwOnError: true },
     );
     expect(remove).toHaveBeenCalledWith({ sessionID: "hidden-session" }, { throwOnError: true });
+    expect(prompt.mock.calls[0][0].system).toContain("compile this source once");
+    expect(prompt.mock.calls[0][0].system).toContain("callTool");
   });
 
-  it("replays the retained collector verbatim without asking for a new plan", async () => {
-    const prompt = vi.fn().mockResolvedValue({ data: { info: { structured: snapshot } } });
-    const client = {
-      session: {
-        create: vi.fn().mockResolvedValue({ data: { id: "replay-session" } }),
-        prompt,
-        delete: vi.fn().mockResolvedValue({ data: true }),
-      },
-    };
-
-    await expect(replayExplorerCollector(client as never, "EXACT COLLECTOR")).resolves.toEqual(
-      snapshot,
-    );
-    const request = prompt.mock.calls[0][0];
-    expect(request.parts[0].text).toContain("<collector>\nEXACT COLLECTOR\n</collector>");
-    expect(request.parts[0].text).not.toContain("design");
-    expect(request.format).toMatchObject({ type: "json_schema", retryCount: 1 });
-  });
-
-  it("rejects invalid collectors before they can be retained", async () => {
+  it("rejects invalid generated program contracts", async () => {
     await expect(
       Effect.runPromise(
-        Schema.decodeUnknown(ExplorerCollectionSchema)({ collector: "", snapshot }),
+        Schema.decodeUnknown(ExplorerProgramEnvelopeSchema)({
+          version: 1,
+          contract: {
+            name: "wrong-contract",
+            version: "1",
+            inputSchemaVersion: "explorer-input-v1",
+            outputSchemaVersion: "explorer-snapshot-v1",
+          },
+          source: "async function run() {}",
+        }),
       ),
     ).rejects.toBeDefined();
   });

--- a/src/test/explorer.test.ts
+++ b/src/test/explorer.test.ts
@@ -1,0 +1,88 @@
+import { Effect, Schema } from "effect";
+import { describe, expect, it, vi } from "vitest";
+import {
+  createExplorerReference,
+  ExplorerSnapshotSchema,
+  loadExplorerSnapshot,
+} from "@/lib/explorer";
+import { isVisibleSession } from "@/lib/sessionVisibility";
+
+const snapshot = {
+  placeName: "Obby Prototype",
+  capturedAt: "2026-07-27T12:00:00Z",
+  roots: [
+    {
+      name: "Workspace",
+      className: "Workspace",
+      path: "game.Workspace",
+      hasChildren: true,
+      children: [
+        {
+          name: "SpawnLocation",
+          className: "SpawnLocation",
+          path: "game.Workspace.SpawnLocation",
+          hasChildren: false,
+          children: [],
+        },
+      ],
+    },
+  ],
+};
+
+describe("Explorer data boundary", () => {
+  it("keeps private Explorer sessions out of the chat list", () => {
+    expect(isVisibleSession({ metadata: { bloxbotHidden: true } } as never)).toBe(false);
+    expect(isVisibleSession({ metadata: {} } as never)).toBe(true);
+  });
+
+  it("validates recursive snapshots owned by the app", async () => {
+    await expect(
+      Effect.runPromise(Schema.decodeUnknown(ExplorerSnapshotSchema)(snapshot)),
+    ).resolves.toEqual(snapshot);
+
+    await expect(
+      Effect.runPromise(
+        Schema.decodeUnknown(ExplorerSnapshotSchema)({
+          ...snapshot,
+          roots: [{ ...snapshot.roots[0], hasChildren: "yes" }],
+        }),
+      ),
+    ).rejects.toBeDefined();
+  });
+
+  it("uses a disposable private session and structured SDK output", async () => {
+    const create = vi.fn().mockResolvedValue({ data: { id: "hidden-session" } });
+    const prompt = vi.fn().mockResolvedValue({ data: { info: { structured: snapshot } } });
+    const remove = vi.fn().mockResolvedValue({ data: true });
+    const client = { session: { create, prompt, delete: remove } };
+
+    await expect(
+      loadExplorerSnapshot(
+        client as never,
+        { providerID: "anthropic", modelID: "claude" },
+        "build",
+      ),
+    ).resolves.toEqual(snapshot);
+
+    expect(create).toHaveBeenCalledWith(
+      expect.objectContaining({ metadata: { bloxbotHidden: true, purpose: "explorer" } }),
+      { throwOnError: true },
+    );
+    expect(prompt).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionID: "hidden-session",
+        format: expect.objectContaining({ type: "json_schema", retryCount: 2 }),
+      }),
+      { throwOnError: true },
+    );
+    expect(remove).toHaveBeenCalledWith({ sessionID: "hidden-session" }, { throwOnError: true });
+  });
+
+  it("makes paths non-authoritative when inserting an object into chat", () => {
+    const prompt = createExplorerReference(snapshot.roots[0].children[0]);
+    expect(prompt).toContain("game.Workspace.SpawnLocation");
+    expect(prompt).toContain("only as a hint");
+    expect(prompt).toContain("Rediscover");
+    expect(prompt).toContain("verify its identity and current state immediately");
+  });
+});

--- a/src/types/desktop.ts
+++ b/src/types/desktop.ts
@@ -1,4 +1,6 @@
 import { Schema } from "effect";
+import type { ExplorerProgramEnvelope, ExplorerSnapshot } from "../lib/explorer";
+import type { GeneratedProgramArtifact } from "./generatedProgram";
 
 const MutableStrings = Schema.mutable(Schema.Array(Schema.String));
 
@@ -59,6 +61,8 @@ export const UpdateInfoSchema = Schema.mutable(
 export type UpdateInfo = typeof UpdateInfoSchema.Type;
 
 export interface DesktopApi {
+  compileExplorerProgram(program: ExplorerProgramEnvelope): Promise<GeneratedProgramArtifact>;
+  invokeExplorerProgram(artifact: GeneratedProgramArtifact): Promise<ExplorerSnapshot>;
   getOpenCodeInfo(): Promise<OpenCodeInfo>;
   onOpenCodeStartupProgress(listener: (progress: OpenCodeStartupProgress) => void): () => void;
   getVersion(): Promise<string>;


### PR DESCRIPTION
## Summary

- add a collapsible, instance-tree Explorer beside active chats with class-aware icons and a compact inspector
- generate a versioned, import-free TypeScript collector once through a private agent session
- compile/cache that collector through the shared generated-program runtime and invoke it directly through the shared Studio MCP broker
- adapt polling to session activity, back off unchanged snapshots, pause Studio calls while hidden/unfocused, and prevent overlaps
- preserve the last good snapshot on errors and regenerate only after compile, tool-contract, runtime, or output failure
- add privacy-safe lifecycle, generation, sync, recovery, and reference telemetry
- reference objects safely as rediscover-and-verify hints rather than durable paths

## Architecture

The initial private agent turn discovers the available Studio MCP contract and returns a strict `GeneratedProgramEnvelope`. Electron validates and compiles it through PR #68's generic runtime. Routine polling invokes the cached artifact directly with `StudioMcpBroker.callTool`; it performs no model inference and incurs no recurring model cost.

The active cadence is 2.5 seconds while the chat session is busy and 5 seconds while idle. Unchanged snapshots back off exponentially to 30 seconds. Polls do not overlap, and hidden or unfocused windows do not call Studio. A compile, tool-contract, runtime, or output-schema failure keeps the last good tree visible and triggers one model-mediated regeneration path.

Feature-specific IPC handlers validate the Explorer program contract and snapshot with Effect Schema. The renderer never receives a generic arbitrary-code or generic MCP endpoint.

## Validation

- `pnpm test` — 157 unit/UI + 8 release tests pass
- `pnpm typecheck`
- `pnpm build`
- `pnpm lint` — passes with 47 pre-existing warnings
- changed-file Biome check and `git diff --check`
- three deterministic 1200×800 headless renders visually inspected

## Screenshots

### Loading

![Explorer loading](https://github.com/user-attachments/assets/16d4a029-457a-40b1-a91f-95c030c0c557)

### Populated and inspecting

![Explorer populated](https://github.com/user-attachments/assets/c8c681d8-2689-45b6-93da-8ba8670f21ef)

### Reconnect error with last-good data

![Explorer reconnect error](https://github.com/user-attachments/assets/c403fcb0-2908-4047-aeae-addc635cf1ed)
