### PR TITLE
Add generated TypeScript program runtime

### DIFF
--- a/docs/generated-program-runtime.md
+++ b/docs/generated-program-runtime.md
@@ -1,0 +1,24 @@
+# Generated TypeScript runtime
+
+Agent-generated collectors and selectors use one generic contract. The agent returns a
+`GeneratedProgramEnvelope` containing import-free TypeScript plus explicit contract, input, and
+output schema versions. `GeneratedProgramRuntime.compile` transpiles it once and returns a
+persistable `GeneratedProgramArtifact`; repeated compiles reuse the in-memory artifact cache.
+
+The source must define:
+
+```ts
+async function run({ input, callTool }) {
+  const result = await callTool("tool_selected_by_the_agent", { value: input.value });
+  return { result };
+}
+```
+
+`GeneratedProgramRuntime.invoke` restores the compiled function from the artifact when necessary,
+passes only the invocation input and trusted Studio broker `callTool` capability, and returns a
+JSON-serializable `GeneratedProgramResult`. Consumers validate `value` against their own versioned
+Effect schema.
+
+All failures have `regenerate: true` and a `phase` of `compile`, `tool-contract`, `runtime`, or
+`output`. Callers should ask the agent for a replacement envelope only for these failures; routine
+invocations do not use model inference.

