### PR TITLE
Add agent playtest flow

### DIFF
--- a/src/components/Chat.tsx
+++ b/src/components/Chat.tsx
@@ -5,6 +5,7 @@ import ChatInput from "@/components/ChatInput";
 import ChatMessages from "@/components/ChatMessages";
 import ChatSidebar from "@/components/ChatSidebar";
 import LoadingScreen from "@/components/LoadingScreen";
+import PlaytestPanel from "@/components/PlaytestPanel";
 import StudioSetup from "@/components/StudioSetup";
 import { useCreateSession } from "@/hooks/mutations/useCreateSession";
 import { useSessionStatus } from "@/hooks/useSessionStatuses";
@@ -31,6 +32,7 @@ function Chat() {
   const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
   const [showSettings, setShowSettings] = useState(false);
   const [showStudioSetup, setShowStudioSetup] = useState(false);
+  const [showPlaytest, setShowPlaytest] = useState(false);
 
   const appScreen =
     showStudioSetup || studioConnection.state === "waiting"
@@ -86,7 +88,7 @@ function Chat() {
         onOpenSettings={handleOpenSettings}
       />
 
-      <div className="flex min-w-0 flex-1 flex-col">
+      <div className="relative flex min-w-0 flex-1 flex-col">
         {showStudioSetup || studioConnection.state === "waiting" ? (
           <StudioSetup
             connected={studioConnection.state === "connected"}
@@ -134,8 +136,8 @@ function Chat() {
           </div>
         ) : (
           <>
-            <div className="flex h-10 shrink-0 items-center border-b px-4">
-              <div className="flex items-center gap-2">
+            <div className="flex h-10 shrink-0 items-center justify-between border-b px-4">
+              <div className="flex min-w-0 items-center gap-2">
                 <h3 className="truncate text-xs font-semibold">
                   {activeSessionTitle || "Untitled"}
                 </h3>
@@ -146,10 +148,20 @@ function Chat() {
                   </span>
                 )}
               </div>
+              <button
+                type="button"
+                onClick={() => setShowPlaytest(true)}
+                disabled={isBusy}
+                className="ml-3 inline-flex h-7 items-center gap-1.5 rounded-md border border-amber-300 bg-amber-50 px-2.5 text-[11px] font-semibold text-amber-800 transition-colors hover:bg-amber-100 disabled:opacity-40 dark:border-amber-800 dark:bg-amber-950/40 dark:text-amber-300 dark:hover:bg-amber-950"
+                title={isBusy ? "Wait for the agent to finish" : "Create a playtest plan"}
+              >
+                <span aria-hidden="true">▶</span> Playtest
+              </button>
             </div>
 
             <ChatMessages />
             <ChatInput />
+            {showPlaytest ? <PlaytestPanel onClose={() => setShowPlaytest(false)} /> : null}
           </>
         )}
 

--- a/src/components/Chat.tsx
+++ b/src/components/Chat.tsx
@@ -88,7 +88,7 @@ function Chat() {
         onOpenSettings={handleOpenSettings}
       />
 
-      <div className="relative flex min-w-0 flex-1 flex-col">
+      <div className="flex min-w-0 flex-1 flex-col">
         {showStudioSetup || studioConnection.state === "waiting" ? (
           <StudioSetup
             connected={studioConnection.state === "connected"}
@@ -161,7 +161,6 @@ function Chat() {
 
             <ChatMessages />
             <ChatInput />
-            {showPlaytest ? <PlaytestPanel onClose={() => setShowPlaytest(false)} /> : null}
           </>
         )}
 
@@ -171,6 +170,9 @@ function Chat() {
           </div>
         )}
       </div>
+      {showPlaytest && activeSessionId ? (
+        <PlaytestPanel onClose={() => setShowPlaytest(false)} />
+      ) : null}
     </div>
   );
 }

--- a/src/components/Chat.tsx
+++ b/src/components/Chat.tsx
@@ -152,10 +152,10 @@ function Chat() {
                 type="button"
                 onClick={() => setShowPlaytest(true)}
                 disabled={isBusy}
-                className="ml-3 inline-flex h-7 items-center gap-1.5 rounded-md border border-amber-300 bg-amber-50 px-2.5 text-[11px] font-semibold text-amber-800 transition-colors hover:bg-amber-100 disabled:opacity-40 dark:border-amber-800 dark:bg-amber-950/40 dark:text-amber-300 dark:hover:bg-amber-950"
+                className="ml-3 inline-flex h-7 items-center gap-1.5 rounded-md bg-foreground px-2.5 text-[11px] font-semibold text-background transition-opacity hover:opacity-85 disabled:opacity-40"
                 title={isBusy ? "Wait for the agent to finish" : "Create a playtest plan"}
               >
-                <span aria-hidden="true">▶</span> Playtest
+                <span aria-hidden="true">▷</span> Playtest
               </button>
             </div>
 

--- a/src/components/Chat.tsx
+++ b/src/components/Chat.tsx
@@ -77,6 +77,14 @@ function Chat() {
   const handleToggleSidebar = useCallback(() => setSidebarCollapsed((c) => !c), []);
   const handleSessionSelect = useCallback(() => setShowSettings(false), []);
   const handleOpenSettings = useCallback(() => setShowSettings(true), []);
+  const handleOpenPlaytest = useCallback(() => {
+    posthog.capture("playtest_opened");
+    setShowPlaytest(true);
+  }, []);
+  const handleClosePlaytest = useCallback(() => {
+    posthog.capture("playtest_closed");
+    setShowPlaytest(false);
+  }, []);
 
   // Main chat UI
   return (
@@ -150,7 +158,7 @@ function Chat() {
               </div>
               <button
                 type="button"
-                onClick={() => setShowPlaytest(true)}
+                onClick={handleOpenPlaytest}
                 disabled={isBusy}
                 className="ml-3 inline-flex h-7 items-center gap-1.5 rounded-md bg-foreground px-2.5 text-[11px] font-semibold text-background transition-opacity hover:opacity-85 disabled:opacity-40"
                 title={isBusy ? "Wait for the agent to finish" : "Create a playtest plan"}
@@ -170,9 +178,7 @@ function Chat() {
           </div>
         )}
       </div>
-      {showPlaytest && activeSessionId ? (
-        <PlaytestPanel onClose={() => setShowPlaytest(false)} />
-      ) : null}
+      {showPlaytest && activeSessionId ? <PlaytestPanel onClose={handleClosePlaytest} /> : null}
     </div>
   );
 }

--- a/src/components/PlaytestPanel.tsx
+++ b/src/components/PlaytestPanel.tsx
@@ -150,7 +150,7 @@ export default function PlaytestPanel({ onClose }: { onClose: () => void }) {
       role="dialog"
       aria-label="Playtest planner"
     >
-      <header className="flex shrink-0 items-start justify-between border-b px-5 py-4">
+      <header className="flex h-16 shrink-0 items-center justify-between border-b px-5">
         <h2 className="font-serif text-xl">Playtest</h2>
         <button
           type="button"

--- a/src/components/PlaytestPanel.tsx
+++ b/src/components/PlaytestPanel.tsx
@@ -1,0 +1,189 @@
+import { useState } from "react";
+import { toast } from "sonner";
+import { useGeneratePlaytestPlan } from "@/hooks/mutations/useGeneratePlaytestPlan";
+import { useSendMessage } from "@/hooks/mutations/useSendMessage";
+import { formatPlaytestPrompt, type PlaytestPlan } from "@/lib/playtestPlan";
+
+function ListEditor({
+  label,
+  items,
+  onChange,
+}: {
+  label: string;
+  items: string[];
+  onChange: (items: string[]) => void;
+}) {
+  return (
+    <fieldset>
+      <legend className="mb-1.5 text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
+        {label}
+      </legend>
+      <div className="space-y-2">
+        {items.map((item, index) => (
+          <div className="flex gap-2" key={`${label}-${index}`}>
+            <span className="mt-2 text-[11px] text-muted-foreground">{index + 1}.</span>
+            <textarea
+              aria-label={`${label} ${index + 1}`}
+              value={item}
+              onChange={(event) =>
+                onChange(items.map((current, i) => (i === index ? event.target.value : current)))
+              }
+              className="min-h-9 flex-1 resize-y rounded-md border bg-background px-2.5 py-2 text-xs outline-none focus:border-ring"
+            />
+            {items.length > 1 ? (
+              <button
+                type="button"
+                onClick={() => onChange(items.filter((_, i) => i !== index))}
+                className="h-8 px-1 text-muted-foreground hover:text-foreground"
+                aria-label={`Remove ${label} ${index + 1}`}
+              >
+                ×
+              </button>
+            ) : null}
+          </div>
+        ))}
+        <button
+          type="button"
+          onClick={() => onChange([...items, ""])}
+          className="text-[11px] font-medium text-muted-foreground hover:text-foreground"
+        >
+          + Add item
+        </button>
+      </div>
+    </fieldset>
+  );
+}
+
+export default function PlaytestPanel({ onClose }: { onClose: () => void }) {
+  const generate = useGeneratePlaytestPlan();
+  const sendMessage = useSendMessage();
+  const [plan, setPlan] = useState<PlaytestPlan | null>(null);
+
+  async function generatePlan() {
+    try {
+      setPlan(await generate.mutateAsync());
+    } catch (error) {
+      toast.error("Couldn't create a playtest plan", {
+        description: error instanceof Error ? error.message : "Try again.",
+      });
+    }
+  }
+
+  function runPlaytest() {
+    if (!plan) return;
+    const complete =
+      plan.goal.trim() &&
+      [plan.steps, plan.watchFor, plan.successCriteria].every(
+        (items) => items.length > 0 && items.every((item) => item.trim()),
+      );
+    if (!complete) {
+      toast.error("Complete every playtest field before running it.");
+      return;
+    }
+    sendMessage.mutate(
+      { text: formatPlaytestPrompt(plan) },
+      {
+        onSuccess: onClose,
+        onError: (error) => toast.error("Playtest not started", { description: error.message }),
+      },
+    );
+  }
+
+  return (
+    <div
+      className="absolute inset-0 z-40 flex justify-end bg-black/25 backdrop-blur-[1px]"
+      role="dialog"
+      aria-modal="true"
+      aria-label="Playtest planner"
+    >
+      <div className="flex h-full w-full max-w-md flex-col border-l bg-card shadow-2xl">
+        <header className="flex items-start justify-between border-b px-5 py-4">
+          <div>
+            <h2 className="font-serif text-xl italic">Playtest</h2>
+            <p className="mt-1 text-xs text-muted-foreground">
+              Turn this chat into an editable Studio test plan.
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded-md px-2 py-1 text-lg text-muted-foreground hover:bg-accent hover:text-foreground"
+            aria-label="Close playtest"
+          >
+            ×
+          </button>
+        </header>
+        <div className="flex-1 overflow-y-auto p-5">
+          {!plan ? (
+            <div className="flex h-full flex-col items-center justify-center text-center">
+              <div className="mb-4 flex h-12 w-12 items-center justify-center rounded-2xl bg-amber-100 text-2xl dark:bg-amber-950/50">
+                ▶
+              </div>
+              <h3 className="text-sm font-semibold">Plan a focused test run</h3>
+              <p className="mt-2 max-w-xs text-xs leading-5 text-muted-foreground">
+                The planner reads this chat, but cannot use Studio tools or change your project.
+              </p>
+              <button
+                type="button"
+                onClick={generatePlan}
+                disabled={generate.isPending}
+                className="mt-5 rounded-lg bg-foreground px-4 py-2 text-xs font-semibold text-background disabled:opacity-50"
+              >
+                {generate.isPending ? "Creating plan…" : "Generate test plan"}
+              </button>
+            </div>
+          ) : (
+            <div className="space-y-5">
+              <label className="block">
+                <span className="mb-1.5 block text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
+                  Goal
+                </span>
+                <textarea
+                  aria-label="Goal"
+                  value={plan.goal}
+                  onChange={(e) => setPlan({ ...plan, goal: e.target.value })}
+                  className="min-h-20 w-full resize-y rounded-md border bg-background px-3 py-2 text-xs outline-none focus:border-ring"
+                />
+              </label>
+              <ListEditor
+                label="Steps"
+                items={plan.steps}
+                onChange={(steps) => setPlan({ ...plan, steps })}
+              />
+              <ListEditor
+                label="Watch for"
+                items={plan.watchFor}
+                onChange={(watchFor) => setPlan({ ...plan, watchFor })}
+              />
+              <ListEditor
+                label="Success criteria"
+                items={plan.successCriteria}
+                onChange={(successCriteria) => setPlan({ ...plan, successCriteria })}
+              />
+            </div>
+          )}
+        </div>
+        {plan ? (
+          <footer className="flex items-center justify-between gap-3 border-t px-5 py-4">
+            <button
+              type="button"
+              onClick={generatePlan}
+              disabled={generate.isPending || sendMessage.isPending}
+              className="text-xs font-medium text-muted-foreground hover:text-foreground disabled:opacity-50"
+            >
+              Regenerate
+            </button>
+            <button
+              type="button"
+              onClick={runPlaytest}
+              disabled={sendMessage.isPending || generate.isPending}
+              className="rounded-lg bg-amber-500 px-4 py-2 text-xs font-semibold text-white hover:bg-amber-600 disabled:opacity-50"
+            >
+              {sendMessage.isPending ? "Starting…" : "Run playtest"}
+            </button>
+          </footer>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/src/components/PlaytestPanel.tsx
+++ b/src/components/PlaytestPanel.tsx
@@ -1,8 +1,22 @@
+import posthog from "posthog-js/dist/module.full.no-external.js";
 import { useState } from "react";
 import { toast } from "sonner";
 import { useGeneratePlaytestPlan } from "@/hooks/mutations/useGeneratePlaytestPlan";
 import { useSendMessage } from "@/hooks/mutations/useSendMessage";
+import { detailedAnalyticsProperties } from "@/lib/analytics";
 import { formatPlaytestPrompt, type PlaytestPlan } from "@/lib/playtestPlan";
+import { splitModelKey } from "@/lib/splitModelKey";
+import { usePreferences } from "@/providers/PreferencesProvider";
+
+function generationErrorCategory(error: unknown): string {
+  if (!(error instanceof Error)) return "unknown";
+  if (error.message.includes("chat context")) return "no_chat_context";
+  if (error.message.includes("invalid") || error.message.includes("incomplete")) {
+    return "invalid_plan";
+  }
+  if (error.message.includes("start")) return "planner_start_failed";
+  return "generation_failed";
+}
 
 function ListEditor({
   label,
@@ -57,16 +71,43 @@ function ListEditor({
 export default function PlaytestPanel({ onClose }: { onClose: () => void }) {
   const generate = useGeneratePlaytestPlan();
   const sendMessage = useSendMessage();
+  const { selectedModel } = usePreferences();
   const [plan, setPlan] = useState<PlaytestPlan | null>(null);
 
+  const [provider, model] = selectedModel ? splitModelKey(selectedModel) : [undefined, undefined];
+
   function writeOwnPlan() {
+    posthog.capture("manual_entry_selected");
     setPlan({ goal: "", steps: [""], watchFor: [""], successCriteria: [""] });
   }
 
   async function generatePlan() {
+    const startedAt = performance.now();
+    posthog.capture("generation_started", detailedAnalyticsProperties({ provider, model }));
     try {
-      setPlan(await generate.mutateAsync());
+      const generatedPlan = await generate.mutateAsync();
+      setPlan(generatedPlan);
+      posthog.capture(
+        "generation_succeeded",
+        detailedAnalyticsProperties({
+          provider,
+          model,
+          duration_ms: Math.round(performance.now() - startedAt),
+          step_count: generatedPlan.steps.length,
+          watch_for_count: generatedPlan.watchFor.length,
+          success_criteria_count: generatedPlan.successCriteria.length,
+        }),
+      );
     } catch (error) {
+      posthog.capture(
+        "generation_failed",
+        detailedAnalyticsProperties({
+          provider,
+          model,
+          duration_ms: Math.round(performance.now() - startedAt),
+          error_category: generationErrorCategory(error),
+        }),
+      );
       toast.error("Couldn't create a playtest plan", {
         description: error instanceof Error ? error.message : "Try again.",
       });
@@ -84,6 +125,16 @@ export default function PlaytestPanel({ onClose }: { onClose: () => void }) {
       toast.error("Complete every playtest field before running it.");
       return;
     }
+    posthog.capture(
+      "playtest_started",
+      detailedAnalyticsProperties({
+        provider,
+        model,
+        step_count: plan.steps.length,
+        watch_for_count: plan.watchFor.length,
+        success_criteria_count: plan.successCriteria.length,
+      }),
+    );
     sendMessage.mutate(
       { text: formatPlaytestPrompt(plan) },
       {
@@ -99,8 +150,8 @@ export default function PlaytestPanel({ onClose }: { onClose: () => void }) {
       role="dialog"
       aria-label="Playtest planner"
     >
-      <header className="flex shrink-0 items-start justify-between px-5 py-4">
-        <h2 className="font-serif text-xl italic">Playtest</h2>
+      <header className="flex shrink-0 items-start justify-between border-b px-5 py-4">
+        <h2 className="font-serif text-xl">Playtest</h2>
         <button
           type="button"
           onClick={onClose}

--- a/src/components/PlaytestPanel.tsx
+++ b/src/components/PlaytestPanel.tsx
@@ -90,100 +90,97 @@ export default function PlaytestPanel({ onClose }: { onClose: () => void }) {
   }
 
   return (
-    <div
-      className="absolute inset-0 z-40 flex justify-end bg-black/25 backdrop-blur-[1px]"
+    <aside
+      className="flex w-[min(24rem,45vw)] min-w-0 shrink-0 flex-col border-l bg-sidebar"
       role="dialog"
-      aria-modal="true"
       aria-label="Playtest planner"
     >
-      <div className="flex h-full w-full max-w-md flex-col border-l bg-card shadow-2xl">
-        <header className="flex items-start justify-between border-b px-5 py-4">
-          <div>
-            <h2 className="font-serif text-xl italic">Playtest</h2>
-            <p className="mt-1 text-xs text-muted-foreground">
-              Turn this chat into an editable Studio test plan.
-            </p>
-          </div>
-          <button
-            type="button"
-            onClick={onClose}
-            className="rounded-md px-2 py-1 text-lg text-muted-foreground hover:bg-accent hover:text-foreground"
-            aria-label="Close playtest"
-          >
-            ×
-          </button>
-        </header>
-        <div className="flex-1 overflow-y-auto p-5">
-          {!plan ? (
-            <div className="flex h-full flex-col items-center justify-center text-center">
-              <div className="mb-4 flex h-12 w-12 items-center justify-center rounded-2xl bg-amber-100 text-2xl dark:bg-amber-950/50">
-                ▶
-              </div>
-              <h3 className="text-sm font-semibold">Plan a focused test run</h3>
-              <p className="mt-2 max-w-xs text-xs leading-5 text-muted-foreground">
-                The planner reads this chat, but cannot use Studio tools or change your project.
-              </p>
-              <button
-                type="button"
-                onClick={generatePlan}
-                disabled={generate.isPending}
-                className="mt-5 rounded-lg bg-foreground px-4 py-2 text-xs font-semibold text-background disabled:opacity-50"
-              >
-                {generate.isPending ? "Creating plan…" : "Generate test plan"}
-              </button>
-            </div>
-          ) : (
-            <div className="space-y-5">
-              <label className="block">
-                <span className="mb-1.5 block text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
-                  Goal
-                </span>
-                <textarea
-                  aria-label="Goal"
-                  value={plan.goal}
-                  onChange={(e) => setPlan({ ...plan, goal: e.target.value })}
-                  className="min-h-20 w-full resize-y rounded-md border bg-background px-3 py-2 text-xs outline-none focus:border-ring"
-                />
-              </label>
-              <ListEditor
-                label="Steps"
-                items={plan.steps}
-                onChange={(steps) => setPlan({ ...plan, steps })}
-              />
-              <ListEditor
-                label="Watch for"
-                items={plan.watchFor}
-                onChange={(watchFor) => setPlan({ ...plan, watchFor })}
-              />
-              <ListEditor
-                label="Success criteria"
-                items={plan.successCriteria}
-                onChange={(successCriteria) => setPlan({ ...plan, successCriteria })}
-              />
-            </div>
-          )}
+      <header className="flex shrink-0 items-start justify-between border-b px-5 py-4">
+        <div>
+          <h2 className="font-serif text-xl italic">Playtest</h2>
+          <p className="mt-1 text-xs text-muted-foreground">
+            Turn this chat into an editable Studio test plan.
+          </p>
         </div>
-        {plan ? (
-          <footer className="flex items-center justify-between gap-3 border-t px-5 py-4">
+        <button
+          type="button"
+          onClick={onClose}
+          className="rounded-md px-2 py-1 text-lg text-muted-foreground hover:bg-accent hover:text-foreground"
+          aria-label="Close playtest"
+        >
+          ×
+        </button>
+      </header>
+      <div className="flex-1 overflow-y-auto p-5">
+        {!plan ? (
+          <div className="flex h-full flex-col items-center justify-center text-center">
+            <div className="mb-4 flex h-12 w-12 items-center justify-center rounded-2xl bg-amber-100 text-2xl dark:bg-amber-950/50">
+              ▶
+            </div>
+            <h3 className="text-sm font-semibold">Plan a focused test run</h3>
+            <p className="mt-2 max-w-xs text-xs leading-5 text-muted-foreground">
+              The planner reads this chat, but cannot use Studio tools or change your project.
+            </p>
             <button
               type="button"
               onClick={generatePlan}
-              disabled={generate.isPending || sendMessage.isPending}
-              className="text-xs font-medium text-muted-foreground hover:text-foreground disabled:opacity-50"
+              disabled={generate.isPending}
+              className="mt-5 rounded-lg bg-foreground px-4 py-2 text-xs font-semibold text-background disabled:opacity-50"
             >
-              Regenerate
+              {generate.isPending ? "Creating plan…" : "Generate test plan"}
             </button>
-            <button
-              type="button"
-              onClick={runPlaytest}
-              disabled={sendMessage.isPending || generate.isPending}
-              className="rounded-lg bg-amber-500 px-4 py-2 text-xs font-semibold text-white hover:bg-amber-600 disabled:opacity-50"
-            >
-              {sendMessage.isPending ? "Starting…" : "Run playtest"}
-            </button>
-          </footer>
-        ) : null}
+          </div>
+        ) : (
+          <div className="space-y-5">
+            <label className="block">
+              <span className="mb-1.5 block text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
+                Goal
+              </span>
+              <textarea
+                aria-label="Goal"
+                value={plan.goal}
+                onChange={(e) => setPlan({ ...plan, goal: e.target.value })}
+                className="min-h-20 w-full resize-y rounded-md border bg-background px-3 py-2 text-xs outline-none focus:border-ring"
+              />
+            </label>
+            <ListEditor
+              label="Steps"
+              items={plan.steps}
+              onChange={(steps) => setPlan({ ...plan, steps })}
+            />
+            <ListEditor
+              label="Watch for"
+              items={plan.watchFor}
+              onChange={(watchFor) => setPlan({ ...plan, watchFor })}
+            />
+            <ListEditor
+              label="Success criteria"
+              items={plan.successCriteria}
+              onChange={(successCriteria) => setPlan({ ...plan, successCriteria })}
+            />
+          </div>
+        )}
       </div>
-    </div>
+      {plan ? (
+        <footer className="flex items-center justify-between gap-3 border-t px-5 py-4">
+          <button
+            type="button"
+            onClick={generatePlan}
+            disabled={generate.isPending || sendMessage.isPending}
+            className="text-xs font-medium text-muted-foreground hover:text-foreground disabled:opacity-50"
+          >
+            Regenerate
+          </button>
+          <button
+            type="button"
+            onClick={runPlaytest}
+            disabled={sendMessage.isPending || generate.isPending}
+            className="rounded-lg bg-amber-500 px-4 py-2 text-xs font-semibold text-white hover:bg-amber-600 disabled:opacity-50"
+          >
+            {sendMessage.isPending ? "Starting…" : "Run playtest"}
+          </button>
+        </footer>
+      ) : null}
+    </aside>
   );
 }

--- a/src/components/PlaytestPanel.tsx
+++ b/src/components/PlaytestPanel.tsx
@@ -59,6 +59,10 @@ export default function PlaytestPanel({ onClose }: { onClose: () => void }) {
   const sendMessage = useSendMessage();
   const [plan, setPlan] = useState<PlaytestPlan | null>(null);
 
+  function writeOwnPlan() {
+    setPlan({ goal: "", steps: [""], watchFor: [""], successCriteria: [""] });
+  }
+
   async function generatePlan() {
     try {
       setPlan(await generate.mutateAsync());
@@ -114,21 +118,31 @@ export default function PlaytestPanel({ onClose }: { onClose: () => void }) {
       <div className="flex-1 overflow-y-auto p-5">
         {!plan ? (
           <div className="flex h-full flex-col items-center justify-center text-center">
-            <div className="mb-4 flex h-12 w-12 items-center justify-center rounded-2xl bg-amber-100 text-2xl dark:bg-amber-950/50">
-              ▶
+            <div className="mb-4 flex h-12 w-12 items-center justify-center rounded-2xl border bg-background text-2xl">
+              ▷
             </div>
             <h3 className="text-sm font-semibold">Plan a focused test run</h3>
             <p className="mt-2 max-w-xs text-xs leading-5 text-muted-foreground">
               The planner reads this chat, but cannot use Studio tools or change your project.
             </p>
-            <button
-              type="button"
-              onClick={generatePlan}
-              disabled={generate.isPending}
-              className="mt-5 rounded-lg bg-foreground px-4 py-2 text-xs font-semibold text-background disabled:opacity-50"
-            >
-              {generate.isPending ? "Creating plan…" : "Generate test plan"}
-            </button>
+            <div className="mt-5 flex items-center gap-2">
+              <button
+                type="button"
+                onClick={generatePlan}
+                disabled={generate.isPending}
+                className="rounded-lg bg-foreground px-4 py-2 text-xs font-semibold text-background transition-opacity hover:opacity-85 disabled:opacity-50"
+              >
+                {generate.isPending ? "Creating plan…" : "Generate from chat"}
+              </button>
+              <button
+                type="button"
+                onClick={writeOwnPlan}
+                disabled={generate.isPending}
+                className="rounded-lg border bg-background px-4 py-2 text-xs font-semibold text-foreground transition-colors hover:bg-accent disabled:opacity-50"
+              >
+                Write my own
+              </button>
+            </div>
           </div>
         ) : (
           <div className="space-y-5">
@@ -175,7 +189,7 @@ export default function PlaytestPanel({ onClose }: { onClose: () => void }) {
             type="button"
             onClick={runPlaytest}
             disabled={sendMessage.isPending || generate.isPending}
-            className="rounded-lg bg-amber-500 px-4 py-2 text-xs font-semibold text-white hover:bg-amber-600 disabled:opacity-50"
+            className="rounded-lg bg-foreground px-4 py-2 text-xs font-semibold text-background transition-opacity hover:opacity-85 disabled:opacity-50"
           >
             {sendMessage.isPending ? "Starting…" : "Run playtest"}
           </button>

--- a/src/components/PlaytestPanel.tsx
+++ b/src/components/PlaytestPanel.tsx
@@ -99,13 +99,8 @@ export default function PlaytestPanel({ onClose }: { onClose: () => void }) {
       role="dialog"
       aria-label="Playtest planner"
     >
-      <header className="flex shrink-0 items-start justify-between border-b px-5 py-4">
-        <div>
-          <h2 className="font-serif text-xl italic">Playtest</h2>
-          <p className="mt-1 text-xs text-muted-foreground">
-            Turn this chat into an editable Studio test plan.
-          </p>
-        </div>
+      <header className="flex shrink-0 items-start justify-between px-5 py-4">
+        <h2 className="font-serif text-xl italic">Playtest</h2>
         <button
           type="button"
           onClick={onClose}

--- a/src/hooks/mutations/useGeneratePlaytestPlan.ts
+++ b/src/hooks/mutations/useGeneratePlaytestPlan.ts
@@ -1,0 +1,69 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { buildPlaytestHistory, PLAYTEST_PLAN_SCHEMA, parsePlaytestPlan } from "@/lib/playtestPlan";
+import { qk } from "@/lib/queryKeys";
+import { splitModelKey } from "@/lib/splitModelKey";
+import type { MessagesCache } from "@/lib/sseDispatch";
+import { useActiveSession } from "@/providers/ActiveSessionProvider";
+import { useOpenCodeClient } from "@/providers/OpenCodeClientProvider";
+import { usePreferences } from "@/providers/PreferencesProvider";
+
+export function useGeneratePlaytestPlan() {
+  const { client } = useOpenCodeClient();
+  const { activeSessionId } = useActiveSession();
+  const { selectedModel, selectedAgent, selectedVariant } = usePreferences();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async () => {
+      if (!client || !activeSessionId) throw new Error("Open a chat before creating a playtest.");
+      const cache = queryClient.getQueryData<MessagesCache>(qk.messages(activeSessionId));
+      const messages = (cache?.messageIds ?? []).flatMap((id) => {
+        const message = cache?.messagesById[id];
+        return message ? [message] : [];
+      });
+      const history = buildPlaytestHistory(messages);
+      if (!history) throw new Error("Add some chat context before creating a playtest.");
+
+      let model: { providerID: string; modelID: string } | undefined;
+      if (selectedModel) {
+        const [providerID, modelID] = splitModelKey(selectedModel);
+        if (providerID && modelID) model = { providerID, modelID };
+      }
+
+      const created = await client.session.create(
+        {
+          title: "Playtest plan (temporary)",
+          agent: selectedAgent ?? undefined,
+          permission: [{ permission: "*", pattern: "*", action: "deny" }],
+        },
+        { throwOnError: true },
+      );
+      const planningSessionId = created.data?.id;
+      if (!planningSessionId) throw new Error("Couldn't start the playtest planner.");
+
+      try {
+        const response = await client.session.prompt(
+          {
+            sessionID: planningSessionId,
+            model,
+            agent: selectedAgent ?? undefined,
+            variant: selectedVariant ?? undefined,
+            format: { type: "json_schema", schema: PLAYTEST_PLAN_SCHEMA, retryCount: 2 },
+            system:
+              "You create concise, practical Roblox playtest plans from conversation history. Return only the requested structured data. Never call tools and never modify files or Roblox Studio.",
+            parts: [
+              {
+                type: "text",
+                text: `Create a focused playtest plan for the work described below. Make each step directly executable and each success criterion observable.\n\nCHAT HISTORY\n${history}`,
+              },
+            ],
+          },
+          { throwOnError: true },
+        );
+        return parsePlaytestPlan(response.data?.info.structured);
+      } finally {
+        await client.session.delete({ sessionID: planningSessionId }).catch(() => undefined);
+      }
+    },
+  });
+}

--- a/src/lib/playtestPlan.ts
+++ b/src/lib/playtestPlan.ts
@@ -1,0 +1,73 @@
+import type { MessageWithParts } from "@/types";
+
+export interface PlaytestPlan {
+  goal: string;
+  steps: string[];
+  watchFor: string[];
+  successCriteria: string[];
+}
+
+export const PLAYTEST_PLAN_SCHEMA = {
+  type: "object",
+  additionalProperties: false,
+  required: ["goal", "steps", "watchFor", "successCriteria"],
+  properties: {
+    goal: { type: "string", minLength: 1 },
+    steps: { type: "array", minItems: 1, items: { type: "string", minLength: 1 } },
+    watchFor: { type: "array", minItems: 1, items: { type: "string", minLength: 1 } },
+    successCriteria: {
+      type: "array",
+      minItems: 1,
+      items: { type: "string", minLength: 1 },
+    },
+  },
+} as const;
+
+function nonEmptyStrings(value: unknown): string[] | null {
+  if (!Array.isArray(value) || value.length === 0) return null;
+  const strings = value
+    .filter((item): item is string => typeof item === "string")
+    .map((s) => s.trim());
+  return strings.length === value.length && strings.every(Boolean) ? strings : null;
+}
+
+export function parsePlaytestPlan(value: unknown): PlaytestPlan {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error("The planner returned an invalid test plan.");
+  }
+  const candidate = value as Record<string, unknown>;
+  const goal = typeof candidate.goal === "string" ? candidate.goal.trim() : "";
+  const steps = nonEmptyStrings(candidate.steps);
+  const watchFor = nonEmptyStrings(candidate.watchFor);
+  const successCriteria = nonEmptyStrings(candidate.successCriteria);
+  if (!goal || !steps || !watchFor || !successCriteria) {
+    throw new Error("The planner returned an incomplete test plan.");
+  }
+  return { goal, steps, watchFor, successCriteria };
+}
+
+export function buildPlaytestHistory(messages: MessageWithParts[]): string {
+  const entries = messages.flatMap(({ info, parts }) => {
+    const text = parts
+      .filter(
+        (part): part is Extract<(typeof parts)[number], { type: "text" }> => part.type === "text",
+      )
+      .map((part) => part.text.trim())
+      .filter(Boolean)
+      .join("\n");
+    return text ? [`${info.role === "user" ? "User" : "Assistant"}: ${text}`] : [];
+  });
+  return entries.join("\n\n").slice(-30_000);
+}
+
+export function formatPlaytestPrompt(plan: PlaytestPlan): string {
+  const section = (title: string, items: string[]) =>
+    `${title}:\n${items.map((item, index) => `${index + 1}. ${item}`).join("\n")}`;
+  return [
+    "Run this playtest in the currently connected Roblox Studio experience. Use the tools available to you as appropriate, observe the results, and report what passed, failed, or needs follow-up. Do not change the experience unless a test step explicitly requires it.",
+    `Goal:\n${plan.goal}`,
+    section("Steps", plan.steps),
+    section("Watch for", plan.watchFor),
+    section("Success criteria", plan.successCriteria),
+  ].join("\n\n");
+}

--- a/src/test/PlaytestPanel.test.tsx
+++ b/src/test/PlaytestPanel.test.tsx
@@ -1,0 +1,131 @@
+import type { Message, Part } from "@opencode-ai/sdk/v2/client";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { useRef } from "react";
+import { describe, expect, it, vi } from "vitest";
+import PlaytestPanel from "@/components/PlaytestPanel";
+import { ThemeProvider } from "@/components/theme-provider";
+import { Toaster } from "@/components/ui/sonner";
+import { qk } from "@/lib/queryKeys";
+import type { MessagesCache } from "@/lib/sseDispatch";
+import { ActiveSessionContext } from "@/providers/ActiveSessionProvider";
+import { OpenCodeClientContext } from "@/providers/OpenCodeClientProvider";
+import { PreferencesProvider } from "@/providers/PreferencesProvider";
+
+function Harness({
+  client,
+  onClose = vi.fn(),
+}: {
+  client: Record<string, unknown>;
+  onClose?: () => void;
+}) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, staleTime: Infinity } },
+  });
+  queryClient.setQueryData(qk.config, {
+    lastModel: "anthropic/claude",
+    hiddenModels: [],
+    theme: "system",
+    detailedAnalytics: "disabled",
+  });
+  queryClient.setQueryData<MessagesCache>(qk.messages("active"), {
+    messageIds: ["m1"],
+    messagesById: {
+      m1: {
+        info: { role: "user" } as Message,
+        parts: [{ type: "text", text: "Build a round system" } as Part],
+      },
+    },
+  });
+  const activeSessionIdRef = useRef<string | null>("active");
+  return (
+    <QueryClientProvider client={queryClient}>
+      <ThemeProvider>
+        <OpenCodeClientContext.Provider
+          value={{
+            client: client as never,
+            status: "ready",
+            port: 1,
+            ready: true,
+            initError: null,
+          }}
+        >
+          <ActiveSessionContext.Provider
+            value={{
+              activeSessionId: "active",
+              activeSessionIdRef,
+              selectSession: async () => {},
+              clearSession: () => {},
+            }}
+          >
+            <PreferencesProvider>
+              <PlaytestPanel onClose={onClose} />
+              <Toaster />
+            </PreferencesProvider>
+          </ActiveSessionContext.Provider>
+        </OpenCodeClientContext.Provider>
+      </ThemeProvider>
+    </QueryClientProvider>
+  );
+}
+
+describe("PlaytestPanel", () => {
+  it("generates through a tool-disabled temporary session, then sends the edited plan normally", async () => {
+    const onClose = vi.fn();
+    const client = {
+      session: {
+        create: vi.fn().mockResolvedValue({ data: { id: "planner" } }),
+        prompt: vi.fn().mockResolvedValue({
+          data: {
+            info: {
+              structured: {
+                goal: "Test rounds",
+                steps: ["Start a round"],
+                watchFor: ["Console errors"],
+                successCriteria: ["Round completes"],
+              },
+            },
+          },
+        }),
+        delete: vi.fn().mockResolvedValue({}),
+        promptAsync: vi.fn().mockResolvedValue({}),
+      },
+    };
+    render(<Harness client={client} onClose={onClose} />);
+    fireEvent.click(screen.getByRole("button", { name: "Generate test plan" }));
+    expect(await screen.findByDisplayValue("Test rounds")).toBeInTheDocument();
+    expect(client.session.prompt.mock.calls[0][0]).toMatchObject({
+      sessionID: "planner",
+      format: { type: "json_schema" },
+    });
+    expect(client.session.create.mock.calls[0][0].permission).toEqual([
+      { permission: "*", pattern: "*", action: "deny" },
+    ]);
+    expect(client.session.delete).toHaveBeenCalledWith({ sessionID: "planner" });
+
+    fireEvent.change(screen.getByLabelText("Goal"), { target: { value: "Test two rounds" } });
+    fireEvent.click(screen.getByRole("button", { name: "Run playtest" }));
+    await waitFor(() => expect(client.session.promptAsync).toHaveBeenCalledOnce());
+    expect(client.session.promptAsync.mock.calls[0][0].sessionID).toBe("active");
+    expect(client.session.promptAsync.mock.calls[0][0].parts[0].text).toContain("Test two rounds");
+    expect(client.session.promptAsync.mock.calls[0][0].tools).toBeUndefined();
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it("shows an error and cleans up when structured output is invalid", async () => {
+    const client = {
+      session: {
+        create: vi.fn().mockResolvedValue({ data: { id: "planner" } }),
+        prompt: vi
+          .fn()
+          .mockResolvedValue({ data: { info: { structured: { goal: "Missing lists" } } } }),
+        delete: vi.fn().mockResolvedValue({}),
+        promptAsync: vi.fn(),
+      },
+    };
+    render(<Harness client={client} />);
+    fireEvent.click(screen.getByRole("button", { name: "Generate test plan" }));
+    expect(await screen.findByText("Couldn't create a playtest plan")).toBeInTheDocument();
+    expect(client.session.delete).toHaveBeenCalledWith({ sessionID: "planner" });
+  });
+});

--- a/src/test/PlaytestPanel.test.tsx
+++ b/src/test/PlaytestPanel.test.tsx
@@ -92,7 +92,9 @@ describe("PlaytestPanel", () => {
       },
     };
     render(<Harness client={client} onClose={onClose} />);
-    fireEvent.click(screen.getByRole("button", { name: "Generate test plan" }));
+    expect(client.session.create).not.toHaveBeenCalled();
+    expect(client.session.prompt).not.toHaveBeenCalled();
+    fireEvent.click(screen.getByRole("button", { name: "Generate from chat" }));
     expect(await screen.findByDisplayValue("Test rounds")).toBeInTheDocument();
     expect(client.session.prompt.mock.calls[0][0]).toMatchObject({
       sessionID: "planner",
@@ -124,8 +126,25 @@ describe("PlaytestPanel", () => {
       },
     };
     render(<Harness client={client} />);
-    fireEvent.click(screen.getByRole("button", { name: "Generate test plan" }));
+    fireEvent.click(screen.getByRole("button", { name: "Generate from chat" }));
     expect(await screen.findByText("Couldn't create a playtest plan")).toBeInTheDocument();
     expect(client.session.delete).toHaveBeenCalledWith({ sessionID: "planner" });
+  });
+
+  it("opens blank manual fields without calling the planning agent", () => {
+    const client = {
+      session: {
+        create: vi.fn(),
+        prompt: vi.fn(),
+        delete: vi.fn(),
+        promptAsync: vi.fn(),
+      },
+    };
+    render(<Harness client={client} />);
+    fireEvent.click(screen.getByRole("button", { name: "Write my own" }));
+    expect(screen.getByLabelText("Goal")).toHaveValue("");
+    expect(screen.getByLabelText("Steps 1")).toHaveValue("");
+    expect(client.session.create).not.toHaveBeenCalled();
+    expect(client.session.prompt).not.toHaveBeenCalled();
   });
 });

--- a/src/test/PlaytestPanel.test.tsx
+++ b/src/test/PlaytestPanel.test.tsx
@@ -12,6 +12,11 @@ import { ActiveSessionContext } from "@/providers/ActiveSessionProvider";
 import { OpenCodeClientContext } from "@/providers/OpenCodeClientProvider";
 import { PreferencesProvider } from "@/providers/PreferencesProvider";
 
+const { capture } = vi.hoisted(() => ({ capture: vi.fn() }));
+vi.mock("posthog-js/dist/module.full.no-external.js", () => ({
+  default: { capture },
+}));
+
 function Harness({
   client,
   onClose = vi.fn(),
@@ -95,7 +100,9 @@ describe("PlaytestPanel", () => {
     expect(client.session.create).not.toHaveBeenCalled();
     expect(client.session.prompt).not.toHaveBeenCalled();
     fireEvent.click(screen.getByRole("button", { name: "Generate from chat" }));
+    expect(capture).toHaveBeenCalledWith("generation_started", {});
     expect(await screen.findByDisplayValue("Test rounds")).toBeInTheDocument();
+    expect(capture).toHaveBeenCalledWith("generation_succeeded", {});
     expect(client.session.prompt.mock.calls[0][0]).toMatchObject({
       sessionID: "planner",
       format: { type: "json_schema" },
@@ -146,5 +153,6 @@ describe("PlaytestPanel", () => {
     expect(screen.getByLabelText("Steps 1")).toHaveValue("");
     expect(client.session.create).not.toHaveBeenCalled();
     expect(client.session.prompt).not.toHaveBeenCalled();
+    expect(capture).toHaveBeenCalledWith("manual_entry_selected");
   });
 });

--- a/src/test/playtestPlan.test.ts
+++ b/src/test/playtestPlan.test.ts
@@ -1,0 +1,49 @@
+import type { Message, Part } from "@opencode-ai/sdk/v2/client";
+import { describe, expect, it } from "vitest";
+import { buildPlaytestHistory, formatPlaytestPrompt, parsePlaytestPlan } from "@/lib/playtestPlan";
+
+describe("playtest plan helpers", () => {
+  it("validates and normalizes a complete plan", () => {
+    expect(
+      parsePlaytestPlan({
+        goal: " Test combat ",
+        steps: [" Join arena "],
+        watchFor: ["Lag"],
+        successCriteria: ["No errors"],
+      }),
+    ).toEqual({
+      goal: "Test combat",
+      steps: ["Join arena"],
+      watchFor: ["Lag"],
+      successCriteria: ["No errors"],
+    });
+  });
+
+  it("rejects incomplete structured output", () => {
+    expect(() => parsePlaytestPlan({ goal: "Test", steps: [] })).toThrow("incomplete");
+  });
+
+  it("includes text-only chat context and formats a normal agent prompt", () => {
+    const history = buildPlaytestHistory([
+      {
+        info: { role: "user" } as Message,
+        parts: [{ type: "text", text: "Build a shop" } as Part],
+      },
+      {
+        info: { role: "assistant" } as Message,
+        parts: [{ type: "text", text: "Shop built" } as Part],
+      },
+    ]);
+    expect(history).toContain("User: Build a shop");
+    const prompt = formatPlaytestPrompt({
+      goal: "Verify shop",
+      steps: ["Buy item"],
+      watchFor: ["Errors"],
+      successCriteria: ["Item granted"],
+    });
+    expect(prompt).toContain(
+      "Run this playtest in the currently connected Roblox Studio experience",
+    );
+    expect(prompt).toContain("1. Buy item");
+  });
+});


### PR DESCRIPTION
## What changed

- adds a neutral BloxBot-style **Playtest** action to active chats
- opens Playtest as a bordered side-by-side rail, keeping the chat crisp and visible
- uses the shared Explorer panel header structure: a centered fixed-height row with non-italic serif title and divider
- starts with an explicit choice to **Generate from chat** or **Write my own**; opening or reopening never invokes the planner automatically
- generates a strict, app-owned structured plan only after the user requests it, using a temporary deny-all planning session
- lets users edit the goal, steps, watch-fors, and success criteria before starting
- sends the approved plan as a normal prompt to the active session, leaving Studio tool choice to the existing agent
- adds lifecycle telemetry for open/close, generation, manual entry, and playtest start

## Analytics privacy

The events never include chat history, prompts, session titles, goals, steps, watch-fors, success criteria, or generated content. Provider/model, aggregate item counts, duration, and coarse error category are included only when detailed analytics consent is enabled.

## Validation

- `NODE_OPTIONS='--localstorage-file=/tmp/bloxbot-playtest-vitest-storage' pnpm test` — 146 app tests and 8 release tests passed
- `pnpm typecheck`
- `pnpm build`
- `pnpm lint` — passes with 47 pre-existing warnings
- four isolated Vite renders inspected at 1200×800 (real component; no Electron/desktop capture)

## Screenshots

### Initial choice

![Playtest initial choice](https://github.com/user-attachments/assets/4b49d22a-14c4-4385-b119-9e12a0153b72)

### Manual plan editor

![Playtest manual editor](https://github.com/user-attachments/assets/e9c00b90-c71e-4834-8d01-ec82455d168e)

### Generating plan

![Playtest generating state](https://github.com/user-attachments/assets/fd8b917e-3051-4cd4-8ba1-192e96f76634)

### Generated plan editor

![Playtest generated editor](https://github.com/user-attachments/assets/11cca5a7-a601-412b-83a8-72e3438a3950)
