### PR TITLE
Add Studio target picker

### DIFF
--- a/electron/channels.ts
+++ b/electron/channels.ts
@@ -8,4 +8,6 @@ export const channels = {
   openUrl: "app:open-url",
   patchConfig: "config:patch",
   relaunch: "app:relaunch",
+  discoverStudioTargets: "studio-target:discover",
+  selectStudioTarget: "studio-target:select",
 } as const;

--- a/electron/channels.ts
+++ b/electron/channels.ts
@@ -9,5 +9,6 @@ export const channels = {
   patchConfig: "config:patch",
   relaunch: "app:relaunch",
   discoverStudioTargets: "studio-target:discover",
+  installStudioTargetPrograms: "studio-target:install-programs",
   selectStudioTarget: "studio-target:select",
 } as const;

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -13,9 +13,16 @@ import {
   DEFAULT_APP_CONFIG,
   type OpenCodeStartupProgress,
 } from "../src/types/desktop";
+import {
+  StudioTargetDiscoverySchema,
+  StudioTargetProgramEnvelopesSchema,
+  StudioTargetProgramsSchema,
+  StudioTargetSelectionSchema,
+} from "../src/types/studioTarget";
 import { handleLastWindowClosed } from "./appLifecycle";
 import { channels } from "./channels";
 import { makeOpenCodeLayer, OpenCode } from "./services/OpenCode";
+import { GeneratedProgramRuntime, GeneratedProgramRuntimeLive } from "./services/GeneratedProgramRuntime";
 import { makeStudioMcpBrokerLayer } from "./services/StudioMcpBroker";
 
 const currentDirectory = dirname(fileURLToPath(import.meta.url));
@@ -30,8 +37,14 @@ class DesktopMainError extends Data.TaggedError("DesktopMainError")<{
   cause?: unknown;
 }> {}
 