--- a/electron/services/GeneratedProgramRuntime.ts
+++ b/electron/services/GeneratedProgramRuntime.ts
@@ -1,0 +1,171 @@
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import { createHash } from "node:crypto";
+
+import { Context, Data, Effect, Layer, Schema } from "effect";
+import { transform } from "sucrase";
+
+import {
+  type GeneratedProgramArtifact,
+  GeneratedProgramArtifactSchema,
+  type GeneratedProgramEnvelope,
+  GeneratedProgramEnvelopeSchema,
+  type GeneratedProgramInvocation,
+  GeneratedProgramInvocationSchema,
+  type GeneratedProgramResult,
+  GeneratedProgramResultSchema,
+} from "../../src/types/generatedProgram";
+import { StudioMcpBroker } from "./StudioMcpBroker";
+
+type CallTool = (name: string, args: Record<string, unknown>) => Promise<CallToolResult>;
+type ProgramFunction = (input: unknown, callTool: CallTool) => Promise<unknown>;
+
+export type GeneratedProgramFailurePhase =
+  | "compile"
+  | "tool-contract"
+  | "runtime"
+  | "output";
+
+export class GeneratedProgramRuntimeError extends Data.TaggedError(
+  "GeneratedProgramRuntimeError",
+)<{
+  message: string;
+  phase: GeneratedProgramFailurePhase;
+  regenerate: true;
+  cause?: unknown;
+}> {}
+
+export interface GeneratedProgramRuntimeService {
+  readonly compile: (
+    envelope: GeneratedProgramEnvelope,
+  ) => Effect.Effect<GeneratedProgramArtifact, GeneratedProgramRuntimeError>;
+  readonly invoke: (
+    invocation: GeneratedProgramInvocation,
+  ) => Effect.Effect<GeneratedProgramResult, GeneratedProgramRuntimeError>;
+}
+
+export class GeneratedProgramRuntime extends Context.Tag("@bloxbot/GeneratedProgramRuntime")<
+  GeneratedProgramRuntime,
+  GeneratedProgramRuntimeService
+>() {}
+
+class ToolContractError extends Error {}
+
+function runtimeError(
+  phase: GeneratedProgramFailurePhase,
+  message: string,
+  cause: unknown,
+) {
+  return new GeneratedProgramRuntimeError({ phase, message, regenerate: true, cause });
+}
+
+function cacheKey(envelope: GeneratedProgramEnvelope): string {
+  return createHash("sha256")
+    .update(JSON.stringify(envelope.contract))
+    .update("\0")
+    .update(envelope.source)
+    .digest("hex");
+}
+
+function makeFunction(compiledSource: string): ProgramFunction {
+  const AsyncFunction = Object.getPrototypeOf(async () => undefined).constructor as new (
+    ...args: string[]
+  ) => ProgramFunction;
+  return new AsyncFunction(
+    "input",
+    "callTool",
+    `"use strict";\n${compiledSource}\nif (typeof run !== "function") throw new Error("Generated program must define async function run({ input, callTool })");\nreturn await run({ input, callTool });`,
+  );
+}
+
+export function startGeneratedProgramRuntime(callTool: CallTool): GeneratedProgramRuntimeService {
+  const artifacts = new Map<string, GeneratedProgramArtifact>();
+  const functions = new Map<string, ProgramFunction>();
+
+  const compile = async (candidate: GeneratedProgramEnvelope) => {
+    const envelope = await Schema.decodeUnknownPromise(GeneratedProgramEnvelopeSchema)(candidate);
+    const key = cacheKey(envelope);
+    const cached = artifacts.get(key);
+    if (cached) return cached;
+    if (/\b(?:import|export)\b/u.test(envelope.source)) {
+      throw new Error("Generated programs must be import-free");
+    }
+    const compiledSource = transform(envelope.source, { transforms: ["typescript"] }).code;
+    const artifact = await Schema.decodeUnknownPromise(GeneratedProgramArtifactSchema)({
+      cacheKey: key,
+      contract: envelope.contract,
+      compiledSource,
+    });
+    functions.set(key, makeFunction(compiledSource));
+    artifacts.set(key, artifact);
+    return artifact;
+  };
+
+  return {
+    compile: (envelope) =>
+      Effect.tryPromise({
+        try: () => compile(envelope),
+        catch: (cause) => runtimeError("compile", "Generated program did not compile", cause),
+      }),
+    invoke: (candidate) =>
+      Effect.gen(function* () {
+        const invocation = yield* Schema.decodeUnknown(GeneratedProgramInvocationSchema)(
+          candidate,
+        ).pipe(
+          Effect.mapError((cause) =>
+            runtimeError("runtime", "Generated program invocation is invalid", cause),
+          ),
+        );
+        let program = functions.get(invocation.artifact.cacheKey);
+        if (!program) {
+          program = yield* Effect.try({
+            try: () => makeFunction(invocation.artifact.compiledSource),
+            catch: (cause) =>
+              runtimeError("compile", "Cached generated program is invalid", cause),
+          });
+          functions.set(invocation.artifact.cacheKey, program);
+        }
+        const guardedCallTool: CallTool = async (name, args) => {
+          try {
+            return await callTool(name, args);
+          } catch (cause) {
+            throw new ToolContractError(
+              cause instanceof Error ? cause.message : "Studio MCP tool call failed",
+            );
+          }
+        };
+        const value = yield* Effect.tryPromise({
+          try: () => program(invocation.input, guardedCallTool),
+          catch: (cause) =>
+            cause instanceof ToolContractError
+              ? runtimeError("tool-contract", "Generated program tool contract failed", cause)
+              : runtimeError("runtime", "Generated program execution failed", cause),
+        });
+        const jsonValue = yield* Effect.try({
+          try: () => {
+            const json = JSON.stringify(value);
+            if (json === undefined) throw new Error("Output is not JSON serializable");
+            return JSON.parse(json) as unknown;
+          },
+          catch: (cause) => runtimeError("output", "Generated program output is invalid", cause),
+        });
+        return yield* Schema.decodeUnknown(GeneratedProgramResultSchema)({
+          contract: invocation.artifact.contract,
+          value: jsonValue,
+        }).pipe(
+          Effect.mapError((cause) =>
+            runtimeError("output", "Generated program result schema failed", cause),
+          ),
+        );
+      }),
+  };
+}
+
+export const GeneratedProgramRuntimeLive = Layer.effect(
+  GeneratedProgramRuntime,
+  Effect.gen(function* () {
+    const broker = yield* StudioMcpBroker;
+    return startGeneratedProgramRuntime((name, args) =>
+      Effect.runPromise(broker.callTool(name, args)),
+    );
+  }),
+);

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "react-markdown": "^10.1.0",
     "remark-gfm": "^4.0.1",
     "sonner": "^2.0.7",
