### PR TITLE
Add snoozed threads

### DIFF
--- a/src/components/ChatSidebar.tsx
+++ b/src/components/ChatSidebar.tsx
@@ -1,4 +1,5 @@
 import type { Session } from "@opencode-ai/sdk/v2/client";
+import posthog from "posthog-js/dist/module.full.no-external.js";
 import { memo, useEffect, useMemo, useRef, useState } from "react";
 import { useArchiveSession } from "@/hooks/mutations/useArchiveSession";
 import { useCreateSession } from "@/hooks/mutations/useCreateSession";
@@ -6,6 +7,7 @@ import { useDeleteSession } from "@/hooks/mutations/useDeleteSession";
 import { useRenameSession } from "@/hooks/mutations/useRenameSession";
 import { useSessionStatuses } from "@/hooks/useSessionStatuses";
 import { useSessions } from "@/hooks/useSessions";
+import { countBucket } from "@/lib/analytics";
 import { useActiveSession } from "@/providers/ActiveSessionProvider";
 
 interface ChatSidebarProps {
@@ -106,10 +108,29 @@ const ChatSidebar = memo(function ChatSidebar({
     archiveSession.mutate(sessionID);
   }
 
+  function handleSnoozedSelect(sessionID: string) {
+    posthog.capture("snoozed_session_opened");
+    handleSelect(sessionID);
+  }
+
+  function handleSnoozedToggle() {
+    setSnoozedExpanded((expanded) => {
+      const nextExpanded = !expanded;
+      posthog.capture("snoozed_section_toggled", {
+        expanded: nextExpanded,
+        count_bucket: countBucket(snoozedSessions.length),
+      });
+      return nextExpanded;
+    });
+  }
+
   function handleDelete(session: Session) {
-    if (
-      window.confirm(`Permanently delete “${session.title || "Untitled"}”? This cannot be undone.`)
-    ) {
+    posthog.capture("permanent_delete_requested");
+    const confirmed = window.confirm(
+      `Permanently delete “${session.title || "Untitled"}”? This cannot be undone.`,
+    );
+    posthog.capture(confirmed ? "permanent_delete_confirmed" : "permanent_delete_cancelled");
+    if (confirmed) {
       deleteSession.mutate(session.id);
     }
   }
@@ -370,7 +391,7 @@ const ChatSidebar = memo(function ChatSidebar({
               <button
                 type="button"
                 aria-expanded={snoozedExpanded}
-                onClick={() => setSnoozedExpanded((expanded) => !expanded)}
+                onClick={handleSnoozedToggle}
                 className="flex w-full items-center gap-1.5 px-3 py-2 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground transition-colors hover:text-foreground"
               >
                 <svg
@@ -397,7 +418,7 @@ const ChatSidebar = memo(function ChatSidebar({
                     >
                       <button
                         type="button"
-                        onClick={() => handleSelect(session.id)}
+                        onClick={() => handleSnoozedSelect(session.id)}
                         className="min-w-0 flex-1 px-2 py-1.5 text-left"
                         title={`Open snoozed session ${session.title || "Untitled"}`}
                       >

--- a/src/components/ChatSidebar.tsx
+++ b/src/components/ChatSidebar.tsx
@@ -103,12 +103,7 @@ const ChatSidebar = memo(function ChatSidebar({
   function handleSnooze(sessionID: string) {
     const status = sessionStatuses[sessionID];
     if (status && status.type !== "idle") return;
-    archiveSession.mutate({ sessionID, archived: true });
-  }
-
-  function handleRestore(sessionID: string) {
-    onSessionSelect();
-    archiveSession.mutate({ sessionID, archived: false });
+    archiveSession.mutate(sessionID);
   }
 
   function handleDelete(session: Session) {
@@ -401,9 +396,9 @@ const ChatSidebar = memo(function ChatSidebar({
                       >
                         <button
                           type="button"
-                          onClick={() => handleRestore(session.id)}
+                          onClick={() => handleSelect(session.id)}
                           className="min-w-0 flex-1 px-2 py-1.5 text-left"
-                          title={`Restore and open ${session.title || "Untitled"}`}
+                          title={`Open snoozed session ${session.title || "Untitled"}`}
                         >
                           <div className="max-w-[8.5rem] truncate text-[11px] leading-snug opacity-80">
                             {session.title || "Untitled"}
@@ -411,9 +406,9 @@ const ChatSidebar = memo(function ChatSidebar({
                         </button>
                         <button
                           type="button"
-                          onClick={() => handleRestore(session.id)}
+                          onClick={() => handleSelect(session.id)}
                           className="mr-0.5 flex h-5 w-5 items-center justify-center rounded opacity-0 transition-opacity hover:bg-accent group-focus-within:opacity-100 group-hover:opacity-100"
-                          title="Restore and open"
+                          title="Open snoozed session"
                         >
                           <svg
                             width="11"

--- a/src/components/ChatSidebar.tsx
+++ b/src/components/ChatSidebar.tsx
@@ -363,91 +363,73 @@ const ChatSidebar = memo(function ChatSidebar({
                 </div>
               );
             })}
-
-            {snoozedSessions.length > 0 && (
-              <div className="mt-2 border-t border-border/70 pt-1">
-                <button
-                  type="button"
-                  aria-expanded={snoozedExpanded}
-                  onClick={() => setSnoozedExpanded((expanded) => !expanded)}
-                  className="flex w-full items-center gap-1.5 px-3 py-1.5 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground transition-colors hover:text-foreground"
-                >
-                  <svg
-                    width="10"
-                    height="10"
-                    viewBox="0 0 24 24"
-                    fill="none"
-                    stroke="currentColor"
-                    strokeWidth="2"
-                    className={`transition-transform ${snoozedExpanded ? "rotate-90" : ""}`}
-                  >
-                    <polyline points="9 18 15 12 9 6" />
-                  </svg>
-                  Snoozed
-                  <span className="ml-auto font-normal tabular-nums">{snoozedSessions.length}</span>
-                </button>
-
-                {snoozedExpanded && (
-                  <div className="pb-1">
-                    {snoozedSessions.map((session) => (
-                      <div
-                        key={session.id}
-                        className="group relative mx-1 flex items-center rounded-md text-muted-foreground transition-colors hover:bg-accent/50 hover:text-foreground"
-                      >
-                        <button
-                          type="button"
-                          onClick={() => handleSelect(session.id)}
-                          className="min-w-0 flex-1 px-2 py-1.5 text-left"
-                          title={`Open snoozed session ${session.title || "Untitled"}`}
-                        >
-                          <div className="max-w-[8.5rem] truncate text-[11px] leading-snug opacity-80">
-                            {session.title || "Untitled"}
-                          </div>
-                        </button>
-                        <button
-                          type="button"
-                          onClick={() => handleSelect(session.id)}
-                          className="mr-0.5 flex h-5 w-5 items-center justify-center rounded opacity-0 transition-opacity hover:bg-accent group-focus-within:opacity-100 group-hover:opacity-100"
-                          title="Open snoozed session"
-                        >
-                          <svg
-                            width="11"
-                            height="11"
-                            viewBox="0 0 24 24"
-                            fill="none"
-                            stroke="currentColor"
-                            strokeWidth="2"
-                          >
-                            <path d="M3 12a9 9 0 1 0 3-6.7L3 8" />
-                            <path d="M3 3v5h5" />
-                          </svg>
-                        </button>
-                        <button
-                          type="button"
-                          onClick={() => handleDelete(session)}
-                          className="mr-1 flex h-5 w-5 items-center justify-center rounded text-muted-foreground opacity-0 transition-opacity hover:text-destructive group-focus-within:opacity-100 group-hover:opacity-100"
-                          title="Delete permanently"
-                        >
-                          <svg
-                            width="10"
-                            height="10"
-                            viewBox="0 0 24 24"
-                            fill="none"
-                            stroke="currentColor"
-                            strokeWidth="2"
-                          >
-                            <path d="M3 6h18" />
-                            <path d="M8 6V4h8v2" />
-                            <path d="M19 6l-1 14H6L5 6" />
-                          </svg>
-                        </button>
-                      </div>
-                    ))}
-                  </div>
-                )}
-              </div>
-            )}
           </div>
+
+          {snoozedSessions.length > 0 && (
+            <div className="shrink-0 border-t border-border/70">
+              <button
+                type="button"
+                aria-expanded={snoozedExpanded}
+                onClick={() => setSnoozedExpanded((expanded) => !expanded)}
+                className="flex w-full items-center gap-1.5 px-3 py-2 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground transition-colors hover:text-foreground"
+              >
+                <svg
+                  width="10"
+                  height="10"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  className={`transition-transform ${snoozedExpanded ? "rotate-90" : ""}`}
+                >
+                  <polyline points="9 18 15 12 9 6" />
+                </svg>
+                Snoozed
+                <span className="ml-auto font-normal tabular-nums">{snoozedSessions.length}</span>
+              </button>
+
+              {snoozedExpanded && (
+                <div className="max-h-40 overflow-y-auto overflow-x-hidden pb-1">
+                  {snoozedSessions.map((session) => (
+                    <div
+                      key={session.id}
+                      className="group relative mx-1 flex min-w-0 items-center rounded-md text-muted-foreground transition-colors hover:bg-accent/50 hover:text-foreground"
+                    >
+                      <button
+                        type="button"
+                        onClick={() => handleSelect(session.id)}
+                        className="min-w-0 flex-1 px-2 py-1.5 text-left"
+                        title={`Open snoozed session ${session.title || "Untitled"}`}
+                      >
+                        <div className="truncate text-[11px] leading-snug opacity-80">
+                          {session.title || "Untitled"}
+                        </div>
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => handleDelete(session)}
+                        className="mr-1 flex h-5 w-5 shrink-0 items-center justify-center rounded text-muted-foreground opacity-0 transition-opacity hover:text-destructive group-focus-within:opacity-100 group-hover:opacity-100"
+                        title="Delete permanently"
+                      >
+                        <svg
+                          width="10"
+                          height="10"
+                          viewBox="0 0 24 24"
+                          fill="none"
+                          stroke="currentColor"
+                          strokeWidth="2"
+                        >
+                          <path d="M3 6h18" />
+                          <path d="M8 6V4h8v2" />
+                          <path d="M19 6l-1 14H6L5 6" />
+                        </svg>
+                      </button>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
+          )}
 
           <div className="shrink-0 border-t px-3 py-2 space-y-1">
             <button

--- a/src/components/ChatSidebar.tsx
+++ b/src/components/ChatSidebar.tsx
@@ -1,4 +1,6 @@
-import { memo, useEffect, useRef, useState } from "react";
+import type { Session } from "@opencode-ai/sdk/v2/client";
+import { memo, useEffect, useMemo, useRef, useState } from "react";
+import { useArchiveSession } from "@/hooks/mutations/useArchiveSession";
 import { useCreateSession } from "@/hooks/mutations/useCreateSession";
 import { useDeleteSession } from "@/hooks/mutations/useDeleteSession";
 import { useRenameSession } from "@/hooks/mutations/useRenameSession";
@@ -51,12 +53,23 @@ const ChatSidebar = memo(function ChatSidebar({
   const { activeSessionId, selectSession } = useActiveSession();
   const { data: sessionStatuses = {} } = useSessionStatuses();
   const createSession = useCreateSession();
+  const archiveSession = useArchiveSession();
   const deleteSession = useDeleteSession();
   const renameSession = useRenameSession();
 
   const [editingId, setEditingId] = useState<string | null>(null);
   const [editValue, setEditValue] = useState("");
+  const [snoozedExpanded, setSnoozedExpanded] = useState(false);
   const editRef = useRef<HTMLInputElement>(null);
+
+  const { activeSessions, snoozedSessions } = useMemo(() => {
+    const active: Session[] = [];
+    const snoozed: Session[] = [];
+    for (const session of sessions) {
+      (session.time.archived ? snoozed : active).push(session);
+    }
+    return { activeSessions: active, snoozedSessions: snoozed };
+  }, [sessions]);
 
   function handleSelect(id: string) {
     onSessionSelect();
@@ -85,6 +98,25 @@ const ChatSidebar = memo(function ChatSidebar({
       renameSession.mutate({ sessionID: editingId, title: editValue.trim() });
     }
     setEditingId(null);
+  }
+
+  function handleSnooze(sessionID: string) {
+    const status = sessionStatuses[sessionID];
+    if (status && status.type !== "idle") return;
+    archiveSession.mutate({ sessionID, archived: true });
+  }
+
+  function handleRestore(sessionID: string) {
+    onSessionSelect();
+    archiveSession.mutate({ sessionID, archived: false });
+  }
+
+  function handleDelete(session: Session) {
+    if (
+      window.confirm(`Permanently delete “${session.title || "Untitled"}”? This cannot be undone.`)
+    ) {
+      deleteSession.mutate(session.id);
+    }
   }
 
   return (
@@ -202,14 +234,14 @@ const ChatSidebar = memo(function ChatSidebar({
           </div>
 
           <div className="flex-1 overflow-y-auto overflow-x-hidden py-1">
-            {sessions.length === 0 && (
+            {activeSessions.length === 0 && snoozedSessions.length === 0 && (
               <div className="animate-fade-in px-3 py-6 text-center text-xs text-muted-foreground">
                 No sessions yet.
                 <br />
                 Start a new one to begin.
               </div>
             )}
-            {sessions.map((session, index) => {
+            {activeSessions.map((session, index) => {
               const isActive = session.id === activeSessionId;
               const isEditing = session.id === editingId;
               const status = sessionStatuses[session.id];
@@ -260,7 +292,7 @@ const ChatSidebar = memo(function ChatSidebar({
                           className={`mt-1.5 h-1.5 w-1.5 shrink-0 rounded-full transition-colors duration-300 ${statusDot(status)}`}
                         />
                         <div className="min-w-0 flex-1">
-                          <div className="truncate text-xs font-medium leading-snug">
+                          <div className="text-xs font-medium leading-snug break-words">
                             {session.title || "Untitled"}
                           </div>
                           <div className="mt-0.5 text-[10px] text-muted-foreground">
@@ -304,10 +336,15 @@ const ChatSidebar = memo(function ChatSidebar({
                           type="button"
                           onClick={(e) => {
                             e.stopPropagation();
-                            deleteSession.mutate(session.id);
+                            handleSnooze(session.id);
                           }}
-                          className="flex h-5 w-5 items-center justify-center rounded text-muted-foreground transition-colors hover:text-destructive"
-                          title="Delete"
+                          disabled={status !== undefined && status.type !== "idle"}
+                          className="flex h-5 w-5 items-center justify-center rounded text-muted-foreground transition-colors hover:text-foreground disabled:cursor-not-allowed disabled:opacity-35"
+                          title={
+                            status && status.type !== "idle"
+                              ? "Wait for session to finish"
+                              : "Snooze"
+                          }
                         >
                           <svg
                             width="10"
@@ -319,8 +356,10 @@ const ChatSidebar = memo(function ChatSidebar({
                             strokeLinecap="round"
                             strokeLinejoin="round"
                           >
-                            <line x1="18" y1="6" x2="6" y2="18" />
-                            <line x1="6" y1="6" x2="18" y2="18" />
+                            <path d="M3 7h18" />
+                            <path d="M5 7l1 13h12l1-13" />
+                            <path d="M9 11h6" />
+                            <path d="M8 4h8l1 3H7l1-3z" />
                           </svg>
                         </button>
                       </div>
@@ -329,6 +368,90 @@ const ChatSidebar = memo(function ChatSidebar({
                 </div>
               );
             })}
+
+            {snoozedSessions.length > 0 && (
+              <div className="mt-2 border-t border-border/70 pt-1">
+                <button
+                  type="button"
+                  aria-expanded={snoozedExpanded}
+                  onClick={() => setSnoozedExpanded((expanded) => !expanded)}
+                  className="flex w-full items-center gap-1.5 px-3 py-1.5 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground transition-colors hover:text-foreground"
+                >
+                  <svg
+                    width="10"
+                    height="10"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth="2"
+                    className={`transition-transform ${snoozedExpanded ? "rotate-90" : ""}`}
+                  >
+                    <polyline points="9 18 15 12 9 6" />
+                  </svg>
+                  Snoozed
+                  <span className="ml-auto font-normal tabular-nums">{snoozedSessions.length}</span>
+                </button>
+
+                {snoozedExpanded && (
+                  <div className="pb-1">
+                    {snoozedSessions.map((session) => (
+                      <div
+                        key={session.id}
+                        className="group relative mx-1 flex items-center rounded-md text-muted-foreground transition-colors hover:bg-accent/50 hover:text-foreground"
+                      >
+                        <button
+                          type="button"
+                          onClick={() => handleRestore(session.id)}
+                          className="min-w-0 flex-1 px-2 py-1.5 text-left"
+                          title={`Restore and open ${session.title || "Untitled"}`}
+                        >
+                          <div className="max-w-[8.5rem] truncate text-[11px] leading-snug opacity-80">
+                            {session.title || "Untitled"}
+                          </div>
+                        </button>
+                        <button
+                          type="button"
+                          onClick={() => handleRestore(session.id)}
+                          className="mr-0.5 flex h-5 w-5 items-center justify-center rounded opacity-0 transition-opacity hover:bg-accent group-focus-within:opacity-100 group-hover:opacity-100"
+                          title="Restore and open"
+                        >
+                          <svg
+                            width="11"
+                            height="11"
+                            viewBox="0 0 24 24"
+                            fill="none"
+                            stroke="currentColor"
+                            strokeWidth="2"
+                          >
+                            <path d="M3 12a9 9 0 1 0 3-6.7L3 8" />
+                            <path d="M3 3v5h5" />
+                          </svg>
+                        </button>
+                        <button
+                          type="button"
+                          onClick={() => handleDelete(session)}
+                          className="mr-1 flex h-5 w-5 items-center justify-center rounded text-muted-foreground opacity-0 transition-opacity hover:text-destructive group-focus-within:opacity-100 group-hover:opacity-100"
+                          title="Delete permanently"
+                        >
+                          <svg
+                            width="10"
+                            height="10"
+                            viewBox="0 0 24 24"
+                            fill="none"
+                            stroke="currentColor"
+                            strokeWidth="2"
+                          >
+                            <path d="M3 6h18" />
+                            <path d="M8 6V4h8v2" />
+                            <path d="M19 6l-1 14H6L5 6" />
+                          </svg>
+                        </button>
+                      </div>
+                    ))}
+                  </div>
+                )}
+              </div>
+            )}
           </div>
 
           <div className="shrink-0 border-t px-3 py-2 space-y-1">

--- a/src/hooks/mutations/useArchiveSession.ts
+++ b/src/hooks/mutations/useArchiveSession.ts
@@ -1,5 +1,6 @@
 import type { Session } from "@opencode-ai/sdk/v2/client";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
+import posthog from "posthog-js/dist/module.full.no-external.js";
 
 import { qk } from "@/lib/queryKeys";
 import { useActiveSession } from "@/providers/ActiveSessionProvider";
@@ -29,6 +30,7 @@ export function useArchiveSession() {
       if (activeSessionId === session.id) {
         clearSession();
       }
+      posthog.capture("session_snoozed");
     },
   });
 }

--- a/src/hooks/mutations/useArchiveSession.ts
+++ b/src/hooks/mutations/useArchiveSession.ts
@@ -1,0 +1,41 @@
+import type { Session } from "@opencode-ai/sdk/v2/client";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+import { qk } from "@/lib/queryKeys";
+import { useActiveSession } from "@/providers/ActiveSessionProvider";
+import { useOpenCodeClient } from "@/providers/OpenCodeClientProvider";
+
+type ArchiveSessionInput = {
+  sessionID: string;
+  archived: boolean;
+};
+
+export function useArchiveSession() {
+  const { client } = useOpenCodeClient();
+  const queryClient = useQueryClient();
+  const { activeSessionId, clearSession, selectSession } = useActiveSession();
+
+  return useMutation({
+    mutationFn: async ({ sessionID, archived }: ArchiveSessionInput) => {
+      if (!client) throw new Error("No client");
+      const response = await client.session.update(
+        { sessionID, time: archived ? { archived: Date.now() } : {} },
+        { throwOnError: true },
+      );
+      if (!response.data) throw new Error("OpenCode did not update the session");
+      return { session: response.data, archived };
+    },
+    onSuccess: ({ session, archived }) => {
+      queryClient.setQueryData<Session[]>(qk.sessions, (previous) => {
+        if (!previous) return [session];
+        return previous.map((item) => (item.id === session.id ? session : item));
+      });
+
+      if (archived && activeSessionId === session.id) {
+        clearSession();
+      } else if (!archived) {
+        void selectSession(session.id);
+      }
+    },
+  });
+}

--- a/src/hooks/mutations/useArchiveSession.ts
+++ b/src/hooks/mutations/useArchiveSession.ts
@@ -5,36 +5,29 @@ import { qk } from "@/lib/queryKeys";
 import { useActiveSession } from "@/providers/ActiveSessionProvider";
 import { useOpenCodeClient } from "@/providers/OpenCodeClientProvider";
 
-type ArchiveSessionInput = {
-  sessionID: string;
-  archived: boolean;
-};
-
 export function useArchiveSession() {
   const { client } = useOpenCodeClient();
   const queryClient = useQueryClient();
-  const { activeSessionId, clearSession, selectSession } = useActiveSession();
+  const { activeSessionId, clearSession } = useActiveSession();
 
   return useMutation({
-    mutationFn: async ({ sessionID, archived }: ArchiveSessionInput) => {
+    mutationFn: async (sessionID: string) => {
       if (!client) throw new Error("No client");
       const response = await client.session.update(
-        { sessionID, time: archived ? { archived: Date.now() } : {} },
+        { sessionID, time: { archived: Date.now() } },
         { throwOnError: true },
       );
       if (!response.data) throw new Error("OpenCode did not update the session");
-      return { session: response.data, archived };
+      return response.data;
     },
-    onSuccess: ({ session, archived }) => {
+    onSuccess: (session) => {
       queryClient.setQueryData<Session[]>(qk.sessions, (previous) => {
         if (!previous) return [session];
         return previous.map((item) => (item.id === session.id ? session : item));
       });
 
-      if (archived && activeSessionId === session.id) {
+      if (activeSessionId === session.id) {
         clearSession();
-      } else if (!archived) {
-        void selectSession(session.id);
       }
     },
   });

--- a/src/hooks/useSessions.ts
+++ b/src/hooks/useSessions.ts
@@ -11,7 +11,10 @@ export function useSessions() {
     queryKey: qk.sessions,
     queryFn: async () => {
       if (!client) return [];
-      const res = await client.session.list({}, { throwOnError: true });
+      const res = await client.experimental.session.list(
+        { archived: true },
+        { throwOnError: true },
+      );
       if (!res.data) return [];
       return [...res.data].sort((a, b) => b.time.created - a.time.created);
     },

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -20,3 +20,10 @@ export function captureDetailedAnalytics(
 ): void {
   if (detailedAnalyticsEnabled) posthog.capture(event, properties);
 }
+
+export function countBucket(count: number): "1" | "2-5" | "6-10" | "11+" {
+  if (count <= 1) return "1";
+  if (count <= 5) return "2-5";
+  if (count <= 10) return "6-10";
+  return "11+";
+}

--- a/src/providers/OpenCodeClientProvider.tsx
+++ b/src/providers/OpenCodeClientProvider.tsx
@@ -384,7 +384,7 @@ export function OpenCodeClientProvider({
 
 export async function prefetchServerState(client: OpencodeClient, queryClient: QueryClient) {
   const results = await Promise.allSettled([
-    client.session.list({}, { throwOnError: true }),
+    client.experimental.session.list({ archived: true }, { throwOnError: true }),
     client.provider.list({}, { throwOnError: true }),
     client.session.status({}, { throwOnError: true }),
     client.app.agents({}, { throwOnError: true }),

--- a/src/test/ChatSidebar.test.tsx
+++ b/src/test/ChatSidebar.test.tsx
@@ -18,20 +18,27 @@ import { PreferencesProvider } from "@/providers/PreferencesProvider";
 
 // ── Helpers ──────────────────────────────────────────────────────────
 
-function makeSession(id: string, title: string, createdAt = Date.now()): Session {
+function makeSession(
+  id: string,
+  title: string,
+  createdAt = Date.now(),
+  archived?: number,
+): Session {
   return {
     id,
     title,
-    time: { created: createdAt, updated: createdAt },
+    time: { created: createdAt, updated: createdAt, archived },
     version: 1,
     parentID: "",
   } as Session;
 }
 
 function createClient(overrides: Record<string, unknown> = {}) {
+  const list = vi.fn().mockResolvedValue({ data: [] });
   return {
+    experimental: { session: { list } },
     session: {
-      list: vi.fn().mockResolvedValue({ data: [] }),
+      list,
       get: vi.fn().mockResolvedValue({ data: null }),
       create: vi.fn().mockResolvedValue({ data: null }),
       delete: vi.fn().mockResolvedValue({ data: true }),
@@ -179,36 +186,84 @@ describe("ChatSidebar", () => {
     expect(onSessionSelect).toHaveBeenCalled();
   });
 
-  it("calls session.delete when Delete is clicked", async () => {
-    const s1 = makeSession("s1", "To Delete");
-    const client = createClient({ delete: vi.fn().mockResolvedValue({ data: true }) });
+  it("snoozes an idle session instead of deleting it", async () => {
+    const s1 = makeSession("s1", "To Snooze");
+    const snoozed = makeSession("s1", "To Snooze", s1.time.created, Date.now());
+    const client = createClient({ update: vi.fn().mockResolvedValue({ data: snoozed }) });
     const qc = createQueryClient();
     seedState(qc, { sessions: [s1] });
     qc.setQueryData(qk.statuses, { s1: { type: "idle" } });
-    qc.setQueryData(qk.messages("s1"), { messageIds: [], messagesById: {} });
-    qc.setQueryData(qk.todos("s1"), []);
-    qc.setQueryData(qk.questions("s1"), null);
-    qc.setQueryData(qk.permissions("s1"), null);
 
     render(<TestSidebar client={client} queryClient={qc} />);
 
-    expect(await screen.findByText("To Delete")).toBeInTheDocument();
+    expect(await screen.findByText("To Snooze")).toBeInTheDocument();
 
-    const deleteBtn = screen.getByTitle("Delete");
+    const snoozeBtn = screen.getByTitle("Snooze");
     await act(async () => {
-      fireEvent.click(deleteBtn);
+      fireEvent.click(snoozeBtn);
     });
 
-    expect(client.session.delete).toHaveBeenCalledWith({ sessionID: "s1" }, { throwOnError: true });
+    expect(client.session.update).toHaveBeenCalledWith(
+      { sessionID: "s1", time: { archived: expect.any(Number) } },
+      { throwOnError: true },
+    );
+    expect(client.session.delete).not.toHaveBeenCalled();
 
     await waitFor(() => {
-      expect(screen.queryByText("To Delete")).not.toBeInTheDocument();
+      expect(screen.getByText("Snoozed")).toBeInTheDocument();
     });
-    expect(qc.getQueryData(qk.messages("s1"))).toBeUndefined();
-    expect(qc.getQueryData(qk.todos("s1"))).toBeUndefined();
-    expect(qc.getQueryData(qk.questions("s1"))).toBeUndefined();
-    expect(qc.getQueryData(qk.permissions("s1"))).toBeUndefined();
-    expect(qc.getQueryData<Record<string, unknown>>(qk.statuses)).toEqual({});
+  });
+
+  it("does not snooze a busy session", async () => {
+    const client = createClient();
+    const qc = createQueryClient();
+    seedState(qc, { sessions: [makeSession("s1", "Still working")] });
+    qc.setQueryData(qk.statuses, { s1: { type: "busy" } });
+
+    render(<TestSidebar client={client} queryClient={qc} />);
+
+    const button = await screen.findByTitle("Wait for session to finish");
+    expect(button).toBeDisabled();
+    fireEvent.click(button);
+    expect(client.session.update).not.toHaveBeenCalled();
+  });
+
+  it("restores and opens a snoozed session", async () => {
+    const snoozed = makeSession("s1", "A very long snoozed session title", Date.now(), Date.now());
+    const restored = makeSession("s1", snoozed.title, snoozed.time.created);
+    const client = createClient({ update: vi.fn().mockResolvedValue({ data: restored }) });
+    const qc = createQueryClient();
+    seedState(qc, { sessions: [snoozed] });
+
+    render(<TestSidebar client={client} queryClient={qc} />);
+    fireEvent.click(await screen.findByText("Snoozed"));
+    await act(async () => {
+      fireEvent.click(screen.getByTitle(`Restore and open ${snoozed.title}`));
+    });
+
+    expect(client.session.update).toHaveBeenCalledWith(
+      { sessionID: "s1", time: {} },
+      { throwOnError: true },
+    );
+    await waitFor(() => expect(screen.queryByText("Snoozed")).not.toBeInTheDocument());
+  });
+
+  it("permanently deletes a snoozed session only after confirmation", async () => {
+    const snoozed = makeSession("s1", "Old session", Date.now(), Date.now());
+    const client = createClient();
+    const qc = createQueryClient();
+    seedState(qc, { sessions: [snoozed] });
+    const confirm = vi.spyOn(window, "confirm").mockReturnValue(false);
+
+    render(<TestSidebar client={client} queryClient={qc} />);
+    fireEvent.click(await screen.findByText("Snoozed"));
+    const deleteButton = screen.getByTitle("Delete permanently");
+    fireEvent.click(deleteButton);
+    expect(client.session.delete).not.toHaveBeenCalled();
+
+    confirm.mockReturnValue(true);
+    await act(async () => fireEvent.click(deleteButton));
+    expect(client.session.delete).toHaveBeenCalledWith({ sessionID: "s1" }, { throwOnError: true });
   });
 
   it("enters rename mode and commits on Enter", async () => {

--- a/src/test/ChatSidebar.test.tsx
+++ b/src/test/ChatSidebar.test.tsx
@@ -16,6 +16,9 @@ import { ActiveSessionProvider } from "@/providers/ActiveSessionProvider";
 import { OpenCodeClientContext } from "@/providers/OpenCodeClientProvider";
 import { PreferencesProvider } from "@/providers/PreferencesProvider";
 
+const { capture } = vi.hoisted(() => ({ capture: vi.fn() }));
+vi.mock("posthog-js/dist/module.full.no-external.js", () => ({ default: { capture } }));
+
 // ── Helpers ──────────────────────────────────────────────────────────
 
 function makeSession(
@@ -212,6 +215,7 @@ describe("ChatSidebar", () => {
     await waitFor(() => {
       expect(screen.getByText("Snoozed")).toBeInTheDocument();
     });
+    expect(capture).toHaveBeenCalledWith("session_snoozed");
   });
 
   it("does not snooze a busy session", async () => {
@@ -237,11 +241,16 @@ describe("ChatSidebar", () => {
 
     render(<TestSidebar client={client} queryClient={qc} onSessionSelect={onSessionSelect} />);
     fireEvent.click(await screen.findByText("Snoozed"));
+    expect(capture).toHaveBeenCalledWith("snoozed_section_toggled", {
+      expanded: true,
+      count_bucket: "1",
+    });
     await act(async () => {
       fireEvent.click(screen.getByTitle(`Open snoozed session ${snoozed.title}`));
     });
 
     expect(onSessionSelect).toHaveBeenCalled();
+    expect(capture).toHaveBeenCalledWith("snoozed_session_opened");
     expect(client.session.update).not.toHaveBeenCalled();
     expect(screen.getByText("Snoozed")).toBeInTheDocument();
   });
@@ -274,9 +283,12 @@ describe("ChatSidebar", () => {
     const deleteButton = screen.getByTitle("Delete permanently");
     fireEvent.click(deleteButton);
     expect(client.session.delete).not.toHaveBeenCalled();
+    expect(capture).toHaveBeenCalledWith("permanent_delete_requested");
+    expect(capture).toHaveBeenCalledWith("permanent_delete_cancelled");
 
     confirm.mockReturnValue(true);
     await act(async () => fireEvent.click(deleteButton));
+    expect(capture).toHaveBeenCalledWith("permanent_delete_confirmed");
     expect(client.session.delete).toHaveBeenCalledWith({ sessionID: "s1" }, { throwOnError: true });
   });
 

--- a/src/test/ChatSidebar.test.tsx
+++ b/src/test/ChatSidebar.test.tsx
@@ -246,6 +246,22 @@ describe("ChatSidebar", () => {
     expect(screen.getByText("Snoozed")).toBeInTheDocument();
   });
 
+  it("pins the snoozed fold directly above settings", async () => {
+    const client = createClient();
+    const qc = createQueryClient();
+    seedState(qc, {
+      sessions: [makeSession("s1", "Archived", Date.now(), Date.now())],
+    });
+
+    render(<TestSidebar client={client} queryClient={qc} />);
+
+    const snoozed = await screen.findByText("Snoozed");
+    const settings = screen.getByText("Settings");
+    expect(
+      snoozed.compareDocumentPosition(settings) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+  });
+
   it("permanently deletes a snoozed session only after confirmation", async () => {
     const snoozed = makeSession("s1", "Old session", Date.now(), Date.now());
     const client = createClient();

--- a/src/test/ChatSidebar.test.tsx
+++ b/src/test/ChatSidebar.test.tsx
@@ -228,24 +228,22 @@ describe("ChatSidebar", () => {
     expect(client.session.update).not.toHaveBeenCalled();
   });
 
-  it("restores and opens a snoozed session", async () => {
+  it("opens a snoozed session without changing its archive timestamp", async () => {
     const snoozed = makeSession("s1", "A very long snoozed session title", Date.now(), Date.now());
-    const restored = makeSession("s1", snoozed.title, snoozed.time.created);
-    const client = createClient({ update: vi.fn().mockResolvedValue({ data: restored }) });
+    const client = createClient({ get: vi.fn().mockResolvedValue({ data: snoozed }) });
     const qc = createQueryClient();
     seedState(qc, { sessions: [snoozed] });
+    const onSessionSelect = vi.fn();
 
-    render(<TestSidebar client={client} queryClient={qc} />);
+    render(<TestSidebar client={client} queryClient={qc} onSessionSelect={onSessionSelect} />);
     fireEvent.click(await screen.findByText("Snoozed"));
     await act(async () => {
-      fireEvent.click(screen.getByTitle(`Restore and open ${snoozed.title}`));
+      fireEvent.click(screen.getByTitle(`Open snoozed session ${snoozed.title}`));
     });
 
-    expect(client.session.update).toHaveBeenCalledWith(
-      { sessionID: "s1", time: {} },
-      { throwOnError: true },
-    );
-    await waitFor(() => expect(screen.queryByText("Snoozed")).not.toBeInTheDocument());
+    expect(onSessionSelect).toHaveBeenCalled();
+    expect(client.session.update).not.toHaveBeenCalled();
+    expect(screen.getByText("Snoozed")).toBeInTheDocument();
   });
 
   it("permanently deletes a snoozed session only after confirmation", async () => {

--- a/src/test/OpenCodeClientProvider.test.ts
+++ b/src/test/OpenCodeClientProvider.test.ts
@@ -13,8 +13,10 @@ function makeQueryClient() {
 describe("OpenCode query lifecycle", () => {
   it("keeps successful startup snapshots when another endpoint fails", async () => {
     const client = {
+      experimental: {
+        session: { list: vi.fn().mockRejectedValue(new Error("sessions unavailable")) },
+      },
       session: {
-        list: vi.fn().mockRejectedValue(new Error("sessions unavailable")),
         status: vi.fn().mockResolvedValue({ data: { s1: { type: "idle" } } }),
       },
       provider: {
@@ -44,7 +46,8 @@ describe("OpenCode query lifecycle", () => {
   it("fails startup when every server-state endpoint is unavailable", async () => {
     const unavailable = vi.fn().mockRejectedValue(new Error("unavailable"));
     const client = {
-      session: { list: unavailable, status: unavailable },
+      experimental: { session: { list: unavailable } },
+      session: { status: unavailable },
       provider: { list: unavailable, auth: unavailable },
       app: { agents: unavailable },
     } as unknown as OpencodeClient;

--- a/src/test/analytics.test.ts
+++ b/src/test/analytics.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   captureDetailedAnalytics,
+  countBucket,
   detailedAnalyticsProperties,
   setDetailedAnalyticsEnabled,
 } from "@/lib/analytics";
@@ -16,6 +17,15 @@ function posthogStub() {
 
 describe("PostHog analytics", () => {
   beforeEach(() => setDetailedAnalyticsEnabled(false));
+
+  it("buckets counts without exposing exact larger values", () => {
+    expect(countBucket(1)).toBe("1");
+    expect(countBucket(2)).toBe("2-5");
+    expect(countBucket(5)).toBe("2-5");
+    expect(countBucket(6)).toBe("6-10");
+    expect(countBucket(10)).toBe("6-10");
+    expect(countBucket(42)).toBe("11+");
+  });
 
   it("removes detailed properties until the user opts in", () => {
     const properties = { provider: "anthropic", model: "claude-sonnet-4" };

--- a/src/test/app.test.tsx
+++ b/src/test/app.test.tsx
@@ -479,11 +479,12 @@ describe("User journeys", () => {
     );
   });
 
-  it("deletes a session and it disappears from the sidebar", async () => {
+  it("snoozes a session and moves it out of the active list", async () => {
     const s1 = makeSession("s1", "Session One");
     const s2 = makeSession("s2", "Session Two");
+    const snoozed = { ...s1, time: { ...s1.time, archived: Date.now() } };
     const client = createClient({
-      delete: vi.fn().mockResolvedValue({ data: true }),
+      update: vi.fn().mockResolvedValue({ data: snoozed }),
       get: vi.fn().mockResolvedValue({ data: s1 }),
       messages: vi.fn().mockResolvedValue({ data: [] }),
     });
@@ -499,17 +500,21 @@ describe("User journeys", () => {
     expect(await screen.findByText("Session One")).toBeInTheDocument();
     expect(screen.getByText("Session Two")).toBeInTheDocument();
 
-    // Find the delete button (title="Delete") within the session row
-    const deleteButtons = screen.getAllByTitle("Delete");
+    const snoozeButtons = screen.getAllByTitle("Snooze");
     await act(async () => {
-      fireEvent.click(deleteButtons[0]);
+      fireEvent.click(snoozeButtons[0]);
     });
 
-    expect(client.session.delete).toHaveBeenCalledWith({ sessionID: "s1" }, { throwOnError: true });
+    expect(client.session.update).toHaveBeenCalledWith(
+      { sessionID: "s1", time: { archived: expect.any(Number) } },
+      { throwOnError: true },
+    );
+    expect(client.session.delete).not.toHaveBeenCalled();
 
-    // Session One should be gone from the sidebar
+    // Session One leaves the active list and the folded snoozed section appears.
     await waitFor(() => {
       expect(screen.queryByText("Session One")).not.toBeInTheDocument();
+      expect(screen.getByText("Snoozed")).toBeInTheDocument();
     });
     // Session Two should still be there
     expect(screen.getByText("Session Two")).toBeInTheDocument();


### PR DESCRIPTION
## What changed

- replaces the active-session delete affordance with Snooze, backed by OpenCode's existing `time.archived` timestamp
- keeps active threads in the main flexible list and pins a folded Snoozed section directly above Settings
- bounds the expanded Snoozed list with its own scrolling and uses normal available-width single-line ellipsis for titles
- opens a snoozed thread when selected without changing its archived state, while permanent deletion remains a secondary, confirmation-gated action
- disables snoozing for busy sessions so in-flight work is not hidden
- fetches archived sessions during startup and normal session queries
- adds privacy-safe product events for snoozing, toggling/opening the Snoozed section, and the permanent-delete decision flow
- adds component and user-journey coverage for snooze, busy protection, opening snoozed sessions, pinned placement, telemetry, and confirmed deletion

## Analytics privacy

The new events are emitted only from user interactions or successful snooze completion. They never include session IDs, titles, content, or timestamps. The section toggle includes only its expanded boolean and a coarse count bucket (`1`, `2-5`, `6-10`, or `11+`).

## Why

Deleting a thread was too easy and irreversible. Snoozing preserves its full OpenCode history while keeping the active list focused. The bottom-pinned fold keeps archived work accessible without interrupting the active thread list.

## Validation

- `NODE_OPTIONS=--localstorage-file=/tmp/bloxbot-vitest-localstorage pnpm test` — 145 app tests and 8 release tests passed
- `pnpm typecheck`
- `pnpm build`
- `pnpm lint` — passes with the repository's existing warnings
- isolated Vite renders inspected; no Electron or desktop capture used

## Screenshots

### Snoozed — collapsed

![Snoozed section collapsed above Settings](https://github.com/user-attachments/assets/2d2403b6-3c3e-45c9-b6ce-a8b16013bc81)

### Snoozed — expanded

![Snoozed section expanded with bounded session list](https://github.com/user-attachments/assets/7a23f601-0558-4cdc-81fa-c3d6171299bf)
