### PR TITLE
Add shared Studio MCP broker

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -4,7 +4,7 @@ import { fileURLToPath } from "node:url";
 
 import { app, BrowserWindow, ipcMain, Menu, shell } from "electron";
 import { autoUpdater } from "electron-updater";
-import { Data, Effect, ManagedRuntime, Schema } from "effect";
+import { Data, Effect, Layer, ManagedRuntime, Schema } from "effect";
 
 import {
   type AppConfig,
@@ -16,6 +16,7 @@ import {
 import { handleLastWindowClosed } from "./appLifecycle";
 import { channels } from "./channels";
 import { makeOpenCodeLayer, OpenCode } from "./services/OpenCode";
+import { makeStudioMcpBrokerLayer } from "./services/StudioMcpBroker";
 
 const currentDirectory = dirname(fileURLToPath(import.meta.url));
 const defaultConfig: AppConfig = DEFAULT_APP_CONFIG;
@@ -38,7 +39,14 @@ const openCodeRuntime = ManagedRuntime.make(
         mainWindow.webContents.send(channels.openCodeStartupProgress, progress);
       }
     },
-  }),
+  }).pipe(
+    Layer.provide(
+      makeStudioMcpBrokerLayer({
+        workspace: join(app.getPath("home"), "BloxBot"),
+        localAppData: process.env.LOCALAPPDATA,
+      }),
+    ),
+  ),
 );
 
 function isMissingFile(cause: unknown): boolean {

--- a/electron/opencodeConfig.ts
+++ b/electron/opencodeConfig.ts
@@ -1,6 +1,6 @@
 import { join } from "node:path";
 
-function studioMcpCommand(platform: NodeJS.Platform, localAppData?: string): string[] {
+export function studioMcpCommand(platform: NodeJS.Platform, localAppData?: string): string[] {
   if (platform === "darwin") {
     return ["/Applications/RobloxStudio.app/Contents/MacOS/StudioMCP"];
   }
@@ -13,7 +13,7 @@ function studioMcpCommand(platform: NodeJS.Platform, localAppData?: string): str
   return ["studio-mcp"];
 }
 
-export function createOpenCodeConfig(platform: NodeJS.Platform, localAppData?: string) {
+export function createOpenCodeConfig(broker: { url: string }) {
   return {
     // Keep OpenCode's standard automatic context compaction enabled for long sessions.
     compaction: {
@@ -21,8 +21,8 @@ export function createOpenCodeConfig(platform: NodeJS.Platform, localAppData?: s
     },
     mcp: {
       "roblox-studio": {
-        type: "local",
-        command: studioMcpCommand(platform, localAppData),
+        type: "remote",
+        url: broker.url,
         enabled: true,
       },
     },

--- a/electron/services/OpenCode.ts
+++ b/electron/services/OpenCode.ts
@@ -9,6 +9,7 @@ import { networkConnections, type Systeminformation } from "systeminformation";
 import type { OpenCodeInfo, OpenCodeStartupProgress } from "../../src/types/desktop";
 import { createOpenCodeConfig } from "../opencodeConfig";
 import { ensureOpenCodeBinary } from "./OpenCodeBinary";
+import { StudioMcpBroker } from "./StudioMcpBroker";
 
 const LOOPBACK = "127.0.0.1";
 const STARTUP_TIMEOUT = "60 seconds";
@@ -188,8 +189,11 @@ function waitForHealth(
   );
 }
 
-function prepareOpenCode(options: OpenCodeOptions): Effect.Effect<PreparedOpenCode, OpenCodeError> {
+function prepareOpenCode(
+  options: OpenCodeOptions,
+): Effect.Effect<PreparedOpenCode, OpenCodeError, StudioMcpBroker> {
   return Effect.gen(function* () {
+    const broker = yield* StudioMcpBroker;
     const { executable, version } = yield* ensureOpenCodeBinary({
       cacheDirectory: options.binaryCacheDirectory,
       onStartupProgress: options.onStartupProgress,
@@ -219,7 +223,7 @@ function prepareOpenCode(options: OpenCodeOptions): Effect.Effect<PreparedOpenCo
       ),
       { concurrency: "unbounded", discard: true },
     );
-    const config = createOpenCodeConfig(process.platform, process.env.LOCALAPPDATA);
+    const config = createOpenCodeConfig(broker.info);
     yield* fileOperation("Failed to write the OpenCode configuration", () =>
       writeFile(
         join(configDirectory, "opencode.json"),

--- a/electron/services/StudioMcpBroker.ts
+++ b/electron/services/StudioMcpBroker.ts
@@ -1,0 +1,206 @@
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
+import {
+  CallToolRequestSchema,
+  CallToolResultSchema,
+  isInitializeRequest,
+  ListToolsRequestSchema,
+  ToolListChangedNotificationSchema,
+  type CallToolResult,
+  type Tool,
+} from "@modelcontextprotocol/sdk/types.js";
+import { randomUUID } from "node:crypto";
+import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
+import { Context, Data, Effect, Layer } from "effect";
+
+import { studioMcpCommand } from "../opencodeConfig";
+
+const LOOPBACK = "127.0.0.1";
+
+export class StudioMcpBrokerError extends Data.TaggedError("StudioMcpBrokerError")<{
+  message: string;
+  cause?: unknown;
+}> {}
+
+export interface StudioMcpBrokerInfo {
+  url: string;
+}
+
+export interface StudioMcpUpstream {
+  callTool(name: string, args: Record<string, unknown>): Promise<CallToolResult>;
+  close(): Promise<void>;
+  listTools(): Promise<{ tools: Tool[] }>;
+  onToolsChanged(listener: () => void): void;
+}
+
+export interface StudioMcpBrokerService {
+  readonly info: StudioMcpBrokerInfo;
+  readonly callTool: (
+    name: string,
+    args: Record<string, unknown>,
+  ) => Effect.Effect<CallToolResult, StudioMcpBrokerError>;
+}
+
+export class StudioMcpBroker extends Context.Tag("@bloxbot/StudioMcpBroker")<
+  StudioMcpBroker,
+  StudioMcpBrokerService
+>() {}
+
+class SdkStudioMcpUpstream implements StudioMcpUpstream {
+  private readonly client = new Client(
+    { name: "bloxbot-studio-broker", version: "1.0.0" },
+    { capabilities: {} },
+  );
+
+  private constructor() {}
+
+  static async connect(command: string[], cwd: string): Promise<SdkStudioMcpUpstream> {
+    const [executable, ...args] = command;
+    if (!executable) throw new Error("Studio MCP command is empty");
+    const transport = new StdioClientTransport({
+      command: executable,
+      args,
+      cwd,
+      stderr: "pipe",
+    });
+    const upstream = new SdkStudioMcpUpstream();
+    await upstream.client.connect(transport);
+    return upstream;
+  }
+
+  onToolsChanged(listener: () => void): void {
+    this.client.setNotificationHandler(ToolListChangedNotificationSchema, listener);
+  }
+
+  async listTools() {
+    return this.client.listTools();
+  }
+
+  async callTool(name: string, args: Record<string, unknown>): Promise<CallToolResult> {
+    const result = await this.client.callTool({ name, arguments: args }, CallToolResultSchema);
+    return CallToolResultSchema.parse(result);
+  }
+
+  async close() {
+    await this.client.close();
+  }
+}
+
+async function readJson(req: IncomingMessage): Promise<unknown> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of req) {
+    const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+    chunks.push(buffer);
+  }
+  return chunks.length === 0 ? undefined : JSON.parse(Buffer.concat(chunks).toString("utf8"));
+}
+
+function reject(res: ServerResponse, statusCode: number, message: string) {
+  res.writeHead(statusCode, { "content-type": "application/json" });
+  res.end(JSON.stringify({ jsonrpc: "2.0", error: { code: -32_000, message }, id: null }));
+}
+
+interface BrokerResource extends StudioMcpBrokerService {
+  close(): Promise<void>;
+}
+
+export async function startStudioMcpBroker(
+  upstream: StudioMcpUpstream,
+): Promise<BrokerResource> {
+  const sessions = new Map<
+    string,
+    { server: Server; transport: StreamableHTTPServerTransport }
+  >();
+  function makeSession() {
+    const server = new Server(
+      { name: "bloxbot-studio-broker", version: "1.0.0" },
+      { capabilities: { tools: { listChanged: true } } },
+    );
+    server.setRequestHandler(ListToolsRequestSchema, () => upstream.listTools());
+    server.setRequestHandler(CallToolRequestSchema, (request) =>
+      upstream.callTool(request.params.name, request.params.arguments ?? {}),
+    );
+    const transport: StreamableHTTPServerTransport = new StreamableHTTPServerTransport({
+      sessionIdGenerator: randomUUID,
+      onsessioninitialized: (sessionId): void => {
+        sessions.set(sessionId, { server, transport });
+      },
+    });
+    transport.onclose = () => {
+      if (transport.sessionId) sessions.delete(transport.sessionId);
+    };
+    return { server, transport };
+  }
+
+  upstream.onToolsChanged(() => {
+    for (const { server } of sessions.values()) void server.sendToolListChanged();
+  });
+
+  const httpServer = createServer(async (req, res) => {
+    try {
+      if (req.url !== "/mcp") return reject(res, 404, "Not found");
+      const sessionId = req.headers["mcp-session-id"];
+      let session = typeof sessionId === "string" ? sessions.get(sessionId) : undefined;
+      let body: unknown;
+      if (req.method === "POST") body = await readJson(req);
+
+      if (!session && req.method === "POST" && isInitializeRequest(body)) {
+        session = makeSession();
+        await session.server.connect(session.transport);
+      }
+      if (!session) return reject(res, 400, "A valid MCP session is required");
+      await session.transport.handleRequest(req, res, body);
+    } catch {
+      if (!res.headersSent) reject(res, 500, "MCP broker request failed");
+    }
+  });
+
+  await new Promise<void>((resolve, rejectListen) => {
+    httpServer.once("error", rejectListen);
+    httpServer.listen(0, LOOPBACK, () => resolve());
+  });
+  const address = httpServer.address();
+  if (!address || typeof address === "string") throw new Error("Broker did not bind a TCP port");
+
+  return {
+    info: { url: `http://${LOOPBACK}:${address.port}/mcp` },
+    callTool: (name, args) =>
+      Effect.tryPromise({
+        try: () => upstream.callTool(name, args),
+        catch: (cause) => new StudioMcpBrokerError({ message: "Studio MCP call failed", cause }),
+      }),
+    close: async () => {
+      for (const { server } of sessions.values()) await server.close();
+      await new Promise<void>((resolve) => httpServer.close(() => resolve()));
+      await upstream.close();
+    },
+  };
+}
+
+export interface StudioMcpBrokerOptions {
+  workspace: string;
+  platform?: NodeJS.Platform;
+  localAppData?: string;
+}
+
+export function makeStudioMcpBrokerLayer(options: StudioMcpBrokerOptions) {
+  return Layer.scoped(
+    StudioMcpBroker,
+    Effect.acquireRelease(
+      Effect.tryPromise({
+        try: async () => {
+          const upstream = await SdkStudioMcpUpstream.connect(
+            studioMcpCommand(options.platform ?? process.platform, options.localAppData),
+            options.workspace,
+          );
+          return startStudioMcpBroker(upstream);
+        },
+        catch: (cause) =>
+          new StudioMcpBrokerError({ message: "Failed to start Studio MCP broker", cause }),
+      }),
+      (resource) => Effect.promise(() => resource.close()),
+    ),
+  );
+}

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "typecheck": "tsc --noEmit && tsc -p electron/tsconfig.json --noEmit && tsc -p scripts/tsconfig.json --noEmit"
   },
   "dependencies": {
+    "@modelcontextprotocol/sdk": "1.26.0",
     "@opencode-ai/sdk": "^1.18.4",
     "@tanstack/react-query": "^5.91.2",
     "@tanstack/react-virtual": "^3.13.23",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@modelcontextprotocol/sdk':
+        specifier: 1.26.0
+        version: 1.26.0(zod@3.25.76)
       '@opencode-ai/sdk':
         specifier: ^1.18.4
         version: 1.18.4
@@ -1134,9 +1137,6 @@ packages:
     peerDependenciesMeta:
       ajv:
         optional: true
-
-  ajv@8.17.1:
-    resolution: {integrity: sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==}
 
   ajv@8.20.0:
     resolution: {integrity: sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==}
@@ -4203,8 +4203,8 @@ snapshots:
   '@modelcontextprotocol/sdk@1.26.0(zod@3.25.76)':
     dependencies:
       '@hono/node-server': 1.19.9(hono@4.11.9)
-      ajv: 8.17.1
-      ajv-formats: 3.0.1(ajv@8.17.1)
+      ajv: 8.20.0
+      ajv-formats: 3.0.1(ajv@8.20.0)
       content-type: 1.0.5
       cors: 2.8.6
       cross-spawn: 7.0.6
@@ -4752,16 +4752,9 @@ snapshots:
 
   agent-base@7.1.4: {}
 
-  ajv-formats@3.0.1(ajv@8.17.1):
+  ajv-formats@3.0.1(ajv@8.20.0):
     optionalDependencies:
-      ajv: 8.17.1
-
-  ajv@8.17.1:
-    dependencies:
-      fast-deep-equal: 3.1.3
-      fast-uri: 3.1.0
-      json-schema-traverse: 1.0.0
-      require-from-string: 2.0.2
+      ajv: 8.20.0
 
   ajv@8.20.0:
     dependencies:

--- a/src/test/opencodeConfig.test.ts
+++ b/src/test/opencodeConfig.test.ts
@@ -2,17 +2,19 @@ import { describe, expect, it } from "vitest";
 
 import { createOpenCodeConfig } from "../../electron/opencodeConfig";
 
+const broker = { url: "http://127.0.0.1:43210/mcp" };
+
 describe("OpenCode configuration", () => {
   it("does not install third-party authentication plugins by default", () => {
-    expect(createOpenCodeConfig("darwin")).not.toHaveProperty("plugin");
+    expect(createOpenCodeConfig(broker)).not.toHaveProperty("plugin");
   });
 
   it("keeps automatic context compaction enabled", () => {
-    expect(createOpenCodeConfig("darwin").compaction).toEqual({ auto: true });
+    expect(createOpenCodeConfig(broker).compaction).toEqual({ auto: true });
   });
 
   it("keeps Studio instructions concise and action-oriented", () => {
-    const prompt = createOpenCodeConfig("darwin").agent.studio.prompt;
+    const prompt = createOpenCodeConfig(broker).agent.studio.prompt;
 
     expect(prompt.trim().split(/\s+/).length).toBeLessThanOrEqual(75);
     expect(prompt).toMatch(/inspect before editing/i);
@@ -20,5 +22,13 @@ describe("OpenCode configuration", () => {
     expect(prompt).toContain("most relevant Studio check");
     expect(prompt).toContain("stop retrying");
     expect(prompt).toContain("select and verify it immediately");
+  });
+
+  it("connects OpenCode to the loopback broker", () => {
+    expect(createOpenCodeConfig(broker).mcp["roblox-studio"]).toEqual({
+      type: "remote",
+      url: broker.url,
+      enabled: true,
+    });
   });
 });

--- a/src/test/studioMcpBroker.test.ts
+++ b/src/test/studioMcpBroker.test.ts
@@ -1,0 +1,68 @@
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+import type { Tool } from "@modelcontextprotocol/sdk/types.js";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { StudioMcpUpstream } from "../../electron/services/StudioMcpBroker";
+import { startStudioMcpBroker } from "../../electron/services/StudioMcpBroker";
+
+const tools: Tool[] = [
+  {
+    name: "inspect_place",
+    description: "Read the place",
+    inputSchema: { type: "object", properties: { depth: { type: "number" } } },
+  },
+];
+
+function fakeUpstream(overrides: Partial<StudioMcpUpstream> = {}): StudioMcpUpstream {
+  return {
+    listTools: vi.fn().mockResolvedValue({ tools }),
+    callTool: vi.fn().mockResolvedValue({ content: [{ type: "text", text: "ok" }] }),
+    onToolsChanged: vi.fn(),
+    close: vi.fn().mockResolvedValue(undefined),
+    ...overrides,
+  };
+}
+
+const cleanups: Array<() => Promise<void>> = [];
+afterEach(async () => {
+  await Promise.all(cleanups.splice(0).map((cleanup) => cleanup()));
+});
+
+async function connect(info: { url: string }) {
+  const client = new Client({ name: "test-client", version: "1.0.0" });
+  const transport = new StreamableHTTPClientTransport(new URL(info.url));
+  await client.connect(transport);
+  cleanups.push(() => client.close());
+  return client;
+}
+
+describe("Studio MCP broker", () => {
+  it("binds the OpenCode adapter to loopback", async () => {
+    const broker = await startStudioMcpBroker(fakeUpstream());
+    cleanups.push(() => broker.close());
+
+    expect(broker.info.url).toMatch(/^http:\/\/127\.0\.0\.1:\d+\/mcp$/);
+  });
+
+  it("forwards tool discovery and calls over standard MCP transport", async () => {
+    const upstream = fakeUpstream();
+    const broker = await startStudioMcpBroker(upstream);
+    cleanups.push(() => broker.close());
+    const client = await connect(broker.info);
+
+    await expect(client.listTools()).resolves.toEqual({ tools });
+    await expect(
+      client.callTool({ name: "inspect_place", arguments: { depth: 3 } }),
+    ).resolves.toMatchObject({ content: [{ type: "text", text: "ok" }] });
+    expect(upstream.callTool).toHaveBeenCalledWith("inspect_place", { depth: 3 });
+  });
+
+  it("closes the single upstream Studio client", async () => {
+    const upstream = fakeUpstream();
+    const broker = await startStudioMcpBroker(upstream);
+
+    await broker.close();
+    expect(upstream.close).toHaveBeenCalledOnce();
+  });
+});


### PR DESCRIPTION
## Summary

- make Electron own the single StudioMCP stdio client using the official MCP SDK
- expose that client to OpenCode through a loopback Streamable HTTP MCP adapter
- expose the same client to trusted native features through `StudioMcpBroker.callTool`
- close HTTP sessions, the listener, and StudioMCP with the scoped Effect layer

## Why

OpenCode 1.18.4 does not expose a generic MCP tool-invocation endpoint. This small adapter lets OpenCode and native desktop features share one StudioMCP connection instead of spawning competing processes.

## Scope

Electron, OpenCode, and native app features are treated as one trusted local application boundary. This PR intentionally does not add authentication, sandboxing, custom protocol validation, call serialization, or bespoke retry policy beyond the official SDK's protocol handling and ordinary error propagation.

## Validation

- `pnpm typecheck`
- `NODE_OPTIONS='--max-old-space-size=8192 --localstorage-file=/tmp/bloxbot-simple-broker-full' pnpm test` (144 unit/UI + 8 release tests)
- `pnpm build`
- `pnpm lint` (passes with 47 pre-existing warnings)
- `git diff --check`