+const studioMcpBrokerLayer = makeStudioMcpBrokerLayer({
+  workspace: join(app.getPath("home"), "BloxBot"),
+  localAppData: process.env.LOCALAPPDATA,
+});
+
 const openCodeRuntime = ManagedRuntime.make(
-  makeOpenCodeLayer({
+  Layer.merge(
+    makeOpenCodeLayer({
     binaryCacheDirectory: join(app.getPath("userData"), "opencode"),
     workspace: join(app.getPath("home"), "BloxBot"),
     onStartupProgress: (progress: OpenCodeStartupProgress) => {
@@ -39,15 +52,25 @@ const openCodeRuntime = ManagedRuntime.make(
         mainWindow.webContents.send(channels.openCodeStartupProgress, progress);
       }
     },
-  }).pipe(
-    Layer.provide(
-      makeStudioMcpBrokerLayer({
-        workspace: join(app.getPath("home"), "BloxBot"),
-        localAppData: process.env.LOCALAPPDATA,
-      }),
-    ),
+    }).pipe(Layer.provide(studioMcpBrokerLayer)),
+    GeneratedProgramRuntimeLive.pipe(Layer.provide(studioMcpBrokerLayer)),
   ),
 );
+
+const expectedContract = (name: string) => ({
+  name,
+  version: "1",
+  inputSchemaVersion: "1",
+  outputSchemaVersion: "1",
+});
+
+function requireContract(contract: { name: string; version: string; inputSchemaVersion: string; outputSchemaVersion: string }, name: string) {
+  const expected = expectedContract(name);
+  if (JSON.stringify(contract) !== JSON.stringify(expected)) {
+    return Effect.fail(new DesktopMainError({ message: `Generated program contract ${name} is invalid` }));
+  }
+  return Effect.void;
+}
 
 function isMissingFile(cause: unknown): boolean {
   return (
@@ -135,6 +158,47 @@ const registerIpcHandlers = Effect.sync(() => {
   ipcMain.handle(channels.getVersion, () => runMain(Effect.sync(() => app.getVersion())));
   ipcMain.handle(channels.loadConfig, () => runMain(loadConfig));
   ipcMain.handle(channels.patchConfig, (_event, patch: unknown) => runMain(patchConfig(patch)));
+  ipcMain.handle(channels.installStudioTargetPrograms, (_event, input: unknown) =>
+    openCodeRuntime.runPromise(
+      Effect.gen(function* () {
+        const envelopes = yield* Schema.decodeUnknown(StudioTargetProgramEnvelopesSchema)(input);
+        yield* requireContract(envelopes.discovery.contract, "studio-target-discovery");
+        yield* requireContract(envelopes.selection.contract, "studio-target-selection");
+        const runtime = yield* GeneratedProgramRuntime;
+        const [discoveryArtifact, selectionArtifact] = yield* Effect.all([
+          runtime.compile(envelopes.discovery),
+          runtime.compile(envelopes.selection),
+        ], { concurrency: "unbounded" });
+        return yield* Schema.decodeUnknown(StudioTargetProgramsSchema)({
+          discovery: { envelope: envelopes.discovery, artifact: discoveryArtifact },
+          selection: { envelope: envelopes.selection, artifact: selectionArtifact },
+        });
+      }),
+    ),
+  );
+  ipcMain.handle(channels.discoverStudioTargets, (_event, input: unknown) =>
+    openCodeRuntime.runPromise(
+      Effect.gen(function* () {
+        const programs = yield* Schema.decodeUnknown(StudioTargetProgramsSchema)(input);
+        yield* requireContract(programs.discovery.artifact.contract, "studio-target-discovery");
+        const runtime = yield* GeneratedProgramRuntime;
+        const result = yield* runtime.invoke({ artifact: programs.discovery.artifact, input: {} });
+        return yield* Schema.decodeUnknown(StudioTargetDiscoverySchema)(result.value);
+      }),
+    ),
+  );
+  ipcMain.handle(channels.selectStudioTarget, (_event, input: unknown, targetKey: unknown) =>
+    openCodeRuntime.runPromise(
+      Effect.gen(function* () {
+        const programs = yield* Schema.decodeUnknown(StudioTargetProgramsSchema)(input);
+        const key = yield* Schema.decodeUnknown(Schema.String.pipe(Schema.minLength(1), Schema.maxLength(512)))(targetKey);
+        yield* requireContract(programs.selection.artifact.contract, "studio-target-selection");
+        const runtime = yield* GeneratedProgramRuntime;
+        const result = yield* runtime.invoke({ artifact: programs.selection.artifact, input: { targetKey: key } });
+        return yield* Schema.decodeUnknown(StudioTargetSelectionSchema)(result.value);
+      }),
+    ),
+  );
   ipcMain.handle(channels.openUrl, (_event, rawUrl: string) =>
     runMain(
       parseExternalUrl(rawUrl).pipe(

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -18,8 +18,12 @@ const api: DesktopApi = {
   checkForUpdate: () => ipcRenderer.invoke(channels.checkForUpdate),
   installUpdate: () => ipcRenderer.invoke(channels.installUpdate),
   relaunch: () => ipcRenderer.invoke(channels.relaunch),
-  discoverStudioTargets: () => ipcRenderer.invoke(channels.discoverStudioTargets),
-  selectStudioTarget: (targetKey) => ipcRenderer.invoke(channels.selectStudioTarget, targetKey),
+  installStudioTargetPrograms: (envelopes) =>
+    ipcRenderer.invoke(channels.installStudioTargetPrograms, envelopes),
+  discoverStudioTargets: (programs) =>
+    ipcRenderer.invoke(channels.discoverStudioTargets, programs),
+  selectStudioTarget: (programs, targetKey) =>
+    ipcRenderer.invoke(channels.selectStudioTarget, programs, targetKey),
 };
 
 contextBridge.exposeInMainWorld("bloxbot", api);

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -18,6 +18,8 @@ const api: DesktopApi = {
   checkForUpdate: () => ipcRenderer.invoke(channels.checkForUpdate),
   installUpdate: () => ipcRenderer.invoke(channels.installUpdate),
   relaunch: () => ipcRenderer.invoke(channels.relaunch),
+  discoverStudioTargets: () => ipcRenderer.invoke(channels.discoverStudioTargets),
+  selectStudioTarget: (targetKey) => ipcRenderer.invoke(channels.selectStudioTarget, targetKey),
 };
 
 contextBridge.exposeInMainWorld("bloxbot", api);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,7 @@ import { ActiveSessionProvider } from "@/providers/ActiveSessionProvider";
 import { OpenCodeClientProvider } from "@/providers/OpenCodeClientProvider";
 import { PreferencesProvider } from "@/providers/PreferencesProvider";
 import { QueryProvider } from "@/providers/QueryProvider";
+import { StudioTargetProvider } from "@/providers/StudioTargetProvider";
 
 function AppInner() {
   useUpdater();
@@ -33,7 +34,9 @@ function App() {
         <OpenCodeClientProvider activeSessionIdRef={activeSessionIdRef}>
           <ActiveSessionProvider activeSessionIdRef={activeSessionIdRef}>
             <PreferencesProvider>
-              <AppInner />
+              <StudioTargetProvider>
+                <AppInner />
+              </StudioTargetProvider>
             </PreferencesProvider>
           </ActiveSessionProvider>
         </OpenCodeClientProvider>

--- a/src/components/Chat.tsx
+++ b/src/components/Chat.tsx
@@ -6,6 +6,7 @@ import ChatMessages from "@/components/ChatMessages";
 import ChatSidebar from "@/components/ChatSidebar";
 import LoadingScreen from "@/components/LoadingScreen";
 import StudioSetup from "@/components/StudioSetup";
+import StudioTargetPicker from "@/components/StudioTargetPicker";
 import { useCreateSession } from "@/hooks/mutations/useCreateSession";
 import { useSessionStatus } from "@/hooks/useSessionStatuses";
 import { useSessions } from "@/hooks/useSessions";
@@ -135,7 +136,7 @@ function Chat() {
         ) : (
           <>
             <div className="flex h-10 shrink-0 items-center border-b px-4">
-              <div className="flex items-center gap-2">
+              <div className="flex min-w-0 flex-1 items-center gap-2">
                 <h3 className="truncate text-xs font-semibold">
                   {activeSessionTitle || "Untitled"}
                 </h3>
@@ -146,6 +147,7 @@ function Chat() {
                   </span>
                 )}
               </div>
+              <StudioTargetPicker />
             </div>
 
             <ChatMessages />

--- a/src/components/ChatInput.tsx
+++ b/src/components/ChatInput.tsx
@@ -8,6 +8,7 @@ import { useIsBusy } from "@/hooks/useSessionStatuses";
 import { splitModelKey } from "@/lib/splitModelKey";
 import { useActiveSession } from "@/providers/ActiveSessionProvider";
 import { usePreferences } from "@/providers/PreferencesProvider";
+import { useStudioTargetOptional } from "@/providers/StudioTargetProvider";
 import type { ModelInfo } from "@/types";
 
 // ── Image attachment helpers ────────────────────────────────────────────
@@ -246,6 +247,7 @@ function ChatInput() {
     setSelectedVariant,
   } = usePreferences();
   const sendMessage = useSendMessage();
+  const studioTargetReference = useStudioTargetOptional()?.promptReference ?? null;
 
   // Available variants for the currently selected model
   const availableVariants = useMemo(() => {
@@ -468,7 +470,7 @@ function ChatInput() {
     setAttachments([]);
     if (textareaRef.current) textareaRef.current.style.height = "auto";
     sendMessage.mutate(
-      { text: trimmed || " ", images },
+      { text: trimmed || " ", images, studioTargetReference },
       {
         onError: (error) => {
           if (activeSessionIdRef.current !== activeSessionId) return;

--- a/src/components/StudioTargetPicker.tsx
+++ b/src/components/StudioTargetPicker.tsx
@@ -1,0 +1,176 @@
+import posthog from "posthog-js/dist/module.full.no-external.js";
+import { useEffect, useRef, useState } from "react";
+
+import { useStudioTarget } from "@/providers/StudioTargetProvider";
+
+function StudioIcon() {
+  return (
+    <svg
+      aria-hidden="true"
+      width="13"
+      height="13"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.8"
+    >
+      <path d="M4 5.5h16v11H4z" />
+      <path d="M8 20h8M12 16.5V20" />
+    </svg>
+  );
+}
+
+export default function StudioTargetPicker() {
+  const { targets, selected, status, selectingKey, error, discover, select } = useStudioTarget();
+  const [open, setOpen] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const close = (event: MouseEvent) => {
+      if (!containerRef.current?.contains(event.target as Node)) setOpen(false);
+    };
+    document.addEventListener("mousedown", close);
+    return () => document.removeEventListener("mousedown", close);
+  }, [open]);
+
+  const buttonLabel =
+    status === "loading"
+      ? "Finding Studios…"
+      : (selected?.label ?? (status === "empty" ? "No Studios" : "Choose Studio"));
+
+  return (
+    <div ref={containerRef} className="relative min-w-0">
+      <button
+        type="button"
+        aria-haspopup="dialog"
+        aria-expanded={open}
+        onClick={() =>
+          setOpen((value) => {
+            if (!value) posthog.capture("studio_target_picker_opened");
+            return !value;
+          })
+        }
+        className="flex h-7 max-w-[240px] items-center gap-1.5 rounded-md border bg-background px-2 text-[11px] text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+      >
+        <StudioIcon />
+        <span className="truncate">{buttonLabel}</span>
+        {status === "loading" ? (
+          <span className="ml-0.5 h-2.5 w-2.5 animate-spin rounded-full border border-current border-t-transparent" />
+        ) : (
+          <svg
+            aria-hidden="true"
+            width="10"
+            height="10"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+          >
+            <path d="m7 10 5 5 5-5" />
+          </svg>
+        )}
+      </button>
+      {open ? (
+        <div
+          role="dialog"
+          aria-label="Choose Roblox Studio"
+          className="absolute right-0 top-9 z-40 w-80 overflow-hidden rounded-xl border bg-popover text-popover-foreground shadow-xl"
+        >
+          <div className="flex items-start justify-between gap-3 border-b px-4 py-3">
+            <div>
+              <h4 className="text-sm font-semibold">Target Studio</h4>
+              <p className="mt-0.5 text-[11px] leading-4 text-muted-foreground">
+                Explorer and new chat actions use this window.
+              </p>
+            </div>
+            <button
+              type="button"
+              onClick={() => void discover()}
+              disabled={status === "loading" || selectingKey !== null}
+              className="rounded-md px-2 py-1 text-[11px] font-medium text-muted-foreground hover:bg-accent hover:text-foreground disabled:opacity-50"
+            >
+              Refresh
+            </button>
+          </div>
+          <div className="max-h-72 p-2">
+            {status === "loading" ? (
+              <output className="block space-y-2 p-2" aria-label="Loading Studio targets">
+                {[0, 1].map((item) => (
+                  <div key={item} className="h-12 animate-pulse rounded-lg bg-muted" />
+                ))}
+              </output>
+            ) : status === "empty" ? (
+              <div className="px-4 py-7 text-center">
+                <p className="text-sm font-medium">No Studio windows found</p>
+                <p className="mt-1 text-[11px] leading-4 text-muted-foreground">
+                  Open a place and enable Studio’s MCP server, then refresh.
+                </p>
+              </div>
+            ) : status === "error" ? (
+              <div className="px-4 py-7 text-center">
+                <p className="text-sm font-medium">Couldn’t find Studios</p>
+                <p className="mt-1 text-[11px] leading-4 text-muted-foreground">
+                  Check that Studio is open and try again.
+                </p>
+              </div>
+            ) : (
+              <div className="space-y-1">
+                {targets.map((target) => {
+                  const active = selected?.key === target.key;
+                  const selecting = selectingKey === target.key;
+                  return (
+                    <button
+                      key={target.key}
+                      type="button"
+                      disabled={selectingKey !== null}
+                      onClick={() => void select(target)}
+                      className={`flex w-full items-center gap-3 rounded-lg px-3 py-2.5 text-left transition-colors disabled:opacity-60 ${active ? "bg-accent" : "hover:bg-accent/70"}`}
+                    >
+                      <span
+                        className={`flex h-7 w-7 shrink-0 items-center justify-center rounded-md border ${active ? "border-foreground/20 bg-background text-foreground" : "bg-muted text-muted-foreground"}`}
+                      >
+                        <StudioIcon />
+                      </span>
+                      <span className="min-w-0 flex-1">
+                        <span className="block truncate text-xs font-medium">{target.label}</span>
+                        {target.detail ? (
+                          <span className="mt-0.5 block truncate text-[10px] text-muted-foreground">
+                            {target.detail}
+                          </span>
+                        ) : null}
+                      </span>
+                      {selecting ? (
+                        <span className="h-3 w-3 animate-spin rounded-full border border-current border-t-transparent" />
+                      ) : active ? (
+                        <svg
+                          aria-label="Selected"
+                          width="14"
+                          height="14"
+                          viewBox="0 0 24 24"
+                          fill="none"
+                          stroke="currentColor"
+                          strokeWidth="2.4"
+                        >
+                          <path d="m5 12 4 4L19 6" />
+                        </svg>
+                      ) : null}
+                    </button>
+                  );
+                })}
+              </div>
+            )}
+          </div>
+          {error ? (
+            <div
+              role="alert"
+              className="border-t border-red-200 bg-red-50 px-4 py-2.5 text-[10px] leading-4 text-red-700 dark:border-red-900 dark:bg-red-950/40 dark:text-red-300"
+            >
+              {error}
+            </div>
+          ) : null}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/src/components/StudioTargetPicker.tsx
+++ b/src/components/StudioTargetPicker.tsx
@@ -1,7 +1,7 @@
 import posthog from "posthog-js/dist/module.full.no-external.js";
 import { useEffect, useRef, useState } from "react";
 
-import { useStudioTarget } from "@/providers/StudioTargetProvider";
+import { useStudioTargetOptional } from "@/providers/StudioTargetProvider";
 
 function StudioIcon() {
   return (
@@ -21,7 +21,7 @@ function StudioIcon() {
 }
 
 export default function StudioTargetPicker() {
-  const { targets, selected, status, selectingKey, error, discover, select } = useStudioTarget();
+  const studioTarget = useStudioTargetOptional();
   const [open, setOpen] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
 
@@ -33,6 +33,9 @@ export default function StudioTargetPicker() {
     document.addEventListener("mousedown", close);
     return () => document.removeEventListener("mousedown", close);
   }, [open]);
+
+  if (!studioTarget) return null;
+  const { targets, selected, status, selectingKey, error, discover, select } = studioTarget;
 
   const buttonLabel =
     status === "loading"

--- a/src/hooks/mutations/useSendMessage.ts
+++ b/src/hooks/mutations/useSendMessage.ts
@@ -12,6 +12,7 @@ import { usePreferences } from "@/providers/PreferencesProvider";
 interface SendMessageInput {
   text: string;
   images?: Array<{ mime: string; url: string; filename?: string }>;
+  studioTargetReference?: string | null;
 }
 
 interface SendMessageContext {
@@ -26,7 +27,7 @@ export function useSendMessage() {
   const queryClient = useQueryClient();
 
   return useMutation<void, Error, SendMessageInput, SendMessageContext | undefined>({
-    mutationFn: async ({ text, images }: SendMessageInput) => {
+    mutationFn: async ({ text, images, studioTargetReference }: SendMessageInput) => {
       if (!client || !activeSessionId) throw new Error("No client or session");
 
       const parts: Array<{ type: string; [k: string]: unknown }> = [{ type: "text", text }];
@@ -39,6 +40,7 @@ export function useSendMessage() {
         sessionID: activeSessionId,
         parts,
       };
+      if (studioTargetReference) opts.system = studioTargetReference;
       let provider: string | undefined;
       let model: string | undefined;
 

--- a/src/lib/desktop.ts
+++ b/src/lib/desktop.ts
@@ -11,6 +11,12 @@ import {
   type UpdateInfo,
   UpdateInfoSchema,
 } from "@/types/desktop";
+import {
+  type StudioTargetDiscovery,
+  StudioTargetDiscoverySchema,
+  type StudioTargetSelection,
+  StudioTargetSelectionSchema,
+} from "@/types/studioTarget";
 
 const CONFIG_KEY = "bloxbot-config";
 const DEFAULT_CONFIG: AppConfig = DEFAULT_APP_CONFIG;
@@ -29,6 +35,10 @@ interface DesktopEffects {
   readonly checkForUpdate: Effect.Effect<UpdateInfo | null, DesktopError>;
   readonly installUpdate: Effect.Effect<void, DesktopError>;
   readonly relaunch: Effect.Effect<void, DesktopError>;
+  readonly discoverStudioTargets: Effect.Effect<StudioTargetDiscovery, DesktopError>;
+  readonly selectStudioTarget: (
+    targetKey: string,
+  ) => Effect.Effect<StudioTargetSelection, DesktopError>;
 }
 
 type StartupProgressListener = (progress: OpenCodeStartupProgress) => void;
@@ -82,6 +92,13 @@ const browserEffects: DesktopEffects = {
     new DesktopError({ message: "Updates are only available in the desktop app." }),
   ),
   relaunch: Effect.sync(() => window.location.reload()),
+  discoverStudioTargets: Effect.fail(
+    new DesktopError({ message: "Studio targets are only available in the desktop app." }),
+  ),
+  selectStudioTarget: () =>
+    Effect.fail(
+      new DesktopError({ message: "Studio targets are only available in the desktop app." }),
+    ),
 };
 
 const invoke = <A>(message: string, operation: () => Promise<A>) =>
@@ -122,6 +139,13 @@ function makeBridgeEffects(api: DesktopApi): DesktopEffects {
     ),
     installUpdate: invoke("Failed to install the update", () => api.installUpdate()),
     relaunch: invoke("Failed to relaunch the app", () => api.relaunch()),
+    discoverStudioTargets: invoke("Failed to discover Studio targets", () =>
+      api.discoverStudioTargets(),
+    ).pipe(decodeBridgeValue("Studio target discovery is invalid", StudioTargetDiscoverySchema)),
+    selectStudioTarget: (targetKey) =>
+      invoke("Failed to select the Studio target", () => api.selectStudioTarget(targetKey)).pipe(
+        decodeBridgeValue("Studio target selection is invalid", StudioTargetSelectionSchema),
+      ),
   };
 }
 
@@ -144,4 +168,6 @@ export const desktop: DesktopApi = {
   checkForUpdate: () => runPromise(desktopEffects.checkForUpdate),
   installUpdate: () => runPromise(desktopEffects.installUpdate),
   relaunch: () => runPromise(desktopEffects.relaunch),
+  discoverStudioTargets: () => runPromise(desktopEffects.discoverStudioTargets),
+  selectStudioTarget: (targetKey) => runPromise(desktopEffects.selectStudioTarget(targetKey)),
 };

--- a/src/lib/desktop.ts
+++ b/src/lib/desktop.ts
@@ -14,6 +14,9 @@ import {
 import {
   type StudioTargetDiscovery,
   StudioTargetDiscoverySchema,
+  type StudioTargetProgramEnvelopes,
+  type StudioTargetPrograms,
+  StudioTargetProgramsSchema,
   type StudioTargetSelection,
   StudioTargetSelectionSchema,
 } from "@/types/studioTarget";
@@ -35,8 +38,14 @@ interface DesktopEffects {
   readonly checkForUpdate: Effect.Effect<UpdateInfo | null, DesktopError>;
   readonly installUpdate: Effect.Effect<void, DesktopError>;
   readonly relaunch: Effect.Effect<void, DesktopError>;
-  readonly discoverStudioTargets: Effect.Effect<StudioTargetDiscovery, DesktopError>;
+  readonly installStudioTargetPrograms: (
+    envelopes: StudioTargetProgramEnvelopes,
+  ) => Effect.Effect<StudioTargetPrograms, DesktopError>;
+  readonly discoverStudioTargets: (
+    programs: StudioTargetPrograms,
+  ) => Effect.Effect<StudioTargetDiscovery, DesktopError>;
   readonly selectStudioTarget: (
+    programs: StudioTargetPrograms,
     targetKey: string,
   ) => Effect.Effect<StudioTargetSelection, DesktopError>;
 }
@@ -92,9 +101,14 @@ const browserEffects: DesktopEffects = {
     new DesktopError({ message: "Updates are only available in the desktop app." }),
   ),
   relaunch: Effect.sync(() => window.location.reload()),
-  discoverStudioTargets: Effect.fail(
-    new DesktopError({ message: "Studio targets are only available in the desktop app." }),
-  ),
+  installStudioTargetPrograms: () =>
+    Effect.fail(
+      new DesktopError({ message: "Studio targets are only available in the desktop app." }),
+    ),
+  discoverStudioTargets: () =>
+    Effect.fail(
+      new DesktopError({ message: "Studio targets are only available in the desktop app." }),
+    ),
   selectStudioTarget: () =>
     Effect.fail(
       new DesktopError({ message: "Studio targets are only available in the desktop app." }),
@@ -139,13 +153,18 @@ function makeBridgeEffects(api: DesktopApi): DesktopEffects {
     ),
     installUpdate: invoke("Failed to install the update", () => api.installUpdate()),
     relaunch: invoke("Failed to relaunch the app", () => api.relaunch()),
-    discoverStudioTargets: invoke("Failed to discover Studio targets", () =>
-      api.discoverStudioTargets(),
-    ).pipe(decodeBridgeValue("Studio target discovery is invalid", StudioTargetDiscoverySchema)),
-    selectStudioTarget: (targetKey) =>
-      invoke("Failed to select the Studio target", () => api.selectStudioTarget(targetKey)).pipe(
-        decodeBridgeValue("Studio target selection is invalid", StudioTargetSelectionSchema),
+    installStudioTargetPrograms: (envelopes) =>
+      invoke("Failed to install Studio target programs", () =>
+        api.installStudioTargetPrograms(envelopes),
+      ).pipe(decodeBridgeValue("Studio target programs are invalid", StudioTargetProgramsSchema)),
+    discoverStudioTargets: (programs) =>
+      invoke("Failed to discover Studio targets", () => api.discoverStudioTargets(programs)).pipe(
+        decodeBridgeValue("Studio target discovery is invalid", StudioTargetDiscoverySchema),
       ),
+    selectStudioTarget: (programs, targetKey) =>
+      invoke("Failed to select the Studio target", () =>
+        api.selectStudioTarget(programs, targetKey),
+      ).pipe(decodeBridgeValue("Studio target selection is invalid", StudioTargetSelectionSchema)),
   };
 }
 
@@ -168,6 +187,9 @@ export const desktop: DesktopApi = {
   checkForUpdate: () => runPromise(desktopEffects.checkForUpdate),
   installUpdate: () => runPromise(desktopEffects.installUpdate),
   relaunch: () => runPromise(desktopEffects.relaunch),
-  discoverStudioTargets: () => runPromise(desktopEffects.discoverStudioTargets),
-  selectStudioTarget: (targetKey) => runPromise(desktopEffects.selectStudioTarget(targetKey)),
+  installStudioTargetPrograms: (envelopes) =>
+    runPromise(desktopEffects.installStudioTargetPrograms(envelopes)),
+  discoverStudioTargets: (programs) => runPromise(desktopEffects.discoverStudioTargets(programs)),
+  selectStudioTarget: (programs, targetKey) =>
+    runPromise(desktopEffects.selectStudioTarget(programs, targetKey)),
 };

--- a/src/lib/studioTargetPrograms.ts
+++ b/src/lib/studioTargetPrograms.ts
@@ -1,0 +1,85 @@
+import type { OpencodeClient } from "@opencode-ai/sdk/v2/client";
+import { Effect, Schema } from "effect";
+
+import {
+  type StudioTargetProgramEnvelopes,
+  StudioTargetProgramEnvelopesSchema,
+} from "@/types/studioTarget";
+
+const ENVELOPE_JSON_SCHEMA = {
+  type: "object",
+  additionalProperties: false,
+  required: ["version", "contract", "source"],
+  properties: {
+    version: { const: 1 },
+    contract: {
+      type: "object",
+      additionalProperties: false,
+      required: ["name", "version", "inputSchemaVersion", "outputSchemaVersion"],
+      properties: {
+        name: { type: "string" },
+        version: { type: "string" },
+        inputSchemaVersion: { type: "string" },
+        outputSchemaVersion: { type: "string" },
+      },
+    },
+    source: { type: "string" },
+  },
+} as const;
+
+const OUTPUT_SCHEMA = {
+  type: "object",
+  additionalProperties: false,
+  required: ["discovery", "selection"],
+  properties: {
+    discovery: ENVELOPE_JSON_SCHEMA,
+    selection: ENVELOPE_JSON_SCHEMA,
+  },
+} as const;
+
+const SYSTEM_PROMPT = `You generate two deterministic, import-free TypeScript programs for BloxBot's Studio target picker.
+First inspect the Studio MCP capabilities available to you. Do not assume tool names, argument names, result shapes, or target identifiers.
+Return envelopes for:
+1. discovery: contract name "studio-target-discovery", version "1", inputSchemaVersion "1", outputSchemaVersion "1". Its async function run({ input, callTool }) lists connected Roblox Studio sessions/places and the currently selected target. Return { targets: [{ key, label, detail }], selectedKey }. Keys must be opaque stable strings suitable for passing back to the selector. Labels/details are user-facing. detail may be null.
+2. selection: contract name "studio-target-selection", version "1", inputSchemaVersion "1", outputSchemaVersion "1". Its run receives input { targetKey }, switches to that target using discovered MCP contracts, then independently verifies the active target. Return { selected: { key, label, detail }, verified: true }. Throw if the target is stale, disconnected, ambiguous, or verification disagrees.
+Each source must define exactly async function run({ input, callTool }) and use only JSON-safe values plus callTool(name,args). No imports, exports, eval, global state, prose, markdown fences, or hardcoded place/session identifiers. Normalize MCP content defensively. Return only the requested structured output.`;
+
+interface StudioTargetModel {
+  providerID: string;
+  modelID: string;
+}
+
+export async function generateStudioTargetPrograms(
+  client: OpencodeClient,
+  model?: StudioTargetModel,
+  agent?: string | null,
+): Promise<StudioTargetProgramEnvelopes> {
+  const created = await client.session.create(
+    {
+      title: "BloxBot Studio target setup",
+      metadata: { bloxbotHidden: true, purpose: "studio-target-programs" },
+    },
+    { throwOnError: true },
+  );
+  const sessionID = created.data.id;
+  try {
+    const response = await client.session.prompt(
+      {
+        sessionID,
+        model,
+        agent: agent ?? undefined,
+        system: SYSTEM_PROMPT,
+        format: { type: "json_schema", schema: OUTPUT_SCHEMA, retryCount: 2 },
+        parts: [
+          { type: "text", text: "Inspect current Studio MCP tools and generate both programs." },
+        ],
+      },
+      { throwOnError: true },
+    );
+    return Effect.runPromise(
+      Schema.decodeUnknown(StudioTargetProgramEnvelopesSchema)(response.data.info.structured),
+    );
+  } finally {
+    await client.session.delete({ sessionID }, { throwOnError: true }).catch(() => undefined);
+  }
+}

--- a/src/providers/StudioTargetProvider.tsx
+++ b/src/providers/StudioTargetProvider.tsx
@@ -1,0 +1,129 @@
+import posthog from "posthog-js/dist/module.full.no-external.js";
+import {
+  createContext,
+  type ReactNode,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+
+import { desktop } from "@/lib/desktop";
+import type { StudioTarget } from "@/types/studioTarget";
+
+export type StudioTargetStatus = "loading" | "ready" | "empty" | "error";
+
+interface StudioTargetContextValue {
+  targets: readonly StudioTarget[];
+  selected: StudioTarget | null;
+  status: StudioTargetStatus;
+  selectingKey: string | null;
+  error: string | null;
+  discover(): Promise<void>;
+  select(target: StudioTarget): Promise<void>;
+}
+
+const StudioTargetContext = createContext<StudioTargetContextValue | null>(null);
+
+function countBucket(count: number): "0" | "1" | "2-4" | "5+" {
+  if (count === 0) return "0";
+  if (count === 1) return "1";
+  if (count < 5) return "2-4";
+  return "5+";
+}
+
+export function StudioTargetProvider({ children }: { children: ReactNode }) {
+  const [targets, setTargets] = useState<readonly StudioTarget[]>([]);
+  const [selected, setSelected] = useState<StudioTarget | null>(null);
+  const [status, setStatus] = useState<StudioTargetStatus>("loading");
+  const [selectingKey, setSelectingKey] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const operationRef = useRef(0);
+
+  const discover = useCallback(async () => {
+    const operation = ++operationRef.current;
+    setStatus("loading");
+    setError(null);
+    try {
+      const result = await desktop.discoverStudioTargets();
+      if (operation !== operationRef.current) return;
+      setTargets(result.targets);
+      let nextSelected = result.targets.find((target) => target.key === result.selectedKey) ?? null;
+      if (!nextSelected && result.targets.length === 1) {
+        const onlyTarget = result.targets[0];
+        setSelectingKey(onlyTarget.key);
+        posthog.capture("studio_target_selected");
+        try {
+          const selection = await desktop.selectStudioTarget(onlyTarget.key);
+          if (operation !== operationRef.current) return;
+          if (!selection.verified) throw new Error("Target verification failed");
+          nextSelected = selection.selected;
+          posthog.capture("studio_target_verification_succeeded");
+        } catch {
+          if (operation !== operationRef.current) return;
+          setError("The only Studio window could not be verified. Refresh to try again.");
+          posthog.capture("studio_target_verification_failed");
+        } finally {
+          if (operation === operationRef.current) setSelectingKey(null);
+        }
+      }
+      setSelected(nextSelected);
+      setStatus(result.targets.length === 0 ? "empty" : "ready");
+      posthog.capture("studio_target_discovery_succeeded", {
+        count_bucket: countBucket(result.targets.length),
+      });
+    } catch {
+      if (operation !== operationRef.current) return;
+      setStatus("error");
+      setError("Couldn’t check connected Studio windows.");
+      posthog.capture("studio_target_discovery_failed");
+    }
+  }, []);
+
+  const select = useCallback(async (target: StudioTarget) => {
+    const operation = ++operationRef.current;
+    setSelectingKey(target.key);
+    setError(null);
+    posthog.capture("studio_target_selected");
+    try {
+      const result = await desktop.selectStudioTarget(target.key);
+      if (operation !== operationRef.current) return;
+      if (!result.verified) throw new Error("Target verification failed");
+      setSelected(result.selected);
+      setTargets((current) =>
+        current.some((item) => item.key === result.selected.key)
+          ? current
+          : [...current, result.selected],
+      );
+      setStatus("ready");
+      posthog.capture("studio_target_verification_succeeded");
+    } catch {
+      if (operation !== operationRef.current) return;
+      setError("That Studio window is no longer available. Refresh and choose another.");
+      posthog.capture("studio_target_verification_failed");
+    } finally {
+      if (operation === operationRef.current) setSelectingKey(null);
+    }
+  }, []);
+
+  useEffect(() => {
+    void discover();
+    return () => {
+      operationRef.current += 1;
+    };
+  }, [discover]);
+
+  const value = useMemo(
+    () => ({ targets, selected, status, selectingKey, error, discover, select }),
+    [targets, selected, status, selectingKey, error, discover, select],
+  );
+  return <StudioTargetContext.Provider value={value}>{children}</StudioTargetContext.Provider>;
+}
+
+export function useStudioTarget() {
+  const value = useContext(StudioTargetContext);
+  if (!value) throw new Error("useStudioTarget must be used inside StudioTargetProvider");
+  return value;
+}

--- a/src/providers/StudioTargetProvider.tsx
+++ b/src/providers/StudioTargetProvider.tsx
@@ -11,13 +11,22 @@ import {
 } from "react";
 
 import { desktop } from "@/lib/desktop";
-import type { StudioTarget } from "@/types/studioTarget";
+import { splitModelKey } from "@/lib/splitModelKey";
+import { generateStudioTargetPrograms } from "@/lib/studioTargetPrograms";
+import { useOpenCodeClient } from "@/providers/OpenCodeClientProvider";
+import { usePreferences } from "@/providers/PreferencesProvider";
+import type {
+  StudioTarget,
+  StudioTargetPrograms,
+  StudioTargetSelection,
+} from "@/types/studioTarget";
 
 export type StudioTargetStatus = "loading" | "ready" | "empty" | "error";
 
 interface StudioTargetContextValue {
   targets: readonly StudioTarget[];
   selected: StudioTarget | null;
+  promptReference: string | null;
   status: StudioTargetStatus;
   selectingKey: string | null;
   error: string | null;
@@ -35,89 +44,149 @@ function countBucket(count: number): "0" | "1" | "2-4" | "5+" {
 }
 
 export function StudioTargetProvider({ children }: { children: ReactNode }) {
+  const { client } = useOpenCodeClient();
+  const { selectedModel, selectedAgent } = usePreferences();
   const [targets, setTargets] = useState<readonly StudioTarget[]>([]);
   const [selected, setSelected] = useState<StudioTarget | null>(null);
   const [status, setStatus] = useState<StudioTargetStatus>("loading");
   const [selectingKey, setSelectingKey] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const operationRef = useRef(0);
+  const programsRef = useRef<StudioTargetPrograms | null>(null);
+  const generationRef = useRef<Promise<StudioTargetPrograms> | null>(null);
+
+  const generatePrograms = useCallback(async () => {
+    if (generationRef.current) return generationRef.current;
+    if (!client) throw new Error("The local agent is not ready");
+    const model = selectedModel
+      ? (() => {
+          const [providerID, modelID] = splitModelKey(selectedModel);
+          return providerID && modelID ? { providerID, modelID } : undefined;
+        })()
+      : undefined;
+    const generation = generateStudioTargetPrograms(client, model, selectedAgent)
+      .then((envelopes) => desktop.installStudioTargetPrograms(envelopes))
+      .then(async (programs) => {
+        programsRef.current = programs;
+        await desktop.patchConfig({ studioTargetPrograms: programs });
+        return programs;
+      })
+      .finally(() => {
+        generationRef.current = null;
+      });
+    generationRef.current = generation;
+    return generation;
+  }, [client, selectedAgent, selectedModel]);
+
+  const getPrograms = useCallback(async () => {
+    if (programsRef.current) return programsRef.current;
+    const config = await desktop.loadConfig();
+    if (config.studioTargetPrograms) {
+      programsRef.current = config.studioTargetPrograms;
+      return config.studioTargetPrograms;
+    }
+    return generatePrograms();
+  }, [generatePrograms]);
+
+  const applyDiscovery = useCallback(async (programs: StudioTargetPrograms, operation: number) => {
+    const result = await desktop.discoverStudioTargets(programs);
+    if (operation !== operationRef.current) return;
+    setTargets(result.targets);
+    let nextSelected = result.targets.find((target) => target.key === result.selectedKey) ?? null;
+    if (!nextSelected && result.targets.length === 1) {
+      const onlyTarget = result.targets[0];
+      setSelectingKey(onlyTarget.key);
+      posthog.capture("studio_target_selected");
+      const selection = await desktop.selectStudioTarget(programs, onlyTarget.key);
+      if (operation !== operationRef.current) return;
+      if (!selection.verified) throw new Error("Target verification failed");
+      nextSelected = selection.selected;
+      posthog.capture("studio_target_verification_succeeded");
+      setSelectingKey(null);
+    }
+    setSelected(nextSelected);
+    setStatus(result.targets.length === 0 ? "empty" : "ready");
+    posthog.capture("studio_target_discovery_succeeded", {
+      count_bucket: countBucket(result.targets.length),
+    });
+  }, []);
 
   const discover = useCallback(async () => {
     const operation = ++operationRef.current;
     setStatus("loading");
     setError(null);
     try {
-      const result = await desktop.discoverStudioTargets();
+      const programs = await getPrograms();
+      await applyDiscovery(programs, operation);
+    } catch {
       if (operation !== operationRef.current) return;
-      setTargets(result.targets);
-      let nextSelected = result.targets.find((target) => target.key === result.selectedKey) ?? null;
-      if (!nextSelected && result.targets.length === 1) {
-        const onlyTarget = result.targets[0];
-        setSelectingKey(onlyTarget.key);
-        posthog.capture("studio_target_selected");
-        try {
-          const selection = await desktop.selectStudioTarget(onlyTarget.key);
-          if (operation !== operationRef.current) return;
-          if (!selection.verified) throw new Error("Target verification failed");
-          nextSelected = selection.selected;
-          posthog.capture("studio_target_verification_succeeded");
-        } catch {
-          if (operation !== operationRef.current) return;
-          setError("The only Studio window could not be verified. Refresh to try again.");
-          posthog.capture("studio_target_verification_failed");
-        } finally {
-          if (operation === operationRef.current) setSelectingKey(null);
-        }
+      try {
+        programsRef.current = null;
+        const regenerated = await generatePrograms();
+        await applyDiscovery(regenerated, operation);
+      } catch {
+        if (operation !== operationRef.current) return;
+        setStatus("error");
+        setSelectingKey(null);
+        setError("Couldn’t check connected Studio windows.");
+        posthog.capture("studio_target_discovery_failed");
       }
-      setSelected(nextSelected);
-      setStatus(result.targets.length === 0 ? "empty" : "ready");
-      posthog.capture("studio_target_discovery_succeeded", {
-        count_bucket: countBucket(result.targets.length),
-      });
-    } catch {
-      if (operation !== operationRef.current) return;
-      setStatus("error");
-      setError("Couldn’t check connected Studio windows.");
-      posthog.capture("studio_target_discovery_failed");
     }
-  }, []);
+  }, [applyDiscovery, generatePrograms, getPrograms]);
 
-  const select = useCallback(async (target: StudioTarget) => {
-    const operation = ++operationRef.current;
-    setSelectingKey(target.key);
-    setError(null);
-    posthog.capture("studio_target_selected");
-    try {
-      const result = await desktop.selectStudioTarget(target.key);
-      if (operation !== operationRef.current) return;
-      if (!result.verified) throw new Error("Target verification failed");
-      setSelected(result.selected);
-      setTargets((current) =>
-        current.some((item) => item.key === result.selected.key)
-          ? current
-          : [...current, result.selected],
-      );
-      setStatus("ready");
-      posthog.capture("studio_target_verification_succeeded");
-    } catch {
-      if (operation !== operationRef.current) return;
-      setError("That Studio window is no longer available. Refresh and choose another.");
-      posthog.capture("studio_target_verification_failed");
-    } finally {
-      if (operation === operationRef.current) setSelectingKey(null);
-    }
-  }, []);
+  const select = useCallback(
+    async (target: StudioTarget) => {
+      const operation = ++operationRef.current;
+      setSelectingKey(target.key);
+      setError(null);
+      posthog.capture("studio_target_selected");
+      const attempt = async (programs: StudioTargetPrograms) => {
+        const result = await desktop.selectStudioTarget(programs, target.key);
+        if (!result.verified) throw new Error("Target verification failed");
+        return result;
+      };
+      try {
+        let result: StudioTargetSelection;
+        try {
+          result = await attempt(await getPrograms());
+        } catch {
+          programsRef.current = null;
+          result = await attempt(await generatePrograms());
+        }
+        if (operation !== operationRef.current) return;
+        setSelected(result.selected);
+        setTargets((current) =>
+          current.some((item) => item.key === result.selected.key)
+            ? current
+            : [...current, result.selected],
+        );
+        setStatus("ready");
+        posthog.capture("studio_target_verification_succeeded");
+      } catch {
+        if (operation !== operationRef.current) return;
+        setError("That Studio window is no longer available. Refresh and choose another.");
+        posthog.capture("studio_target_verification_failed");
+      } finally {
+        if (operation === operationRef.current) setSelectingKey(null);
+      }
+    },
+    [generatePrograms, getPrograms],
+  );
 
   useEffect(() => {
+    if (!client) return;
     void discover();
     return () => {
       operationRef.current += 1;
     };
-  }, [discover]);
+  }, [client, discover]);
 
+  const promptReference = selected
+    ? `The app-selected Studio target is "${selected.label}". Treat that label as a hint; verify the active target before place-specific work.`
+    : null;
   const value = useMemo(
-    () => ({ targets, selected, status, selectingKey, error, discover, select }),
-    [targets, selected, status, selectingKey, error, discover, select],
+    () => ({ targets, selected, promptReference, status, selectingKey, error, discover, select }),
+    [targets, selected, promptReference, status, selectingKey, error, discover, select],
   );
   return <StudioTargetContext.Provider value={value}>{children}</StudioTargetContext.Provider>;
 }
@@ -126,4 +195,8 @@ export function useStudioTarget() {
   const value = useContext(StudioTargetContext);
   if (!value) throw new Error("useStudioTarget must be used inside StudioTargetProvider");
   return value;
+}
+
+export function useStudioTargetOptional() {
+  return useContext(StudioTargetContext);
 }

--- a/src/test/StudioTargetPicker.test.tsx
+++ b/src/test/StudioTargetPicker.test.tsx
@@ -1,0 +1,105 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { discoverStudioTargets, selectStudioTarget, capture } = vi.hoisted(() => ({
+  discoverStudioTargets: vi.fn(),
+  selectStudioTarget: vi.fn(),
+  capture: vi.fn(),
+}));
+
+vi.mock("@/lib/desktop", () => ({
+  desktop: { discoverStudioTargets, selectStudioTarget },
+}));
+
+vi.mock("posthog-js/dist/module.full.no-external.js", () => ({
+  default: { capture },
+}));
+
+import StudioTargetPicker from "@/components/StudioTargetPicker";
+import { StudioTargetProvider } from "@/providers/StudioTargetProvider";
+
+function renderPicker() {
+  return render(
+    <StudioTargetProvider>
+      <StudioTargetPicker />
+    </StudioTargetProvider>,
+  );
+}
+
+describe("StudioTargetPicker", () => {
+  beforeEach(() => {
+    discoverStudioTargets.mockReset();
+    selectStudioTarget.mockReset();
+    capture.mockReset();
+  });
+
+  it("auto-selects a single Studio and reports only a count bucket", async () => {
+    discoverStudioTargets.mockResolvedValue({
+      targets: [{ key: "private-session-id", label: "Obby", detail: "Editing" }],
+      selectedKey: null,
+    });
+    selectStudioTarget.mockResolvedValue({
+      selected: { key: "private-session-id", label: "Obby", detail: "Editing" },
+      verified: true,
+    });
+    renderPicker();
+
+    expect(await screen.findByRole("button", { name: /Obby/ })).toBeVisible();
+    expect(capture).toHaveBeenCalledWith("studio_target_discovery_succeeded", {
+      count_bucket: "1",
+    });
+    expect(selectStudioTarget).toHaveBeenCalledWith("private-session-id");
+    expect(JSON.stringify(capture.mock.calls)).not.toContain("private-session-id");
+    expect(JSON.stringify(capture.mock.calls)).not.toContain("Obby");
+  });
+
+  it("lists multiple Studios and verifies a new selection", async () => {
+    discoverStudioTargets.mockResolvedValue({
+      targets: [
+        { key: "one", label: "Lobby", detail: null },
+        { key: "two", label: "Dungeon", detail: "Team Create" },
+      ],
+      selectedKey: "one",
+    });
+    selectStudioTarget.mockResolvedValue({
+      selected: { key: "two", label: "Dungeon", detail: "Team Create" },
+      verified: true,
+    });
+    renderPicker();
+
+    fireEvent.click(await screen.findByRole("button", { name: /Lobby/ }));
+    fireEvent.click(screen.getByRole("button", { name: /Dungeon/ }));
+
+    await waitFor(() => expect(selectStudioTarget).toHaveBeenCalledWith("two"));
+    expect(screen.getByRole("button", { expanded: true })).toHaveTextContent("Dungeon");
+    expect(capture).toHaveBeenCalledWith("studio_target_verification_succeeded");
+  });
+
+  it("handles no Studios and discovery errors", async () => {
+    discoverStudioTargets.mockResolvedValueOnce({ targets: [], selectedKey: null });
+    renderPicker();
+    fireEvent.click(await screen.findByRole("button", { name: /No Studios/ }));
+    expect(screen.getByText("No Studio windows found")).toBeVisible();
+
+    discoverStudioTargets.mockRejectedValueOnce(new Error("offline"));
+    fireEvent.click(screen.getByRole("button", { name: "Refresh" }));
+    expect(await screen.findByText("Couldn’t find Studios")).toBeVisible();
+  });
+
+  it("keeps the prior target when verification fails", async () => {
+    discoverStudioTargets.mockResolvedValue({
+      targets: [
+        { key: "one", label: "Lobby", detail: null },
+        { key: "two", label: "Dungeon", detail: null },
+      ],
+      selectedKey: "one",
+    });
+    selectStudioTarget.mockRejectedValue(new Error("stale"));
+    renderPicker();
+    fireEvent.click(await screen.findByRole("button", { name: /Lobby/ }));
+    fireEvent.click(screen.getByRole("button", { name: /Dungeon/ }));
+
+    expect(await screen.findByRole("alert")).toHaveTextContent("no longer available");
+    expect(screen.getByRole("button", { expanded: true })).toHaveTextContent("Lobby");
+  });
+});

--- a/src/test/StudioTargetPicker.test.tsx
+++ b/src/test/StudioTargetPicker.test.tsx
@@ -1,14 +1,32 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { discoverStudioTargets, selectStudioTarget, capture } = vi.hoisted(() => ({
-  discoverStudioTargets: vi.fn(),
-  selectStudioTarget: vi.fn(),
-  capture: vi.fn(),
-}));
+const { discoverStudioTargets, selectStudioTarget, capture, loadConfig, generatePrograms, client } =
+  vi.hoisted(() => ({
+    discoverStudioTargets: vi.fn(),
+    selectStudioTarget: vi.fn(),
+    capture: vi.fn(),
+    loadConfig: vi.fn(),
+    generatePrograms: vi.fn(),
+    client: {},
+  }));
+
+const programs = { discovery: {}, selection: {} };
 
 vi.mock("@/lib/desktop", () => ({
-  desktop: { discoverStudioTargets, selectStudioTarget },
+  desktop: {
+    discoverStudioTargets,
+    selectStudioTarget,
+    loadConfig,
+    patchConfig: vi.fn(),
+    installStudioTargetPrograms: vi.fn(),
+  },
+}));
+
+vi.mock("@/lib/studioTargetPrograms", () => ({ generateStudioTargetPrograms: generatePrograms }));
+vi.mock("@/providers/OpenCodeClientProvider", () => ({ useOpenCodeClient: () => ({ client }) }));
+vi.mock("@/providers/PreferencesProvider", () => ({
+  usePreferences: () => ({ selectedModel: null, selectedAgent: null }),
 }));
 
 vi.mock("posthog-js/dist/module.full.no-external.js", () => ({
@@ -31,6 +49,8 @@ describe("StudioTargetPicker", () => {
     discoverStudioTargets.mockReset();
     selectStudioTarget.mockReset();
     capture.mockReset();
+    loadConfig.mockResolvedValue({ studioTargetPrograms: programs });
+    generatePrograms.mockRejectedValue(new Error("generation failed"));
   });
 
   it("auto-selects a single Studio and reports only a count bucket", async () => {
@@ -48,7 +68,7 @@ describe("StudioTargetPicker", () => {
     expect(capture).toHaveBeenCalledWith("studio_target_discovery_succeeded", {
       count_bucket: "1",
     });
-    expect(selectStudioTarget).toHaveBeenCalledWith("private-session-id");
+    expect(selectStudioTarget).toHaveBeenCalledWith(programs, "private-session-id");
     expect(JSON.stringify(capture.mock.calls)).not.toContain("private-session-id");
     expect(JSON.stringify(capture.mock.calls)).not.toContain("Obby");
   });
@@ -70,7 +90,7 @@ describe("StudioTargetPicker", () => {
     fireEvent.click(await screen.findByRole("button", { name: /Lobby/ }));
     fireEvent.click(screen.getByRole("button", { name: /Dungeon/ }));
 
-    await waitFor(() => expect(selectStudioTarget).toHaveBeenCalledWith("two"));
+    await waitFor(() => expect(selectStudioTarget).toHaveBeenCalledWith(programs, "two"));
     expect(screen.getByRole("button", { expanded: true })).toHaveTextContent("Dungeon");
     expect(capture).toHaveBeenCalledWith("studio_target_verification_succeeded");
   });

--- a/src/test/desktop.test.ts
+++ b/src/test/desktop.test.ts
@@ -25,6 +25,7 @@ describe("browser desktop fallback", () => {
       hiddenModels: [],
       theme: "system",
       detailedAnalytics: "unset",
+      studioTargetPrograms: null,
     });
   });
 
@@ -40,6 +41,7 @@ describe("browser desktop fallback", () => {
       hiddenModels: [],
       theme: "system",
       detailedAnalytics: "unset",
+      studioTargetPrograms: null,
     });
   });
 
@@ -53,6 +55,7 @@ describe("browser desktop fallback", () => {
       hiddenModels: [],
       theme: "dark",
       detailedAnalytics: "unset",
+      studioTargetPrograms: null,
     });
   });
 

--- a/src/test/studioTargetPrograms.test.ts
+++ b/src/test/studioTargetPrograms.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { generateStudioTargetPrograms } from "@/lib/studioTargetPrograms";
+
+const envelope = (name: string) => ({
+  version: 1 as const,
+  contract: { name, version: "1", inputSchemaVersion: "1", outputSchemaVersion: "1" },
+  source:
+    "async function run({ input, callTool }: { input: unknown; callTool: Function }) { return {}; }",
+});
+
+describe("Studio target program generation", () => {
+  it("uses a disposable private session and strict structured output", async () => {
+    const create = vi.fn().mockResolvedValue({ data: { id: "private" } });
+    const prompt = vi.fn().mockResolvedValue({
+      data: {
+        info: {
+          structured: {
+            discovery: envelope("studio-target-discovery"),
+            selection: envelope("studio-target-selection"),
+          },
+        },
+      },
+    });
+    const remove = vi.fn().mockResolvedValue({ data: true });
+    const client = { session: { create, prompt, delete: remove } };
+
+    const result = await generateStudioTargetPrograms(
+      client as never,
+      { providerID: "openai", modelID: "gpt" },
+      "build",
+    );
+
+    expect(result.discovery.contract.name).toBe("studio-target-discovery");
+    expect(create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        metadata: { bloxbotHidden: true, purpose: "studio-target-programs" },
+      }),
+      { throwOnError: true },
+    );
+    expect(prompt).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionID: "private",
+        model: { providerID: "openai", modelID: "gpt" },
+        agent: "build",
+        format: expect.objectContaining({ type: "json_schema", retryCount: 2 }),
+      }),
+      { throwOnError: true },
+    );
+    expect(remove).toHaveBeenCalledWith({ sessionID: "private" }, { throwOnError: true });
+  });
+
+  it("always deletes the private session after generation fails", async () => {
+    const remove = vi.fn().mockResolvedValue({ data: true });
+    const client = {
+      session: {
+        create: vi.fn().mockResolvedValue({ data: { id: "private" } }),
+        prompt: vi.fn().mockRejectedValue(new Error("generation failed")),
+        delete: remove,
+      },
+    };
+
+    await expect(generateStudioTargetPrograms(client as never)).rejects.toThrow(
+      "generation failed",
+    );
+    expect(remove).toHaveBeenCalledOnce();
+  });
+});

--- a/src/types/desktop.ts
+++ b/src/types/desktop.ts
@@ -1,4 +1,5 @@
 import { Schema } from "effect";
+import type { StudioTargetDiscovery, StudioTargetSelection } from "./studioTarget";
 
 const MutableStrings = Schema.mutable(Schema.Array(Schema.String));
 
@@ -68,4 +69,6 @@ export interface DesktopApi {
   checkForUpdate(): Promise<UpdateInfo | null>;
   installUpdate(): Promise<void>;
   relaunch(): Promise<void>;
+  discoverStudioTargets(): Promise<StudioTargetDiscovery>;
+  selectStudioTarget(targetKey: string): Promise<StudioTargetSelection>;
 }

--- a/src/types/desktop.ts
+++ b/src/types/desktop.ts
@@ -1,5 +1,11 @@
 import { Schema } from "effect";
-import type { StudioTargetDiscovery, StudioTargetSelection } from "./studioTarget";
+import type { StudioTargetDiscovery } from "./studioTarget";
+import {
+  type StudioTargetProgramEnvelopes,
+  type StudioTargetPrograms,
+  StudioTargetProgramsSchema,
+  type StudioTargetSelection,
+} from "./studioTarget";
 
 const MutableStrings = Schema.mutable(Schema.Array(Schema.String));
 
@@ -14,6 +20,7 @@ export const AppConfigSchema = Schema.mutable(
     hiddenModels: MutableStrings,
     theme: ThemePreferenceSchema,
     detailedAnalytics: DetailedAnalyticsPreferenceSchema,
+    studioTargetPrograms: Schema.NullOr(StudioTargetProgramsSchema),
   }),
 );
 
@@ -24,6 +31,7 @@ export const DEFAULT_APP_CONFIG: AppConfig = {
   hiddenModels: [],
   theme: "system",
   detailedAnalytics: "unset",
+  studioTargetPrograms: null,
 };
 
 export const AppConfigPatchSchema = Schema.partial(AppConfigSchema);
@@ -69,6 +77,12 @@ export interface DesktopApi {
   checkForUpdate(): Promise<UpdateInfo | null>;
   installUpdate(): Promise<void>;
   relaunch(): Promise<void>;
-  discoverStudioTargets(): Promise<StudioTargetDiscovery>;
-  selectStudioTarget(targetKey: string): Promise<StudioTargetSelection>;
+  installStudioTargetPrograms(
+    envelopes: StudioTargetProgramEnvelopes,
+  ): Promise<StudioTargetPrograms>;
+  discoverStudioTargets(programs: StudioTargetPrograms): Promise<StudioTargetDiscovery>;
+  selectStudioTarget(
+    programs: StudioTargetPrograms,
+    targetKey: string,
+  ): Promise<StudioTargetSelection>;
 }

--- a/src/types/studioTarget.ts
+++ b/src/types/studioTarget.ts
@@ -1,0 +1,23 @@
+import { Schema } from "effect";
+
+export const StudioTargetSchema = Schema.Struct({
+  key: Schema.String.pipe(Schema.minLength(1), Schema.maxLength(512)),
+  label: Schema.String.pipe(Schema.minLength(1), Schema.maxLength(256)),
+  detail: Schema.NullOr(Schema.String.pipe(Schema.maxLength(512))),
+});
+
+export type StudioTarget = typeof StudioTargetSchema.Type;
+
+export const StudioTargetDiscoverySchema = Schema.Struct({
+  targets: Schema.Array(StudioTargetSchema),
+  selectedKey: Schema.NullOr(Schema.String.pipe(Schema.minLength(1), Schema.maxLength(512))),
+});
+
+export type StudioTargetDiscovery = typeof StudioTargetDiscoverySchema.Type;
+
+export const StudioTargetSelectionSchema = Schema.Struct({
+  selected: StudioTargetSchema,
+  verified: Schema.Boolean,
+});
+
+export type StudioTargetSelection = typeof StudioTargetSelectionSchema.Type;

--- a/src/types/studioTarget.ts
+++ b/src/types/studioTarget.ts
@@ -1,4 +1,5 @@
 import { Schema } from "effect";
+import { GeneratedProgramArtifactSchema, GeneratedProgramEnvelopeSchema } from "./generatedProgram";
 
 export const StudioTargetSchema = Schema.Struct({
   key: Schema.String.pipe(Schema.minLength(1), Schema.maxLength(512)),
@@ -21,3 +22,22 @@ export const StudioTargetSelectionSchema = Schema.Struct({
 });
 
 export type StudioTargetSelection = typeof StudioTargetSelectionSchema.Type;
+
+export const StudioTargetProgramSchema = Schema.Struct({
+  envelope: GeneratedProgramEnvelopeSchema,
+  artifact: GeneratedProgramArtifactSchema,
+});
+
+export const StudioTargetProgramsSchema = Schema.Struct({
+  discovery: StudioTargetProgramSchema,
+  selection: StudioTargetProgramSchema,
+});
+
+export type StudioTargetPrograms = typeof StudioTargetProgramsSchema.Type;
+
+export const StudioTargetProgramEnvelopesSchema = Schema.Struct({
+  discovery: GeneratedProgramEnvelopeSchema,
+  selection: GeneratedProgramEnvelopeSchema,
+});
+
+export type StudioTargetProgramEnvelopes = typeof StudioTargetProgramEnvelopesSchema.Type;


### PR DESCRIPTION
## Summary

- add a visible Roblox Studio target picker for chat and Explorer workflows
- generate strict TypeScript discovery/selection programs in a disposable private OpenCode session, then compile and invoke them through the shared Electron runtime and Studio MCP broker
- persist generated artifacts, replay normal list/select operations without model inference, and regenerate once only after drift or failure
- share the verified target through broker state and chat system context while keeping PostHog properties free of place/session identifiers

## States handled

- one Studio (automatic verified selection)
- multiple Studios and explicit selection
- no connected Studios
- stale/disconnected targets
- loading, discovery errors, and verification errors
- concurrent refresh/selection races

## Validation

- `NODE_OPTIONS=--no-experimental-webstorage pnpm test` — 157 app tests + 8 release tests passed
- `pnpm typecheck`
- `pnpm build`
- `pnpm lint` — passes with existing warnings only

## Dependency

Draft and intentionally based on `agent/generated-ts-runtime` / #68. That PR is based on the Studio MCP broker foundation #67.

## Screenshots

These are isolated Vite renders of the real component and shared styles, not live Electron captures.

### Single Studio / automatic target

![Single Studio automatically selected](https://github.com/user-attachments/assets/6f2e0b8b-e7e6-4768-8dc7-68630722b3f8)

### Multiple Studios / picker open

![Multiple connected Studios](https://github.com/user-attachments/assets/fb031fae-2d8c-4c1d-9623-4136c6568640)

### Verified selection

![Dungeon selected and verified](https://github.com/user-attachments/assets/ed9049d5-3039-4445-b51f-bb3c0a379eae)

### No connected Studios

![No Studio windows found](https://github.com/user-attachments/assets/f97ae357-5335-4ebf-8e0f-d011a90552de)

### Loading

![Loading connected Studios](https://github.com/user-attachments/assets/8032d041-c27c-4312-838f-f83d021fe1f5)

### Discovery error

![Studio discovery error](https://github.com/user-attachments/assets/a8dbe121-418d-444b-8755-21f5ef2b6cc0)