+    "sucrase": "3.35.0",
     "systeminformation": "^5.31.16",
     "tar": "^7.5.20"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,6 +47,9 @@ importers:
       sonner:
         specifier: ^2.0.7
         version: 2.0.7(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      sucrase:
+        specifier: 3.35.0
+        version: 3.35.0
       systeminformation:
         specifier: ^5.31.16
         version: 5.31.16
@@ -504,6 +507,10 @@ packages:
     resolution: {integrity: sha512-WMz71T1JS624nWj2n2fnYAuPovhv7EUhk69R6i9dsVyzxt5eM3bjwvgk9L+APE1TRscGysAVMANkB0jh0LQZrQ==}
     engines: {node: 20 || >=22}
 
+  '@isaacs/cliui@8.0.2':
+    resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
+    engines: {node: '>=12'}
+
   '@isaacs/fs-minipass@4.0.1':
     resolution: {integrity: sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==}
     engines: {node: '>=18.0.0'}
@@ -684,6 +691,10 @@ packages:
   '@peculiar/webcrypto@1.7.1':
     resolution: {integrity: sha512-ODOov0sGMJMf3jPonOkgGqPknTsu+DdQ7kD++gz8aI+aFMOMHFbWAA2taqXXVTdP+OTOQR/znGvSpmkeI0WTYQ==}
     engines: {node: '>=14.18.0'}
+
+  '@pkgjs/parseargs@0.11.0':
+    resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
+    engines: {node: '>=14'}
 
   '@posthog/core@1.24.1':
     resolution: {integrity: sha512-e8AciAnc6MRFws89ux8lJKFAaI03yEon0ASDoUO7yS91FVqbUGXYekObUUR3LHplcg+pmyiJBI0jolY0SFbGRA==}
@@ -1157,9 +1168,16 @@ packages:
     resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
     engines: {node: '>=10'}
 
+  ansi-styles@6.2.3:
+    resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
+    engines: {node: '>=12'}
+
   ansis@4.2.0:
     resolution: {integrity: sha512-HqZ5rWlFjGiV0tDm3UxxgNRqsOTniqoKZu0pIAfh7TZQMGuZK+hH0drySty0si0QXj1ieop4+SkSfPZBPPkHig==}
     engines: {node: '>=14'}
+
+  any-promise@1.3.0:
+    resolution: {integrity: sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==}
 
   app-builder-lib@26.15.3:
     resolution: {integrity: sha512-2VnyWkqsP5v5XbBhL3tD5Syx8iNPBYsoU7kY4S2fz7wg8Rj/nztWKCUzGKaFRTv0Xwf3/H058CR1Kvtd/3lRow==}
@@ -1395,6 +1413,10 @@ packages:
     resolution: {integrity: sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==}
     engines: {node: '>=20'}
 
+  commander@4.1.1:
+    resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
+    engines: {node: '>= 6'}
+
   commander@5.1.0:
     resolution: {integrity: sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==}
     engines: {node: '>= 6'}
@@ -1603,6 +1625,9 @@ packages:
   duplexer2@0.1.4:
     resolution: {integrity: sha512-asLFVfWWtJ90ZyOUHMqk7/S2w2guQKxUI2itj3d92ADHhxUSbCMGi1f1cBcJ7xM1To+pE/Khbwo1yuNbMEPKeA==}
 
+  eastasianwidth@0.2.0:
+    resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
+
   eciesjs@0.4.17:
     resolution: {integrity: sha512-TOOURki4G7sD1wDCjj7NfLaXZZ49dFOeEb5y39IXpb8p0hRzVvfvzZHOi5JcT+PpyAbi/Y+lxPb8eTag2WYH8w==}
     engines: {bun: '>=1', deno: '>=2', node: '>=16'}
@@ -1649,6 +1674,9 @@ packages:
 
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
+
+  emoji-regex@9.2.2:
+    resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
 
   encodeurl@2.0.0:
     resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
@@ -1826,6 +1854,10 @@ packages:
     resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
     engines: {node: '>= 18.0.0'}
 
+  foreground-child@3.3.1:
+    resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
+    engines: {node: '>=14'}
+
   form-data@4.0.6:
     resolution: {integrity: sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==}
     engines: {node: '>= 6'}
@@ -1922,6 +1954,11 @@ packages:
   glob-parent@5.1.2:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
     engines: {node: '>= 6'}
+
+  glob@10.5.0:
+    resolution: {integrity: sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+    hasBin: true
 
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
@@ -2181,6 +2218,9 @@ packages:
     resolution: {integrity: sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==}
     engines: {node: '>=8'}
 
+  jackspeak@3.4.3:
+    resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
+
   jake@10.9.4:
     resolution: {integrity: sha512-wpHYzhxiVQL+IV05BLE2Xn34zW1S223hvjtqk0+gsPrwd/8JNLXJgZZM/iPFsYc1xyphF+6M6EvdE5E9MBGkDA==}
     engines: {node: '>=10'}
@@ -2365,6 +2405,9 @@ packages:
   lowercase-keys@2.0.0:
     resolution: {integrity: sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==}
     engines: {node: '>=8'}
+
+  lru-cache@10.4.3:
+    resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
 
   lru-cache@11.2.7:
     resolution: {integrity: sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==}
@@ -2648,6 +2691,9 @@ packages:
     resolution: {integrity: sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==}
     engines: {node: ^18.17.0 || >=20.5.0}
 
+  mz@2.7.0:
+    resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
+
   nanoid@3.3.11:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
@@ -2759,6 +2805,9 @@ packages:
     resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
     engines: {node: '>=10'}
 
+  package-json-from-dist@1.0.1:
+    resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
+
   package-manager-detector@1.6.0:
     resolution: {integrity: sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA==}
 
@@ -2799,6 +2848,10 @@ packages:
     resolution: {integrity: sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==}
     engines: {node: '>=12'}
 
+  path-scurry@1.11.1:
+    resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
+    engines: {node: '>=16 || 14 >=14.18'}
+
   path-to-regexp@6.3.0:
     resolution: {integrity: sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==}
 
@@ -2829,6 +2882,10 @@ packages:
   picomatch@4.0.5:
     resolution: {integrity: sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==}
     engines: {node: '>=12'}
+
+  pirates@4.0.7:
+    resolution: {integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==}
+    engines: {node: '>= 6'}
 
   pkce-challenge@5.0.1:
     resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
@@ -3214,6 +3271,10 @@ packages:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
     engines: {node: '>=8'}
 
+  string-width@5.1.2:
+    resolution: {integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==}
+    engines: {node: '>=12'}
+
   string-width@7.2.0:
     resolution: {integrity: sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==}
     engines: {node: '>=18'}
@@ -3258,6 +3319,11 @@ packages:
   style-to-object@1.0.14:
     resolution: {integrity: sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==}
 
+  sucrase@3.35.0:
+    resolution: {integrity: sha512-8EbVDiu9iN/nESwxeSxDKe0dunta1GOlHufmSSXxMD2z2/tMZpDMpvXQGsc+ajGo8y2uYUmixaSRUc/QPoQ0GA==}
+    engines: {node: '>=16 || 14 >=14.17'}
+    hasBin: true
+
   sumchecker@3.0.1:
     resolution: {integrity: sha512-MvjXzkz/BOfyVDkG0oFOtBxHX2u3gKbMHIF/dXblZsgD3BWOFLmHovIpZY7BykJdAjcqRCBi1WYBNdEC9yI7vg==}
     engines: {node: '>= 8.0'}
@@ -3299,6 +3365,13 @@ packages:
   temp@0.9.4:
     resolution: {integrity: sha512-yYrrsWnrXMcdsnu/7YMYAofM1ktpL5By7vZhf15CrXijWWrEYZks5AXBudalfSWJLlnen/QUJUB5aoB0kqZUGA==}
     engines: {node: '>=6.0.0'}
+
+  thenify-all@1.6.0:
+    resolution: {integrity: sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==}
+    engines: {node: '>=0.8'}
+
+  thenify@3.3.1:
+    resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
 
   tiny-async-pool@1.3.0:
     resolution: {integrity: sha512-01EAw5EDrcVrdgyCLgoSPvqznC0sVxDSVeiOz09FUpjh71G79VCqneOr+xvt7T1r76CF6ZZfPjHorN2+d+3mqA==}
@@ -3366,6 +3439,9 @@ packages:
 
   truncate-utf8-bytes@1.0.2:
     resolution: {integrity: sha512-95Pu1QXQvruGEhv62XCMO3Mm90GscOCClvrIUwCM0PYOXK3kaF3l3sIHxx71ThJfcbM2O5Au6SO3AWCSEfW4mQ==}
+
+  ts-interface-checker@0.1.13:
+    resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
 
   ts-morph@26.0.0:
     resolution: {integrity: sha512-ztMO++owQnz8c/gIENcM9XfCEzgoGphTv+nKpYNM1bgsdOVC/jRZuEBf6N+mLLDNg68Kl+GgUZfOySaRiG1/Ug==}
@@ -3630,6 +3706,10 @@ packages:
   wrap-ansi@7.0.0:
     resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
     engines: {node: '>=10'}
+
+  wrap-ansi@8.1.0:
+    resolution: {integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==}
+    engines: {node: '>=12'}
 
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
@@ -4164,6 +4244,15 @@ snapshots:
     dependencies:
       '@isaacs/balanced-match': 4.0.1
 
+  '@isaacs/cliui@8.0.2':
+    dependencies:
+      string-width: 5.1.2
+      string-width-cjs: string-width@4.2.3
+      strip-ansi: 7.1.2
+      strip-ansi-cjs: strip-ansi@6.0.1
+      wrap-ansi: 8.1.0
+      wrap-ansi-cjs: wrap-ansi@7.0.0
+
   '@isaacs/fs-minipass@4.0.1':
     dependencies:
       minipass: 7.1.3
@@ -4374,6 +4463,9 @@ snapshots:
       '@peculiar/utils': 2.0.3
       tslib: 2.8.1
       webcrypto-core: 1.9.2
+
+  '@pkgjs/parseargs@0.11.0':
+    optional: true
 
   '@posthog/core@1.24.1':
     dependencies:
@@ -4773,7 +4865,11 @@ snapshots:
 
   ansi-styles@5.2.0: {}
 
+  ansi-styles@6.2.3: {}
+
   ansis@4.2.0: {}
+
+  any-promise@1.3.0: {}
 
   app-builder-lib@26.15.3(dmg-builder@26.15.3)(electron-builder-squirrel-windows@26.15.3):
     dependencies:
@@ -5044,6 +5140,8 @@ snapshots:
 
   commander@14.0.3: {}
 
+  commander@4.1.1: {}
+
   commander@5.1.0: {}
 
   commander@9.5.0:
@@ -5217,6 +5315,8 @@ snapshots:
     dependencies:
       readable-stream: 2.3.8
 
+  eastasianwidth@0.2.0: {}
+
   eciesjs@0.4.17:
     dependencies:
       '@ecies/ciphers': 0.2.5(@noble/ciphers@1.3.0)
@@ -5312,6 +5412,8 @@ snapshots:
   emoji-regex@10.6.0: {}
 
   emoji-regex@8.0.0: {}
+
+  emoji-regex@9.2.2: {}
 
   encodeurl@2.0.0: {}
 
@@ -5526,6 +5628,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  foreground-child@3.3.1:
+    dependencies:
+      cross-spawn: 7.0.6
+      signal-exit: 4.1.0
+
   form-data@4.0.6:
     dependencies:
       asynckit: 0.4.0
@@ -5630,6 +5737,15 @@ snapshots:
   glob-parent@5.1.2:
     dependencies:
       is-glob: 4.0.3
+
+  glob@10.5.0:
+    dependencies:
+      foreground-child: 3.3.1
+      jackspeak: 3.4.3
+      minimatch: 9.0.9
+      minipass: 7.1.3
+      package-json-from-dist: 1.0.1
+      path-scurry: 1.11.1
 
   glob@7.2.3:
     dependencies:
@@ -5876,6 +5992,12 @@ snapshots:
       html-escaper: 2.0.2
       istanbul-lib-report: 3.0.1
 
+  jackspeak@3.4.3:
+    dependencies:
+      '@isaacs/cliui': 8.0.2
+    optionalDependencies:
+      '@pkgjs/parseargs': 0.11.0
+
   jake@10.9.4:
     dependencies:
       async: 3.2.6
@@ -6032,6 +6154,8 @@ snapshots:
       js-tokens: 4.0.0
 
   lowercase-keys@2.0.0: {}
+
+  lru-cache@10.4.3: {}
 
   lru-cache@11.2.7: {}
 
@@ -6519,6 +6643,12 @@ snapshots:
 
   mute-stream@2.0.0: {}
 
+  mz@2.7.0:
+    dependencies:
+      any-promise: 1.3.0
+      object-assign: 4.1.1
+      thenify-all: 1.6.0
+
   nanoid@3.3.11: {}
 
   nanoid@3.3.16: {}
@@ -6629,6 +6759,8 @@ snapshots:
     dependencies:
       yocto-queue: 0.1.0
 
+  package-json-from-dist@1.0.1: {}
+
   package-manager-detector@1.6.0: {}
 
   parent-module@1.0.1:
@@ -6668,6 +6800,11 @@ snapshots:
 
   path-key@4.0.0: {}
 
+  path-scurry@1.11.1:
+    dependencies:
+      lru-cache: 10.4.3
+      minipass: 7.1.3
+
   path-to-regexp@6.3.0: {}
 
   path-to-regexp@8.3.0: {}
@@ -6685,6 +6822,8 @@ snapshots:
   picomatch@4.0.3: {}
 
   picomatch@4.0.5: {}
+
+  pirates@4.0.7: {}
 
   pkce-challenge@5.0.1: {}
 
@@ -7206,6 +7345,12 @@ snapshots:
       is-fullwidth-code-point: 3.0.0
       strip-ansi: 6.0.1
 
+  string-width@5.1.2:
+    dependencies:
+      eastasianwidth: 0.2.0
+      emoji-regex: 9.2.2
+      strip-ansi: 7.1.2
+
   string-width@7.2.0:
     dependencies:
       emoji-regex: 10.6.0
@@ -7253,6 +7398,16 @@ snapshots:
     dependencies:
       inline-style-parser: 0.2.7
 
+  sucrase@3.35.0:
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      commander: 4.1.1
+      glob: 10.5.0
+      lines-and-columns: 1.2.4
+      mz: 2.7.0
+      pirates: 4.0.7
+      ts-interface-checker: 0.1.13
+
   sumchecker@3.0.1:
     dependencies:
       debug: 4.4.3
@@ -7292,6 +7447,14 @@ snapshots:
     dependencies:
       mkdirp: 0.5.6
       rimraf: 2.6.3
+
+  thenify-all@1.6.0:
+    dependencies:
+      thenify: 3.3.1
+
+  thenify@3.3.1:
+    dependencies:
+      any-promise: 1.3.0
 
   tiny-async-pool@1.3.0:
     dependencies:
@@ -7350,6 +7513,8 @@ snapshots:
   truncate-utf8-bytes@1.0.2:
     dependencies:
       utf8-byte-length: 1.0.5
+
+  ts-interface-checker@0.1.13: {}
 
   ts-morph@26.0.0:
     dependencies:
@@ -7572,6 +7737,12 @@ snapshots:
       ansi-styles: 4.3.0
       string-width: 4.2.3
       strip-ansi: 6.0.1
+
+  wrap-ansi@8.1.0:
+    dependencies:
+      ansi-styles: 6.2.3
+      string-width: 5.1.2
+      strip-ansi: 7.1.2
 
   wrappy@1.0.2: {}
 

--- a/src/test/generatedProgramRuntime.test.ts
+++ b/src/test/generatedProgramRuntime.test.ts
@@ -1,0 +1,106 @@
+import { Effect } from "effect";
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  GeneratedProgramRuntimeError,
+  startGeneratedProgramRuntime,
+} from "../../electron/services/GeneratedProgramRuntime";
+
+const envelope = (source: string) => ({
+  version: 1 as const,
+  contract: {
+    name: "test-program",
+    version: "1",
+    inputSchemaVersion: "input-v1",
+    outputSchemaVersion: "output-v1",
+  },
+  source,
+});
+
+describe("GeneratedProgramRuntime", () => {
+  it("compiles TypeScript once and invokes it through the broker capability", async () => {
+    const callTool = vi.fn().mockResolvedValue({ content: [{ type: "text", text: "ok" }] });
+    const runtime = startGeneratedProgramRuntime(callTool);
+    const source = `
+      async function run({ input, callTool }: { input: { depth: number }; callTool: Function }) {
+        const result = await callTool("inspect_place", { depth: input.depth });
+        return { result, depth: input.depth };
+      }
+    `;
+    const first = await Effect.runPromise(runtime.compile(envelope(source)));
+    const second = await Effect.runPromise(runtime.compile(envelope(source)));
+    expect(second).toBe(first);
+
+    await expect(
+      Effect.runPromise(runtime.invoke({ artifact: first, input: { depth: 3 } })),
+    ).resolves.toMatchObject({
+      contract: { outputSchemaVersion: "output-v1" },
+      value: { depth: 3, result: { content: [{ type: "text", text: "ok" }] } },
+    });
+    expect(callTool).toHaveBeenCalledWith("inspect_place", { depth: 3 });
+  });
+
+  it("restores a compiled function from a persisted artifact", async () => {
+    const firstRuntime = startGeneratedProgramRuntime(vi.fn());
+    const artifact = await Effect.runPromise(
+      firstRuntime.compile(envelope("async function run({ input }) { return input; }")),
+    );
+    const restoredRuntime = startGeneratedProgramRuntime(vi.fn());
+
+    await expect(
+      Effect.runPromise(restoredRuntime.invoke({ artifact, input: { selected: "Workspace" } })),
+    ).resolves.toMatchObject({ value: { selected: "Workspace" } });
+  });
+
+  it.each([
+    ["compile", "import fs from 'node:fs'; async function run() {}"],
+    ["compile", "async function run( {"],
+  ])("classifies %s failures for regeneration", async (phase, source) => {
+    const runtime = startGeneratedProgramRuntime(vi.fn());
+    await expect(
+      Effect.runPromise(Effect.flip(runtime.compile(envelope(source)))),
+    ).resolves.toMatchObject({
+      _tag: "GeneratedProgramRuntimeError",
+      phase,
+      regenerate: true,
+    });
+  });
+
+  it("classifies broker contract failures for regeneration", async () => {
+    const runtime = startGeneratedProgramRuntime(vi.fn().mockRejectedValue(new Error("gone")));
+    const artifact = await Effect.runPromise(
+      runtime.compile(
+        envelope('async function run({ callTool }) { return callTool("missing", {}); }'),
+      ),
+    );
+    await expect(
+      Effect.runPromise(Effect.flip(runtime.invoke({ artifact, input: null }))),
+    ).resolves.toMatchObject({
+      phase: "tool-contract",
+      regenerate: true,
+    });
+  });
+
+  it("classifies non-serializable output failures for regeneration", async () => {
+    const runtime = startGeneratedProgramRuntime(vi.fn());
+    const artifact = await Effect.runPromise(
+      runtime.compile(envelope("async function run() { return undefined; }")),
+    );
+    await expect(
+      Effect.runPromise(Effect.flip(runtime.invoke({ artifact, input: null }))),
+    ).resolves.toMatchObject({
+      phase: "output",
+      regenerate: true,
+    });
+  });
+
+  it("uses a typed runtime error", () => {
+    expect(
+      new GeneratedProgramRuntimeError({
+        message: "failed",
+        phase: "runtime",
+        regenerate: true,
+      })._tag,
+    ).toBe("GeneratedProgramRuntimeError");
+  });
+});

--- a/src/types/generatedProgram.ts
+++ b/src/types/generatedProgram.ts
@@ -1,0 +1,40 @@
+import { Schema } from "effect";
+
+export const GENERATED_PROGRAM_VERSION = 1 as const;
+
+export const GeneratedProgramContractSchema = Schema.Struct({
+  name: Schema.String.pipe(Schema.minLength(1), Schema.maxLength(128)),
+  version: Schema.String.pipe(Schema.minLength(1), Schema.maxLength(64)),
+  inputSchemaVersion: Schema.String.pipe(Schema.minLength(1), Schema.maxLength(64)),
+  outputSchemaVersion: Schema.String.pipe(Schema.minLength(1), Schema.maxLength(64)),
+});
+
+export const GeneratedProgramEnvelopeSchema = Schema.Struct({
+  version: Schema.Literal(GENERATED_PROGRAM_VERSION),
+  contract: GeneratedProgramContractSchema,
+  source: Schema.String.pipe(Schema.minLength(1), Schema.maxLength(100_000)),
+});
+
+export type GeneratedProgramEnvelope = typeof GeneratedProgramEnvelopeSchema.Type;
+
+export const GeneratedProgramArtifactSchema = Schema.Struct({
+  cacheKey: Schema.String.pipe(Schema.minLength(64), Schema.maxLength(64)),
+  contract: GeneratedProgramContractSchema,
+  compiledSource: Schema.String.pipe(Schema.minLength(1), Schema.maxLength(250_000)),
+});
+
+export type GeneratedProgramArtifact = typeof GeneratedProgramArtifactSchema.Type;
+
+export const GeneratedProgramInvocationSchema = Schema.Struct({
+  artifact: GeneratedProgramArtifactSchema,
+  input: Schema.Unknown,
+});
+
+export type GeneratedProgramInvocation = typeof GeneratedProgramInvocationSchema.Type;
+
+export const GeneratedProgramResultSchema = Schema.Struct({
+  contract: GeneratedProgramContractSchema,
+  value: Schema.Unknown,
+});
+
+export type GeneratedProgramResult = typeof GeneratedProgramResultSchema.Type;


### PR DESCRIPTION
## Summary

- add a generic versioned envelope/artifact/invocation/result contract for agent-generated TypeScript
- transpile import-free TypeScript once with Sucrase and cache artifacts/functions by SHA-256
- execute collectors and selectors against the trusted shared `StudioMcpBroker.callTool` capability
- classify compile, tool-contract, runtime, and output failures with `regenerate: true`
- document persistence and feature-specific integration boundaries

## Contract

Generated source defines `async function run({ input, callTool })`. `compile` returns a persistable artifact containing the compiled source and versioned contract metadata. `invoke` accepts that artifact plus feature input and returns JSON-serializable output. Feature-specific handlers validate the result value against their own Effect schema; routine invocation performs no model inference.

This is intentionally a trusted Electron runtime, not a security sandbox. Features expose narrow, feature-specific IPC handlers rather than a generic renderer arbitrary-code endpoint.

## Validation

- `pnpm typecheck`
- focused runtime tests: 7 passed
- full suite: 151 unit/UI + 8 release tests passed
- `pnpm build`
- `pnpm lint` (47 pre-existing warnings)
- `git diff --check`
