### PR TITLE
Default-on telemetry with first-run notice, split toggles, and DO_NOT_TRACK support

### DIFF
--- a/TELEMETRY.md
+++ b/TELEMETRY.md
@@ -1,47 +1,108 @@
 # Telemetry
 
-BloxBot collects usage analytics **by default** in official builds. This
-intentionally exceeds OpenCode's opt-in posture as a product decision: richer
-default telemetry helps the team understand how the app is used and where it
-fails.
+BloxBot collects anonymous usage data and crash reports **by default** in
+official builds, following the same practice as VS Code and Zed. On first
+launch a notice tells the user what is collected and offers a one-click
+opt-out. The choice persists and can be changed at any time in
+Settings > Privacy.
 
-| Category | Default | Disable method |
+## Controls
+
+| Category | Default | Disable methods |
 |---|---|---|
-| **Usage analytics** (PostHog) | On in official builds (`VITE_POSTHOG_PROJECT_TOKEN`). Detailed analytics (provider, model, token counts) are on by default and can be turned off in Settings. | Omit the token at build time, or toggle off in Settings > Privacy. |
-| **Error reporting** (PostHog Error Tracking) | On in official builds (`VITE_POSTHOG_PROJECT_TOKEN`). Baseline telemetry, not affected by the detailed-analytics toggle. | Omit the token at build time. |
-| **Update checks** (electron-updater) | On in packaged builds (`app.isPackaged`). Independent of the PostHog token. | `BLOXBOT_DISABLE_AUTOUPDATE=1` |
+| **Usage analytics** (PostHog) | On | First-run notice, Settings > Privacy toggle, `DO_NOT_TRACK=1` |
+| **Crash reports** (PostHog Error Tracking) | On | First-run notice, Settings > Privacy toggle, `DO_NOT_TRACK=1` |
+| **Update checks** (electron-updater) | On in packaged builds | `BLOXBOT_DISABLE_AUTOUPDATE=1` |
 
-## What is collected
+## Two toggles
 
-### Event categories
+Usage analytics and crash reports are controlled independently. Each has its
+own toggle in Settings > Privacy. Turning off both prevents PostHog from
+initializing entirely.
 
-- **App lifecycle**: app opened (with version).
-- **Session lifecycle**: session created, message sent, session archived/unarchived/deleted.
-- **Model usage** (detailed): provider, model name, aggregate token counts per response.
-- **Feature usage**: explorer interactions, playtest runs, prompt templates, studio target connections.
-- **Update lifecycle**: update available, auto-installed (with version, patch flag).
-- **Preferences**: analytics preference changed (with enabled/disabled flag).
-- **Errors**: error type and phase (never the error message itself); unhandled exceptions via PostHog Error Tracking.
+## First-run notice
 
-### Property policy
+On the very first launch (`telemetryNoticeShown: false` in config), BloxBot
+shows a notice explaining what is collected. The user can accept (both toggles
+stay on, PostHog initializes) or turn off telemetry (both toggles go to off,
+PostHog never initializes). Either choice sets `telemetryNoticeShown: true` so
+the notice does not reappear.
+
+## DO_NOT_TRACK
+
+When the `DO_NOT_TRACK` environment variable is set to `1` or `true`, all
+telemetry is suppressed: PostHog is never initialized, both toggles are forced
+off, and the first-run notice is skipped. The toggles in Settings > Privacy
+appear disabled.
+
+## Event inventory
+
+| Event | Properties |
+|---|---|
+| `app_opened` | `app_version` |
+| `$pageview` | `$current_url`, `$host`, `$pathname`, `app_screen` |
+| `$exception` | (PostHog Error Tracking built-in) |
+| `session_created` | `outcome` |
+| `message_sent` | `outcome`, `has_attachments`, `attachment_count`, `token_count_bucket` |
+| `session_snoozed` | `outcome` |
+| `session_unsnoozed` | `outcome` |
+| `permanent_delete_requested` | (none beyond standard) |
+| `session_permanently_deleted` | `outcome` |
+| `snoozed_session_opened` | (none beyond standard) |
+| `model_usage` | `provider`, `model`, `tokens_total`, `tokens_input`, `tokens_output`, `tokens_cache_read`, `tokens_cache_write`, `tokens_reasoning` |
+| `update_available` | `update_version`, `current_version`, `is_patch` |
+| `update_auto_installed` | `update_version` |
+| `playtest_opened` | (none beyond standard) |
+| `playtest_closed` | (none beyond standard) |
+| `manual_entry_selected` | (none beyond standard) |
+| `playtest_started` | `outcome`, `mode` |
+| `playtest_stopped` | `reason` |
+| `playtest_error` | (none beyond standard) |
+| `sync_started` | `source` |
+| `sync_completed` | `source`, `duration_ms`, `node_count`, `root_count` |
+| `sync_error` | `error_type`, `phase` |
+| `explorer_class_selected` | `class_category`, `has_attributes` |
+| `explorer_node_toggled` | `class_category`, `model_mediated` |
+| `explorer_copy_path` | (none beyond standard) |
+| `prompt_template_selected` | `prompt_key` |
+| `prompt_template_cancelled` | (none beyond standard) |
+| `studio_target_selected` | (none beyond standard) |
+| `studio_target_selection_error` | `error_type`, `phase` |
+| `studio_connection_started` | `outcome` |
+| `studio_connection_check_started` | (none beyond standard) |
+| `studio_connection_check_completed` | `outcome` |
+| `studio_connection_completed` | `outcome` |
+| `studio_connection_skipped` | (none beyond standard) |
+| `studio_target_picker_opened` | (none beyond standard) |
+| `oauth_started` | `provider_id`, `outcome` |
+| `provider_api_key_set` | `provider_id`, `outcome` |
+| `provider_disconnected` | `provider_id`, `outcome` |
+
+All events carry standard super-properties: `analytics_schema_version`,
+`feature`, `app`, `app_version`, `app_platform`, `app_runtime`,
+`app_user_agent`, `analytics_detail_enabled`.
+
+## Property policy
 
 All properties are metadata only: counts, durations, booleans, versions, model
 identifiers, and outcome flags. **Never collected**: message content, prompts,
-file contents, file paths, code, or agent names.
+responses, file contents, file paths, code, or agent names.
 
-### Detailed-analytics opt-out
+## Anonymous-ID policy
 
-The in-app Settings > Privacy toggle controls whether detailed fields (provider
-name, model name, token counts) are included. When turned off, only coarse
-feature-usage events are sent. The preference persists across sessions. New
-installs default to on; users who previously opted out remain opted out.
+PostHog is initialized with `person_profiles: "identified_only"`.
+`posthog.identify()` is never called. Each device gets an anonymous distinct ID
+that cannot be linked to a person without explicit identification (which BloxBot
+does not perform).
+
+## Update checks
+
+Update checks are independent of PostHog. They only run in packaged
+(installed) builds (`app.isPackaged`) and are inactive during development.
+To disable them in a packaged build, set `BLOXBOT_DISABLE_AUTOUPDATE=1`.
 
 ## Self-built binaries
 
 When you build BloxBot from source without setting `VITE_POSTHOG_PROJECT_TOKEN`,
-PostHog is completely inert: the SDK is never initialised, and no analytics or
+PostHog is completely inert: the SDK is never initialized, and no analytics or
 error-tracking network requests are made.
-
-Update checks are independent of the PostHog token. They only run in packaged
-(installed) builds (`app.isPackaged`), so they are inactive during development.
-To disable them in a packaged build, set `BLOXBOT_DISABLE_AUTOUPDATE=1`.

--- a/TELEMETRY.md
+++ b/TELEMETRY.md
@@ -1,8 +1,6 @@
 # Telemetry
 
-BloxBot includes three categories of outbound communication. All three are
-inactive in self-built binaries because the required build-time token is
-absent.
+BloxBot includes three categories of outbound communication.
 
 | Category | What is sent | Default | How to disable |
 |---|---|---|---|
@@ -14,5 +12,8 @@ absent.
 
 When you build BloxBot from source without setting `VITE_POSTHOG_PROJECT_TOKEN`,
 PostHog is completely inert: the SDK is never initialised, and no analytics or
-error-tracking network requests are made. Update checks still run in packaged
-builds unless `BLOXBOT_DISABLE_AUTOUPDATE` is set.
+error-tracking network requests are made.
+
+Update checks are independent of the PostHog token. They only run in packaged
+(installed) builds (`app.isPackaged`), so they are inactive during development.
+To disable them in a packaged build, set `BLOXBOT_DISABLE_AUTOUPDATE=1`.

--- a/TELEMETRY.md
+++ b/TELEMETRY.md
@@ -1,12 +1,40 @@
 # Telemetry
 
-BloxBot includes three categories of outbound communication.
+BloxBot collects usage analytics **by default** in official builds. This
+intentionally exceeds OpenCode's opt-in posture as a product decision: richer
+default telemetry helps the team understand how the app is used and where it
+fails.
 
-| Category | What is sent | Default | How to disable |
-|---|---|---|---|
-| **Usage analytics** (PostHog) | Anonymous product-usage events (screens viewed, features used, error types). Detailed model analytics (provider, model name, token counts) are sent only after the user opts in via Settings. | Active in official builds when `VITE_POSTHOG_PROJECT_TOKEN` is set. | Omit the token at build time, or remove the PostHog init block in `src/main.tsx`. |
-| **Error reporting** (PostHog Error Tracking) | Unhandled exceptions with stack traces. Sent to the same PostHog project (`eu.i.posthog.com`) as usage analytics. No additional vendor or token is required. Error reporting is baseline telemetry and is not gated behind the detailed-analytics opt-in. | Active in official builds when `VITE_POSTHOG_PROJECT_TOKEN` is set. | Omit the token at build time. |
-| **Update checks** (electron-updater) | An HTTPS request to the GitHub Releases API to check whether a newer version is available. No usage data is sent. | Active in packaged (installed) builds. | Set the environment variable `BLOXBOT_DISABLE_AUTOUPDATE=1` before launching the app. |
+| Category | Default | Disable method |
+|---|---|---|
+| **Usage analytics** (PostHog) | On in official builds (`VITE_POSTHOG_PROJECT_TOKEN`). Detailed analytics (provider, model, token counts) are on by default and can be turned off in Settings. | Omit the token at build time, or toggle off in Settings > Privacy. |
+| **Error reporting** (PostHog Error Tracking) | On in official builds (`VITE_POSTHOG_PROJECT_TOKEN`). Baseline telemetry, not affected by the detailed-analytics toggle. | Omit the token at build time. |
+| **Update checks** (electron-updater) | On in packaged builds (`app.isPackaged`). Independent of the PostHog token. | `BLOXBOT_DISABLE_AUTOUPDATE=1` |
+
+## What is collected
+
+### Event categories
+
+- **App lifecycle**: app opened (with version).
+- **Session lifecycle**: session created, message sent, session archived/unarchived/deleted.
+- **Model usage** (detailed): provider, model name, aggregate token counts per response.
+- **Feature usage**: explorer interactions, playtest runs, prompt templates, studio target connections.
+- **Update lifecycle**: update available, auto-installed (with version, patch flag).
+- **Preferences**: analytics preference changed (with enabled/disabled flag).
+- **Errors**: error type and phase (never the error message itself); unhandled exceptions via PostHog Error Tracking.
+
+### Property policy
+
+All properties are metadata only: counts, durations, booleans, versions, model
+identifiers, and outcome flags. **Never collected**: message content, prompts,
+file contents, file paths, code, or agent names.
+
+### Detailed-analytics opt-out
+
+The in-app Settings > Privacy toggle controls whether detailed fields (provider
+name, model name, token counts) are included. When turned off, only coarse
+feature-usage events are sent. The preference persists across sessions. New
+installs default to on; users who previously opted out remain opted out.
 
 ## Self-built binaries
 

--- a/TELEMETRY.md
+++ b/TELEMETRY.md
@@ -1,0 +1,18 @@
+# Telemetry
+
+BloxBot includes three categories of outbound communication. All three are
+inactive in self-built binaries because the required build-time token is
+absent.
+
+| Category | What is sent | Default | How to disable |
+|---|---|---|---|
+| **Usage analytics** (PostHog) | Anonymous product-usage events (screens viewed, features used, error types). Detailed model analytics (provider, model name, token counts) are sent only after the user opts in via Settings. | Active in official builds when `VITE_POSTHOG_PROJECT_TOKEN` is set. | Omit the token at build time, or remove the PostHog init block in `src/main.tsx`. |
+| **Error reporting** (PostHog Error Tracking) | Unhandled exceptions with stack traces. Sent to the same PostHog project (`eu.i.posthog.com`) as usage analytics. No additional vendor or token is required. Error reporting is baseline telemetry and is not gated behind the detailed-analytics opt-in. | Active in official builds when `VITE_POSTHOG_PROJECT_TOKEN` is set. | Omit the token at build time. |
+| **Update checks** (electron-updater) | An HTTPS request to the GitHub Releases API to check whether a newer version is available. No usage data is sent. | Active in packaged (installed) builds. | Set the environment variable `BLOXBOT_DISABLE_AUTOUPDATE=1` before launching the app. |
+
+## Self-built binaries
+
+When you build BloxBot from source without setting `VITE_POSTHOG_PROJECT_TOKEN`,
+PostHog is completely inert: the SDK is never initialised, and no analytics or
+error-tracking network requests are made. Update checks still run in packaged
+builds unless `BLOXBOT_DISABLE_AUTOUPDATE` is set.

--- a/electron/channels.ts
+++ b/electron/channels.ts
@@ -3,6 +3,7 @@ export const channels = {
   checkForUpdate: "app:check-for-update",
   getOpenCodeInfo: "opencode:get-info",
   openCodeStartupProgress: "opencode:startup-progress",
+  getDoNotTrack: "app:get-do-not-track",
   getVersion: "app:get-version",
   installUpdate: "app:install-update",
   invokeExplorerProgram: "explorer:invoke-program",

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -162,6 +162,13 @@ function patchConfig(input: unknown) {
   }).pipe(configMutex.withPermits(1));
 }
 
+const AUTOUPDATE_DISABLE_VALUES = new Set(["1", "true", "yes"]);
+
+function isAutoUpdateDisabled(): boolean {
+  const value = process.env.BLOXBOT_DISABLE_AUTOUPDATE?.trim().toLowerCase() ?? "";
+  return AUTOUPDATE_DISABLE_VALUES.has(value);
+}
+
 const runMain = <A, E>(effect: Effect.Effect<A, E>) => Effect.runPromise(effect);
 
 const registerIpcHandlers = Effect.sync(() => {
@@ -244,6 +251,7 @@ const registerIpcHandlers = Effect.sync(() => {
     runMain(
       Effect.gen(function* () {
         if (!app.isPackaged) return null;
+        if (isAutoUpdateDisabled()) return null;
         const result = yield* Effect.tryPromise({
           try: () => autoUpdater.checkForUpdates(),
           catch: (cause) =>
@@ -262,6 +270,11 @@ const registerIpcHandlers = Effect.sync(() => {
         if (!app.isPackaged) {
           return yield* Effect.fail(
             new DesktopMainError({ message: "Updates are only available in packaged builds" }),
+          );
+        }
+        if (isAutoUpdateDisabled()) {
+          return yield* Effect.fail(
+            new DesktopMainError({ message: "Auto-update is disabled via BLOXBOT_DISABLE_AUTOUPDATE" }),
           );
         }
         yield* Effect.tryPromise({

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -186,6 +186,14 @@ const registerIpcHandlers = Effect.sync(() => {
       OpenCode.pipe(Effect.flatMap((service) => service.info)),
     ),
   );
+  ipcMain.handle(channels.getDoNotTrack, () =>
+    runMain(
+      Effect.sync(() => {
+        const value = process.env.DO_NOT_TRACK?.trim().toLowerCase() ?? "";
+        return value === "1" || value === "true";
+      }),
+    ),
+  );
   ipcMain.handle(channels.getVersion, () => runMain(Effect.sync(() => app.getVersion())));
   ipcMain.handle(channels.loadConfig, () => runMain(loadConfig));
   ipcMain.handle(channels.patchConfig, (_event, patch: unknown) => runMain(patchConfig(patch)));

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -13,6 +13,7 @@ const api: DesktopApi = {
     ipcRenderer.on(channels.openCodeStartupProgress, handleProgress);
     return () => ipcRenderer.removeListener(channels.openCodeStartupProgress, handleProgress);
   },
+  getDoNotTrack: () => ipcRenderer.invoke(channels.getDoNotTrack),
   getVersion: () => ipcRenderer.invoke(channels.getVersion),
   openUrl: (url) => ipcRenderer.invoke(channels.openUrl, url),
   loadConfig: () => ipcRenderer.invoke(channels.loadConfig),

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,6 +11,7 @@ import { OpenCodeClientProvider } from "@/providers/OpenCodeClientProvider";
 import { PreferencesProvider } from "@/providers/PreferencesProvider";
 import { QueryProvider } from "@/providers/QueryProvider";
 import { StudioTargetProvider } from "@/providers/StudioTargetProvider";
+import { TelemetryProvider } from "@/providers/TelemetryProvider";
 
 function AppInner() {
   useUpdater();
@@ -31,19 +32,21 @@ function App() {
 
   return (
     <QueryProvider>
-      <ThemeProvider>
-        <OpenCodeClientProvider activeSessionIdRef={activeSessionIdRef}>
-          <ActiveSessionProvider activeSessionIdRef={activeSessionIdRef}>
-            <PreferencesProvider>
-              <StudioTargetProvider>
-                <ExplorerReferenceProvider>
-                  <AppInner />
-                </ExplorerReferenceProvider>
-              </StudioTargetProvider>
-            </PreferencesProvider>
-          </ActiveSessionProvider>
-        </OpenCodeClientProvider>
-      </ThemeProvider>
+      <TelemetryProvider>
+        <ThemeProvider>
+          <OpenCodeClientProvider activeSessionIdRef={activeSessionIdRef}>
+            <ActiveSessionProvider activeSessionIdRef={activeSessionIdRef}>
+              <PreferencesProvider>
+                <StudioTargetProvider>
+                  <ExplorerReferenceProvider>
+                    <AppInner />
+                  </ExplorerReferenceProvider>
+                </StudioTargetProvider>
+              </PreferencesProvider>
+            </ActiveSessionProvider>
+          </OpenCodeClientProvider>
+        </ThemeProvider>
+      </TelemetryProvider>
     </QueryProvider>
   );
 }

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -1,3 +1,4 @@
+import posthog from "posthog-js/dist/module.full.no-external.js";
 import { Component, type ErrorInfo, type ReactNode } from "react";
 
 interface Props {
@@ -21,6 +22,7 @@ class ErrorBoundary extends Component<Props, State> {
 
   componentDidCatch(error: Error, info: ErrorInfo) {
     console.error("ErrorBoundary caught:", error, info.componentStack);
+    posthog.captureException(error);
   }
 
   handleRetry = () => {

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -1,5 +1,6 @@
 import posthog from "posthog-js/dist/module.full.no-external.js";
 import { Component, type ErrorInfo, type ReactNode } from "react";
+import { isCrashReportsEnabled } from "@/lib/analytics";
 
 interface Props {
   children: ReactNode;
@@ -22,7 +23,9 @@ class ErrorBoundary extends Component<Props, State> {
 
   componentDidCatch(error: Error, info: ErrorInfo) {
     console.error("ErrorBoundary caught:", error, info.componentStack);
-    posthog.captureException(error);
+    if (isCrashReportsEnabled()) {
+      posthog.captureException(error);
+    }
   }
 
   handleRetry = () => {

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -11,6 +11,7 @@ import {
 } from "@/hooks/useProviders";
 import { desktop } from "@/lib/desktop";
 import { usePreferences } from "@/providers/PreferencesProvider";
+import { useTelemetry } from "@/providers/TelemetryProvider";
 import type { ModelInfo, ProviderInfo } from "@/types";
 import type { UpdateInfo } from "@/types/desktop";
 
@@ -1022,43 +1023,82 @@ function ThemePreview({ swatch }: { swatch: Theme }) {
 // Privacy Tab
 // ═══════════════════════════════════════════════════════════════════════
 
+function PrivacyToggle({
+  label,
+  description,
+  checked,
+  disabled,
+  onChange,
+}: {
+  label: string;
+  description: string;
+  checked: boolean;
+  disabled: boolean;
+  onChange: (value: boolean) => void;
+}) {
+  return (
+    <div className="flex items-start justify-between gap-4">
+      <div>
+        <div className="text-sm font-medium">{label}</div>
+        <p className="mt-1 text-[11px] leading-relaxed text-muted-foreground">{description}</p>
+      </div>
+      <button
+        type="button"
+        role="switch"
+        aria-checked={checked}
+        aria-label={label}
+        disabled={disabled}
+        onClick={() => onChange(!checked)}
+        className={`relative mt-0.5 inline-flex h-5 w-9 shrink-0 items-center rounded-full transition-colors ${
+          checked ? "bg-foreground" : "bg-border"
+        } ${disabled ? "cursor-not-allowed opacity-50" : ""}`}
+      >
+        <span
+          className={`inline-block h-3.5 w-3.5 rounded-full bg-background transition-transform ${
+            checked ? "translate-x-4" : "translate-x-0.5"
+          }`}
+        />
+      </button>
+    </div>
+  );
+}
+
 function PrivacyTab() {
-  const { detailedAnalyticsEnabled, setDetailedAnalyticsEnabled } = usePreferences();
+  const { usageAnalytics, crashReports, doNotTrack, setUsageAnalytics, setCrashReports } =
+    useTelemetry();
 
   return (
     <div className="mx-auto w-full max-w-md px-6 py-8">
       <h4 className="font-serif text-lg italic text-foreground">Privacy</h4>
       <p className="mt-1 text-xs text-muted-foreground">
-        BloxBot collects usage analytics by default in official builds, including provider and model
-        names plus aggregate token counts. Prompts, responses, file contents, and agent names are
-        never collected.
+        BloxBot collects anonymous usage data and crash reports to improve the app. No prompts,
+        code, or file contents are ever collected.
       </p>
 
-      <div className="mt-6 rounded-lg border bg-card p-3.5">
-        <div className="flex items-start justify-between gap-4">
-          <div>
-            <div className="text-sm font-medium">Detailed usage analytics</div>
-            <p className="mt-1 text-[11px] leading-relaxed text-muted-foreground">
-              Shares provider and model names plus aggregate token counts. This is on by default.
-              Turn it off to limit collection to coarse feature-usage events only.
-            </p>
-          </div>
-          <button
-            type="button"
-            role="switch"
-            aria-checked={detailedAnalyticsEnabled}
-            aria-label="Detailed usage analytics"
-            onClick={() => setDetailedAnalyticsEnabled(!detailedAnalyticsEnabled)}
-            className={`relative mt-0.5 inline-flex h-5 w-9 shrink-0 items-center rounded-full transition-colors ${
-              detailedAnalyticsEnabled ? "bg-foreground" : "bg-border"
-            }`}
-          >
-            <span
-              className={`inline-block h-3.5 w-3.5 rounded-full bg-background transition-transform ${
-                detailedAnalyticsEnabled ? "translate-x-4" : "translate-x-0.5"
-              }`}
-            />
-          </button>
+      {doNotTrack && (
+        <p className="mt-3 text-xs font-medium text-muted-foreground">
+          Telemetry is disabled via the DO_NOT_TRACK environment variable.
+        </p>
+      )}
+
+      <div className="mt-6 space-y-4">
+        <div className="rounded-lg border bg-card p-3.5">
+          <PrivacyToggle
+            label="Usage analytics"
+            description="Shares provider and model names plus aggregate token counts. This is on by default."
+            checked={usageAnalytics}
+            disabled={doNotTrack}
+            onChange={setUsageAnalytics}
+          />
+        </div>
+        <div className="rounded-lg border bg-card p-3.5">
+          <PrivacyToggle
+            label="Crash reports"
+            description="Sends unhandled exceptions to help diagnose bugs. This is on by default."
+            checked={crashReports}
+            disabled={doNotTrack}
+            onChange={setCrashReports}
+          />
         </div>
       </div>
     </div>

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -1029,25 +1029,25 @@ function PrivacyTab() {
     <div className="mx-auto w-full max-w-md px-6 py-8">
       <h4 className="font-serif text-lg italic text-foreground">Privacy</h4>
       <p className="mt-1 text-xs text-muted-foreground">
-        BloxBot uses PostHog's standard product analytics with persistent device and session
-        identifiers plus a person profile. Feature flags and other PostHog products use the same
-        profile. Detailed usage is always your choice.
+        BloxBot collects usage analytics by default in official builds, including provider and model
+        names plus aggregate token counts. Prompts, responses, file contents, and agent names are
+        never collected.
       </p>
 
       <div className="mt-6 rounded-lg border bg-card p-3.5">
         <div className="flex items-start justify-between gap-4">
           <div>
-            <div className="text-sm font-medium">Share detailed usage analytics</div>
+            <div className="text-sm font-medium">Detailed usage analytics</div>
             <p className="mt-1 text-[11px] leading-relaxed text-muted-foreground">
-              Additionally shares provider and model names plus aggregate token counts. This switch
-              controls those detailed fields; standard PostHog collection remains enabled.
+              Shares provider and model names plus aggregate token counts. This is on by default.
+              Turn it off to limit collection to coarse feature-usage events only.
             </p>
           </div>
           <button
             type="button"
             role="switch"
             aria-checked={detailedAnalyticsEnabled}
-            aria-label="Share detailed usage analytics"
+            aria-label="Detailed usage analytics"
             onClick={() => setDetailedAnalyticsEnabled(!detailedAnalyticsEnabled)}
             className={`relative mt-0.5 inline-flex h-5 w-9 shrink-0 items-center rounded-full transition-colors ${
               detailedAnalyticsEnabled ? "bg-foreground" : "bg-border"

--- a/src/hooks/useUpdater.ts
+++ b/src/hooks/useUpdater.ts
@@ -1,7 +1,9 @@
+import posthog from "posthog-js/dist/module.full.no-external.js";
 import { createElement, useEffect } from "react";
 import { toast } from "sonner";
 
 import { UpdateReleaseNotes } from "@/components/UpdateReleaseNotes";
+import { analyticsProperties } from "@/lib/analytics";
 import { desktop } from "@/lib/desktop";
 
 // ── Semver helpers ──────────────────────────────────────────────────────
@@ -52,10 +54,23 @@ export function useUpdater(): void {
         const next = parseSemver(update.version);
         const patch = current && next ? isPatchOnly(current, next) : false;
 
+        posthog.capture(
+          "update_available",
+          analyticsProperties("updater", {
+            update_version: update.version,
+            current_version: currentVersion,
+            is_patch: patch,
+          }),
+        );
+
         if (patch) {
           // Patch update — auto-install silently.
           console.debug(
             `[updater] Auto-installing patch update ${currentVersion} → ${update.version}`,
+          );
+          posthog.capture(
+            "update_auto_installed",
+            analyticsProperties("updater", { update_version: update.version }),
           );
           await desktop.installUpdate();
         } else {

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -3,13 +3,26 @@ import posthog, { type PostHogInterface, type Properties } from "posthog-js";
 export const POSTHOG_PROJECT_TOKEN = import.meta.env.VITE_POSTHOG_PROJECT_TOKEN?.trim() ?? "";
 export const POSTHOG_API_HOST = "https://eu.i.posthog.com";
 
-let detailedAnalyticsEnabled = true;
+let usageAnalyticsEnabled = true;
+let crashReportsEnabled = true;
 
 export const ANALYTICS_SCHEMA_VERSION = 1;
 
-export function setDetailedAnalyticsEnabled(enabled: boolean): void {
-  detailedAnalyticsEnabled = enabled;
+export function setUsageAnalyticsEnabled(enabled: boolean): void {
+  usageAnalyticsEnabled = enabled;
   posthog.register({ analytics_detail_enabled: enabled });
+}
+
+export function setCrashReportsEnabled(enabled: boolean): void {
+  crashReportsEnabled = enabled;
+}
+
+export function isUsageAnalyticsEnabled(): boolean {
+  return usageAnalyticsEnabled;
+}
+
+export function isCrashReportsEnabled(): boolean {
+  return crashReportsEnabled;
 }
 
 export function analyticsProperties(feature: string, properties: Properties = {}): Properties {
@@ -35,7 +48,7 @@ export function errorAnalyticsProperties(
 }
 
 export function detailedAnalyticsProperties(properties: Properties): Properties {
-  return detailedAnalyticsEnabled ? properties : {};
+  return usageAnalyticsEnabled ? properties : {};
 }
 
 export function captureDetailedAnalytics(
@@ -43,7 +56,7 @@ export function captureDetailedAnalytics(
   event: string,
   properties: Properties,
 ): void {
-  if (detailedAnalyticsEnabled) {
+  if (usageAnalyticsEnabled) {
     posthog.capture(event, analyticsProperties("model", properties));
   }
 }

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -3,7 +3,7 @@ import posthog, { type PostHogInterface, type Properties } from "posthog-js";
 export const POSTHOG_PROJECT_TOKEN = import.meta.env.VITE_POSTHOG_PROJECT_TOKEN?.trim() ?? "";
 export const POSTHOG_API_HOST = "https://eu.i.posthog.com";
 
-let detailedAnalyticsEnabled = false;
+let detailedAnalyticsEnabled = true;
 
 export const ANALYTICS_SCHEMA_VERSION = 1;
 

--- a/src/lib/desktop.ts
+++ b/src/lib/desktop.ts
@@ -43,6 +43,7 @@ interface DesktopEffects {
     ? (input: Input) => Effect.Effect<Output, DesktopError>
     : never;
   readonly getOpenCodeInfo: Effect.Effect<OpenCodeInfo, DesktopError>;
+  readonly getDoNotTrack: Effect.Effect<boolean, DesktopError>;
   readonly getVersion: Effect.Effect<string, DesktopError>;
   readonly openUrl: (url: string) => Effect.Effect<void, DesktopError>;
   readonly loadConfig: Effect.Effect<AppConfig, DesktopError>;
@@ -86,6 +87,7 @@ const loadBrowserConfig = Effect.gen(function* () {
 const browserEffects: DesktopEffects = {
   compileExplorerProgram: () =>
     Effect.fail(new DesktopError({ message: "Explorer requires the desktop app." })),
+  getDoNotTrack: Effect.succeed(false),
   getOpenCodeInfo: Effect.fail(
     new DesktopError({
       message: "The desktop service is unavailable. Start BloxBot with pnpm dev.",
@@ -157,6 +159,9 @@ function makeBridgeEffects(api: DesktopApi): DesktopEffects {
       invoke("Failed to compile Explorer program", () => api.compileExplorerProgram(program)).pipe(
         decodeBridgeValue("Explorer program artifact is invalid", GeneratedProgramArtifactSchema),
       ),
+    getDoNotTrack: invoke("Failed to read DO_NOT_TRACK", () => api.getDoNotTrack()).pipe(
+      decodeBridgeValue("DO_NOT_TRACK value is invalid", Schema.Boolean),
+    ),
     getOpenCodeInfo: invoke("Failed to get OpenCode connection details", () =>
       api.getOpenCodeInfo(),
     ).pipe(decodeBridgeValue("OpenCode connection details are invalid", OpenCodeInfoSchema)),
@@ -202,6 +207,7 @@ const runPromise = <A>(effect: Effect.Effect<A, DesktopError>): Promise<A> =>
 /** Promise-only adapter consumed by React and exposed by the Electron bridge contract. */
 export const desktop: DesktopApi = {
   compileExplorerProgram: (program) => runPromise(desktopEffects.compileExplorerProgram(program)),
+  getDoNotTrack: () => runPromise(desktopEffects.getDoNotTrack),
   getOpenCodeInfo: () => runPromise(desktopEffects.getOpenCodeInfo),
   onOpenCodeStartupProgress: (listener: StartupProgressListener) =>
     window.bloxbot?.onOpenCodeStartupProgress(listener) ?? (() => {}),

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -26,7 +26,7 @@ if (import.meta.env.PROD && POSTHOG_PROJECT_TOKEN) {
     $pathname: "/loading",
     app: "bloxbot",
     analytics_schema_version: ANALYTICS_SCHEMA_VERSION,
-    analytics_detail_enabled: false,
+    analytics_detail_enabled: true,
     app_platform: navigator.platform,
     app_runtime: window.bloxbot ? "electron" : "browser",
     app_screen: "loading",

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -16,6 +16,7 @@ if (import.meta.env.PROD && POSTHOG_PROJECT_TOKEN) {
     api_host: POSTHOG_API_HOST,
     person_profiles: "always",
     capture_pageview: false,
+    capture_exceptions: true,
     // BloxBot intentionally contains "bot", which matches PostHog's bot heuristic.
     opt_out_useragent_filter: true,
   });

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,45 +1,7 @@
-import posthog from "posthog-js/dist/module.full.no-external.js";
 import React from "react";
 import ReactDOM from "react-dom/client";
 import App from "./App";
 import "./index.css";
-import {
-  ANALYTICS_SCHEMA_VERSION,
-  analyticsProperties,
-  POSTHOG_API_HOST,
-  POSTHOG_PROJECT_TOKEN,
-} from "./lib/analytics";
-import { desktop } from "./lib/desktop";
-
-if (import.meta.env.PROD && POSTHOG_PROJECT_TOKEN) {
-  posthog.init(POSTHOG_PROJECT_TOKEN, {
-    api_host: POSTHOG_API_HOST,
-    person_profiles: "always",
-    capture_pageview: false,
-    capture_exceptions: true,
-    // BloxBot intentionally contains "bot", which matches PostHog's bot heuristic.
-    opt_out_useragent_filter: true,
-  });
-  posthog.register({
-    $current_url: "bloxbot://app/loading",
-    $host: "app",
-    $pathname: "/loading",
-    app: "bloxbot",
-    analytics_schema_version: ANALYTICS_SCHEMA_VERSION,
-    analytics_detail_enabled: true,
-    app_platform: navigator.platform,
-    app_runtime: window.bloxbot ? "electron" : "browser",
-    app_screen: "loading",
-    app_user_agent: navigator.userAgent,
-  });
-  void desktop.getVersion().then(
-    (version) => {
-      posthog.register({ app_version: version });
-      posthog.capture("app_opened", analyticsProperties("app", { app_version: version }));
-    },
-    () => posthog.capture("app_opened", analyticsProperties("app", { app_version: "unknown" })),
-  );
-}
 
 ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
   <React.StrictMode>

--- a/src/providers/PreferencesProvider.tsx
+++ b/src/providers/PreferencesProvider.tsx
@@ -1,5 +1,4 @@
 import { useQuery } from "@tanstack/react-query";
-import posthog from "posthog-js/dist/module.full.no-external.js";
 import {
   createContext,
   type ReactNode,
@@ -7,15 +6,10 @@ import {
   useContext,
   useEffect,
   useMemo,
-  useRef,
   useState,
 } from "react";
 import { useAgents } from "@/hooks/useAgents";
 import { useConnectedProviders } from "@/hooks/useProviders";
-import {
-  analyticsProperties,
-  setDetailedAnalyticsEnabled as setDetailedAnalyticsCollection,
-} from "@/lib/analytics";
 import { type AppConfig, loadConfig, patchConfig } from "@/lib/config";
 import { qk } from "@/lib/queryKeys";
 import { splitModelKey } from "@/lib/splitModelKey";
@@ -25,12 +19,10 @@ interface PreferencesContextValue {
   selectedAgent: string | null;
   selectedVariant: string | null;
   hiddenModels: Set<string>;
-  detailedAnalyticsEnabled: boolean;
   setSelectedModel: (modelID: string) => void;
   setSelectedAgent: (name: string) => void;
   setSelectedVariant: (variant: string | null) => void;
   toggleModelVisibility: (modelKey: string) => void;
-  setDetailedAnalyticsEnabled: (enabled: boolean) => void;
 }
 
 export const PreferencesContext = createContext<PreferencesContextValue | undefined>(undefined);
@@ -51,39 +43,13 @@ export function PreferencesProvider({ children }: { children: ReactNode }) {
   const [selectedAgent, setSelectedAgentState] = useState<string | null>(null);
   const [selectedVariant, setSelectedVariantState] = useState<string | null>(null);
   const [hiddenModels, setHiddenModels] = useState<Set<string>>(new Set());
-  const [detailedAnalyticsEnabled, setDetailedAnalyticsEnabledState] = useState(true);
-  const detailedAnalyticsEnabledRef = useRef(true);
 
   const connectedProviders = useConnectedProviders();
 
-  const setDetailedAnalyticsEnabled = useCallback((enabled: boolean) => {
-    const previous = detailedAnalyticsEnabledRef.current;
-    // Capture the preference change before toggling (ensures the opt-out
-    // event itself is still recorded with detailed analytics active).
-    posthog.capture(
-      "analytics_preference_changed",
-      analyticsProperties("app", { detailed_analytics_enabled: enabled }),
-    );
-    detailedAnalyticsEnabledRef.current = enabled;
-    setDetailedAnalyticsEnabledState(enabled);
-    setDetailedAnalyticsCollection(enabled);
-    patchConfig({ detailedAnalytics: enabled ? "enabled" : "disabled" }).catch(() => {
-      detailedAnalyticsEnabledRef.current = previous;
-      setDetailedAnalyticsEnabledState(previous);
-      setDetailedAnalyticsCollection(previous);
-    });
-  }, []);
-
-  // Initialize from config data when it arrives. Detailed analytics are on by
-  // default ("unset" and "enabled" both resolve to true); only an explicit
-  // "disabled" preference turns them off.
+  // Initialize from config data when it arrives.
   useEffect(() => {
     if (!configData) return;
     setHiddenModels(new Set(configData.hiddenModels));
-    const detailedEnabled = configData.detailedAnalytics !== "disabled";
-    detailedAnalyticsEnabledRef.current = detailedEnabled;
-    setDetailedAnalyticsEnabledState(detailedEnabled);
-    setDetailedAnalyticsCollection(detailedEnabled);
   }, [configData]);
 
   // Restore a valid last-used model and clear selections whose provider disconnected.
@@ -144,24 +110,20 @@ export function PreferencesProvider({ children }: { children: ReactNode }) {
       selectedAgent,
       selectedVariant,
       hiddenModels,
-      detailedAnalyticsEnabled,
       setSelectedModel,
       setSelectedAgent,
       setSelectedVariant,
       toggleModelVisibility,
-      setDetailedAnalyticsEnabled,
     }),
     [
       selectedModel,
       selectedAgent,
       selectedVariant,
       hiddenModels,
-      detailedAnalyticsEnabled,
       setSelectedModel,
       setSelectedAgent,
       setSelectedVariant,
       toggleModelVisibility,
-      setDetailedAnalyticsEnabled,
     ],
   );
 

--- a/src/providers/PreferencesProvider.tsx
+++ b/src/providers/PreferencesProvider.tsx
@@ -1,4 +1,5 @@
 import { useQuery } from "@tanstack/react-query";
+import posthog from "posthog-js/dist/module.full.no-external.js";
 import {
   createContext,
   type ReactNode,
@@ -9,10 +10,12 @@ import {
   useRef,
   useState,
 } from "react";
-import { toast } from "sonner";
 import { useAgents } from "@/hooks/useAgents";
 import { useConnectedProviders } from "@/hooks/useProviders";
-import { setDetailedAnalyticsEnabled as setDetailedAnalyticsCollection } from "@/lib/analytics";
+import {
+  analyticsProperties,
+  setDetailedAnalyticsEnabled as setDetailedAnalyticsCollection,
+} from "@/lib/analytics";
 import { type AppConfig, loadConfig, patchConfig } from "@/lib/config";
 import { qk } from "@/lib/queryKeys";
 import { splitModelKey } from "@/lib/splitModelKey";
@@ -48,13 +51,19 @@ export function PreferencesProvider({ children }: { children: ReactNode }) {
   const [selectedAgent, setSelectedAgentState] = useState<string | null>(null);
   const [selectedVariant, setSelectedVariantState] = useState<string | null>(null);
   const [hiddenModels, setHiddenModels] = useState<Set<string>>(new Set());
-  const [detailedAnalyticsEnabled, setDetailedAnalyticsEnabledState] = useState(false);
-  const detailedAnalyticsEnabledRef = useRef(false);
+  const [detailedAnalyticsEnabled, setDetailedAnalyticsEnabledState] = useState(true);
+  const detailedAnalyticsEnabledRef = useRef(true);
 
   const connectedProviders = useConnectedProviders();
 
   const setDetailedAnalyticsEnabled = useCallback((enabled: boolean) => {
     const previous = detailedAnalyticsEnabledRef.current;
+    // Capture the preference change before toggling (ensures the opt-out
+    // event itself is still recorded with detailed analytics active).
+    posthog.capture(
+      "analytics_preference_changed",
+      analyticsProperties("app", { detailed_analytics_enabled: enabled }),
+    );
     detailedAnalyticsEnabledRef.current = enabled;
     setDetailedAnalyticsEnabledState(enabled);
     setDetailedAnalyticsCollection(enabled);
@@ -65,33 +74,17 @@ export function PreferencesProvider({ children }: { children: ReactNode }) {
     });
   }, []);
 
-  // Initialize from config data when it arrives and prompt once when no choice exists.
+  // Initialize from config data when it arrives. Detailed analytics are on by
+  // default ("unset" and "enabled" both resolve to true); only an explicit
+  // "disabled" preference turns them off.
   useEffect(() => {
     if (!configData) return;
     setHiddenModels(new Set(configData.hiddenModels));
-    const detailedEnabled = configData.detailedAnalytics === "enabled";
+    const detailedEnabled = configData.detailedAnalytics !== "disabled";
     detailedAnalyticsEnabledRef.current = detailedEnabled;
     setDetailedAnalyticsEnabledState(detailedEnabled);
     setDetailedAnalyticsCollection(detailedEnabled);
-
-    if (configData.detailedAnalytics === "unset") {
-      toast("Help improve BloxBot", {
-        id: "detailed-analytics-consent",
-        className: "analytics-consent-toast",
-        description:
-          "Share provider, model, and aggregate token usage. Prompts, responses, files, and agent names are never collected.",
-        duration: Number.POSITIVE_INFINITY,
-        action: {
-          label: "Share usage",
-          onClick: () => setDetailedAnalyticsEnabled(true),
-        },
-        cancel: {
-          label: "Not now",
-          onClick: () => setDetailedAnalyticsEnabled(false),
-        },
-      });
-    }
-  }, [configData, setDetailedAnalyticsEnabled]);
+  }, [configData]);
 
   // Restore a valid last-used model and clear selections whose provider disconnected.
   useEffect(() => {

--- a/src/providers/TelemetryProvider.tsx
+++ b/src/providers/TelemetryProvider.tsx
@@ -1,0 +1,218 @@
+import { useQuery } from "@tanstack/react-query";
+import posthog from "posthog-js/dist/module.full.no-external.js";
+import {
+  createContext,
+  type ReactNode,
+  useCallback,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
+import {
+  ANALYTICS_SCHEMA_VERSION,
+  analyticsProperties,
+  isCrashReportsEnabled,
+  isUsageAnalyticsEnabled,
+  POSTHOG_API_HOST,
+  POSTHOG_PROJECT_TOKEN,
+  setCrashReportsEnabled,
+  setUsageAnalyticsEnabled,
+} from "@/lib/analytics";
+import { type AppConfig, loadConfig, patchConfig } from "@/lib/config";
+import { desktop } from "@/lib/desktop";
+import { qk } from "@/lib/queryKeys";
+
+interface TelemetryContextValue {
+  usageAnalytics: boolean;
+  crashReports: boolean;
+  doNotTrack: boolean;
+  setUsageAnalytics: (enabled: boolean) => void;
+  setCrashReports: (enabled: boolean) => void;
+}
+
+const TelemetryContext = createContext<TelemetryContextValue | undefined>(undefined);
+
+export function useTelemetry() {
+  const ctx = useContext(TelemetryContext);
+  if (!ctx) throw new Error("useTelemetry must be used within a TelemetryProvider");
+  return ctx;
+}
+
+let posthogInitialized = false;
+
+function initPostHog(crashReports: boolean): void {
+  if (posthogInitialized) return;
+  if (!import.meta.env.PROD || !POSTHOG_PROJECT_TOKEN) return;
+  posthogInitialized = true;
+  posthog.init(POSTHOG_PROJECT_TOKEN, {
+    api_host: POSTHOG_API_HOST,
+    person_profiles: "identified_only",
+    capture_pageview: false,
+    capture_exceptions: crashReports,
+    opt_out_useragent_filter: true,
+    before_send: (event) => {
+      if (!event) return null;
+      const isException = event.event === "$exception";
+      if (isException && !isCrashReportsEnabled()) return null;
+      if (!isException && !isUsageAnalyticsEnabled()) return null;
+      return event;
+    },
+  });
+  posthog.register({
+    $current_url: "bloxbot://app/loading",
+    $host: "app",
+    $pathname: "/loading",
+    app: "bloxbot",
+    analytics_schema_version: ANALYTICS_SCHEMA_VERSION,
+    analytics_detail_enabled: true,
+    app_platform: navigator.platform,
+    app_runtime: window.bloxbot ? "electron" : "browser",
+    app_screen: "loading",
+    app_user_agent: navigator.userAgent,
+  });
+  desktop.getVersion().then(
+    (version) => {
+      posthog.register({ app_version: version });
+      posthog.capture("app_opened", analyticsProperties("app", { app_version: version }));
+    },
+    () => posthog.capture("app_opened", analyticsProperties("app", { app_version: "unknown" })),
+  );
+}
+
+export function TelemetryProvider({ children }: { children: ReactNode }) {
+  const { data: config } = useQuery<AppConfig>({
+    queryKey: qk.config,
+    queryFn: loadConfig,
+  });
+  const { data: dnt } = useQuery({
+    queryKey: ["doNotTrack"],
+    queryFn: () => desktop.getDoNotTrack(),
+  });
+
+  const doNotTrack = dnt === true;
+  const [usageAnalytics, setUsageAnalyticsState] = useState(true);
+  const [crashReports, setCrashReportsState] = useState(true);
+  const [showNotice, setShowNotice] = useState(false);
+  const initializedRef = useRef(false);
+
+  // Apply config when it arrives.
+  useEffect(() => {
+    if (!config || dnt === undefined) return;
+
+    const usage = config.usageAnalytics !== "off";
+    const crash = config.crashReports !== "off";
+    setUsageAnalyticsState(usage);
+    setCrashReportsState(crash);
+    setUsageAnalyticsEnabled(usage);
+    setCrashReportsEnabled(crash);
+
+    if (doNotTrack) {
+      setUsageAnalyticsEnabled(false);
+      setCrashReportsEnabled(false);
+      setUsageAnalyticsState(false);
+      setCrashReportsState(false);
+      return;
+    }
+
+    if (!config.telemetryNoticeShown) {
+      setShowNotice(true);
+      return;
+    }
+
+    // Subsequent launch with at least one toggle on -- init immediately.
+    if ((usage || crash) && !initializedRef.current) {
+      initializedRef.current = true;
+      initPostHog(crash);
+    }
+  }, [config, dnt, doNotTrack]);
+
+  const handleNoticeAccept = useCallback(() => {
+    setShowNotice(false);
+    patchConfig({ telemetryNoticeShown: true }).catch(() => {});
+    initializedRef.current = true;
+    initPostHog(true);
+  }, []);
+
+  const handleNoticeTurnOff = useCallback(() => {
+    setShowNotice(false);
+    setUsageAnalyticsState(false);
+    setCrashReportsState(false);
+    setUsageAnalyticsEnabled(false);
+    setCrashReportsEnabled(false);
+    patchConfig({
+      telemetryNoticeShown: true,
+      usageAnalytics: "off",
+      crashReports: "off",
+    }).catch(() => {});
+    // Do NOT init PostHog -- both toggles are off.
+  }, []);
+
+  const setUsageAnalyticsToggle = useCallback((enabled: boolean) => {
+    setUsageAnalyticsState(enabled);
+    setUsageAnalyticsEnabled(enabled);
+    patchConfig({ usageAnalytics: enabled ? "on" : "off" }).catch(() => {});
+    if (enabled && !posthogInitialized) {
+      initializedRef.current = true;
+      initPostHog(isCrashReportsEnabled());
+    }
+  }, []);
+
+  const setCrashReportsToggle = useCallback((enabled: boolean) => {
+    setCrashReportsState(enabled);
+    setCrashReportsEnabled(enabled);
+    patchConfig({ crashReports: enabled ? "on" : "off" }).catch(() => {});
+    if (enabled && !posthogInitialized) {
+      initializedRef.current = true;
+      initPostHog(true);
+    }
+  }, []);
+
+  const value: TelemetryContextValue = {
+    usageAnalytics,
+    crashReports,
+    doNotTrack,
+    setUsageAnalytics: setUsageAnalyticsToggle,
+    setCrashReports: setCrashReportsToggle,
+  };
+
+  return (
+    <TelemetryContext.Provider value={value}>
+      {showNotice && (
+        <TelemetryNotice onAccept={handleNoticeAccept} onTurnOff={handleNoticeTurnOff} />
+      )}
+      {children}
+    </TelemetryContext.Provider>
+  );
+}
+
+function TelemetryNotice({ onAccept, onTurnOff }: { onAccept: () => void; onTurnOff: () => void }) {
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40">
+      <div className="mx-4 w-full max-w-sm rounded-xl border bg-card p-6 shadow-lg">
+        <h2 className="text-base font-semibold text-foreground">Usage data &amp; crash reports</h2>
+        <p className="mt-2 text-sm leading-relaxed text-muted-foreground">
+          BloxBot collects anonymous usage data and crash reports to improve the app. No prompts,
+          code, or file contents are ever collected. You can turn this off now or anytime in
+          Settings.
+        </p>
+        <div className="mt-5 flex items-center justify-end gap-3">
+          <button
+            type="button"
+            onClick={onTurnOff}
+            className="rounded-lg px-4 py-2 text-sm font-medium text-muted-foreground transition-colors hover:text-foreground"
+          >
+            Turn off telemetry
+          </button>
+          <button
+            type="button"
+            onClick={onAccept}
+            className="rounded-lg bg-foreground px-4 py-2 text-sm font-medium text-background transition-opacity hover:opacity-90"
+          >
+            OK
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/test/PlaytestPanel.test.tsx
+++ b/src/test/PlaytestPanel.test.tsx
@@ -31,7 +31,11 @@ function Harness({
     lastModel: "anthropic/claude",
     hiddenModels: [],
     theme: "system",
-    detailedAnalytics: "disabled",
+    telemetryNoticeShown: true,
+    usageAnalytics: "on",
+    crashReports: "on",
+    studioTargetPrograms: null,
+    studioTargetsBySession: {},
   });
   queryClient.setQueryData<MessagesCache>(qk.messages("active"), {
     messageIds: ["m1"],
@@ -100,15 +104,21 @@ describe("PlaytestPanel", () => {
     expect(client.session.create).not.toHaveBeenCalled();
     expect(client.session.prompt).not.toHaveBeenCalled();
     fireEvent.click(screen.getByRole("button", { name: "Generate from chat" }));
-    expect(capture).toHaveBeenCalledWith("generation_started", {
-      analytics_schema_version: 1,
-      feature: "playtest",
-    });
+    expect(capture).toHaveBeenCalledWith(
+      "generation_started",
+      expect.objectContaining({
+        analytics_schema_version: 1,
+        feature: "playtest",
+      }),
+    );
     expect(await screen.findByDisplayValue("Test rounds")).toBeInTheDocument();
-    expect(capture).toHaveBeenCalledWith("generation_succeeded", {
-      analytics_schema_version: 1,
-      feature: "playtest",
-    });
+    expect(capture).toHaveBeenCalledWith(
+      "generation_succeeded",
+      expect.objectContaining({
+        analytics_schema_version: 1,
+        feature: "playtest",
+      }),
+    );
     expect(client.session.prompt.mock.calls[0][0]).toMatchObject({
       sessionID: "planner",
       format: { type: "json_schema" },

--- a/src/test/analytics.test.ts
+++ b/src/test/analytics.test.ts
@@ -18,7 +18,9 @@ function posthogStub() {
 }
 
 describe("PostHog analytics", () => {
-  beforeEach(() => setDetailedAnalyticsEnabled(false));
+  // Detailed analytics are now on by default. Each test that exercises the
+  // disabled path must explicitly opt out.
+  beforeEach(() => setDetailedAnalyticsEnabled(true));
 
   it("buckets counts without exposing exact larger values", () => {
     expect(countBucket(1)).toBe("1");
@@ -29,24 +31,26 @@ describe("PostHog analytics", () => {
     expect(countBucket(42)).toBe("11+");
   });
 
-  it("removes detailed properties until the user opts in", () => {
+  it("includes detailed properties by default", () => {
     const properties = { provider: "anthropic", model: "claude-sonnet-4" };
-
-    expect(detailedAnalyticsProperties(properties)).toEqual({});
-
-    setDetailedAnalyticsEnabled(true);
 
     expect(detailedAnalyticsProperties(properties)).toEqual(properties);
   });
 
-  it("captures detailed token usage only after opt-in", () => {
+  it("removes detailed properties after explicit opt-out", () => {
+    const properties = { provider: "anthropic", model: "claude-sonnet-4" };
+
+    setDetailedAnalyticsEnabled(false);
+    expect(detailedAnalyticsProperties(properties)).toEqual({});
+
+    setDetailedAnalyticsEnabled(true);
+    expect(detailedAnalyticsProperties(properties)).toEqual(properties);
+  });
+
+  it("captures detailed token usage by default and stops after opt-out", () => {
     const posthog = posthogStub();
     const usage = { provider: "anthropic", model: "claude-sonnet-4", tokens_total: 42 };
 
-    captureDetailedAnalytics(posthog as never, "model_usage", usage);
-    expect(posthog.capture).not.toHaveBeenCalled();
-
-    setDetailedAnalyticsEnabled(true);
     captureDetailedAnalytics(posthog as never, "model_usage", usage);
 
     expect(posthog.capture).toHaveBeenCalledOnce();
@@ -55,6 +59,11 @@ describe("PostHog analytics", () => {
       feature: "model",
       ...usage,
     });
+
+    posthog.capture.mockClear();
+    setDetailedAnalyticsEnabled(false);
+    captureDetailedAnalytics(posthog as never, "model_usage", usage);
+    expect(posthog.capture).not.toHaveBeenCalled();
   });
 
   it("keeps Explorer analytics coarse and strips object content", () => {

--- a/src/test/analytics.test.ts
+++ b/src/test/analytics.test.ts
@@ -5,7 +5,7 @@ import {
   detailedAnalyticsProperties,
   errorAnalyticsProperties,
   explorerAnalyticsProperties,
-  setDetailedAnalyticsEnabled,
+  setUsageAnalyticsEnabled,
 } from "@/lib/analytics";
 
 function posthogStub() {
@@ -18,9 +18,9 @@ function posthogStub() {
 }
 
 describe("PostHog analytics", () => {
-  // Detailed analytics are now on by default. Each test that exercises the
+  // Usage analytics are now on by default. Each test that exercises the
   // disabled path must explicitly opt out.
-  beforeEach(() => setDetailedAnalyticsEnabled(true));
+  beforeEach(() => setUsageAnalyticsEnabled(true));
 
   it("buckets counts without exposing exact larger values", () => {
     expect(countBucket(1)).toBe("1");
@@ -40,10 +40,10 @@ describe("PostHog analytics", () => {
   it("removes detailed properties after explicit opt-out", () => {
     const properties = { provider: "anthropic", model: "claude-sonnet-4" };
 
-    setDetailedAnalyticsEnabled(false);
+    setUsageAnalyticsEnabled(false);
     expect(detailedAnalyticsProperties(properties)).toEqual({});
 
-    setDetailedAnalyticsEnabled(true);
+    setUsageAnalyticsEnabled(true);
     expect(detailedAnalyticsProperties(properties)).toEqual(properties);
   });
 
@@ -61,7 +61,7 @@ describe("PostHog analytics", () => {
     });
 
     posthog.capture.mockClear();
-    setDetailedAnalyticsEnabled(false);
+    setUsageAnalyticsEnabled(false);
     captureDetailedAnalytics(posthog as never, "model_usage", usage);
     expect(posthog.capture).not.toHaveBeenCalled();
   });

--- a/src/test/app.test.tsx
+++ b/src/test/app.test.tsx
@@ -22,6 +22,7 @@ import { ActiveSessionProvider } from "@/providers/ActiveSessionProvider";
 import { ExplorerReferenceProvider } from "@/providers/ExplorerReferenceProvider";
 import { OpenCodeClientContext } from "@/providers/OpenCodeClientProvider";
 import { PreferencesProvider } from "@/providers/PreferencesProvider";
+import { TelemetryProvider } from "@/providers/TelemetryProvider";
 
 // Mock react-virtual so all items render in jsdom (no viewport measurement)
 vi.mock("@tanstack/react-virtual", () => ({
@@ -69,25 +70,27 @@ function TestApp({
 
   return (
     <QueryClientProvider client={queryClient}>
-      <ThemeProvider>
-        <OpenCodeClientContext.Provider
-          value={{
-            client: client as never,
-            status: "ready",
-            port: 4096,
-            ready: true,
-            initError: null,
-          }}
-        >
-          <ActiveSessionProvider activeSessionIdRef={activeSessionIdRef}>
-            <PreferencesProvider>
-              <ExplorerReferenceProvider>
-                <ChatWithSonner />
-              </ExplorerReferenceProvider>
-            </PreferencesProvider>
-          </ActiveSessionProvider>
-        </OpenCodeClientContext.Provider>
-      </ThemeProvider>
+      <TelemetryProvider>
+        <ThemeProvider>
+          <OpenCodeClientContext.Provider
+            value={{
+              client: client as never,
+              status: "ready",
+              port: 4096,
+              ready: true,
+              initError: null,
+            }}
+          >
+            <ActiveSessionProvider activeSessionIdRef={activeSessionIdRef}>
+              <PreferencesProvider>
+                <ExplorerReferenceProvider>
+                  <ChatWithSonner />
+                </ExplorerReferenceProvider>
+              </PreferencesProvider>
+            </ActiveSessionProvider>
+          </OpenCodeClientContext.Provider>
+        </ThemeProvider>
+      </TelemetryProvider>
     </QueryClientProvider>
   );
 }
@@ -180,10 +183,7 @@ function createQueryClient() {
 }
 
 /** Seed the query cache with the minimum state the app needs to be "ready" */
-function seedReadyState(
-  queryClient: QueryClient,
-  opts: { sessions?: Session[]; detailedAnalytics?: "unset" | "enabled" | "disabled" } = {},
-) {
+function seedReadyState(queryClient: QueryClient, opts: { sessions?: Session[] } = {}) {
   const sessions = opts.sessions ?? [];
 
   queryClient.setQueryData(qk.sessions, sessions);
@@ -207,7 +207,11 @@ function seedReadyState(
     lastModel: "anthropic/claude-3.5-sonnet",
     hiddenModels: [],
     theme: "system",
-    detailedAnalytics: opts.detailedAnalytics ?? "disabled",
+    telemetryNoticeShown: true,
+    usageAnalytics: "on",
+    crashReports: "on",
+    studioTargetPrograms: null,
+    studioTargetsBySession: {},
   });
 }
 
@@ -226,34 +230,34 @@ afterEach(() => {
 // ── Tests ──────────────────────────────────────────────────────────────────
 
 describe("User journeys", () => {
-  it("enables detailed analytics by default and allows opting out via Settings", async () => {
+  it("shows two telemetry toggles in Settings and allows toggling them", async () => {
     const client = createClient();
     const queryClient = createQueryClient();
-    seedReadyState(queryClient, { detailedAnalytics: "unset" });
+    seedReadyState(queryClient);
 
     render(<TestApp client={client} queryClient={queryClient} />);
 
-    // No consent toast should appear — analytics are on by default.
+    // No consent dialog should appear -- telemetryNoticeShown is true.
     await screen.findByText("What would you like to build?");
-    expect(screen.queryByText("Help improve BloxBot")).not.toBeInTheDocument();
+    expect(screen.queryByText("Usage data & crash reports")).not.toBeInTheDocument();
 
-    // Open Settings > Privacy and verify the toggle is on.
+    // Open Settings > Privacy and verify both toggles are on.
     fireEvent.click(await screen.findByText("Settings"));
     fireEvent.click(await screen.findByRole("button", { name: "Privacy" }));
-    const analyticsSwitch = screen.getByRole("switch", {
-      name: "Detailed usage analytics",
-    });
-    expect(analyticsSwitch).toHaveAttribute("aria-checked", "true");
+    const usageSwitch = screen.getByRole("switch", { name: "Usage analytics" });
+    const crashSwitch = screen.getByRole("switch", { name: "Crash reports" });
+    expect(usageSwitch).toHaveAttribute("aria-checked", "true");
+    expect(crashSwitch).toHaveAttribute("aria-checked", "true");
 
-    // Opt out — toggle should flip and config should persist "disabled".
-    fireEvent.click(analyticsSwitch);
-    expect(analyticsSwitch).toHaveAttribute("aria-checked", "false");
-    await expect(desktop.loadConfig()).resolves.toMatchObject({ detailedAnalytics: "disabled" });
+    // Opt out of usage analytics.
+    fireEvent.click(usageSwitch);
+    expect(usageSwitch).toHaveAttribute("aria-checked", "false");
+    await expect(desktop.loadConfig()).resolves.toMatchObject({ usageAnalytics: "off" });
 
-    // Opt back in — toggle flips and config persists "enabled".
-    fireEvent.click(analyticsSwitch);
-    expect(analyticsSwitch).toHaveAttribute("aria-checked", "true");
-    await expect(desktop.loadConfig()).resolves.toMatchObject({ detailedAnalytics: "enabled" });
+    // Opt out of crash reports.
+    fireEvent.click(crashSwitch);
+    expect(crashSwitch).toHaveAttribute("aria-checked", "false");
+    await expect(desktop.loadConfig()).resolves.toMatchObject({ crashReports: "off" });
   });
 
   it("guides the user until Roblox Studio connects", async () => {

--- a/src/test/app.test.tsx
+++ b/src/test/app.test.tsx
@@ -226,30 +226,34 @@ afterEach(() => {
 // ── Tests ──────────────────────────────────────────────────────────────────
 
 describe("User journeys", () => {
-  it("prompts once for detailed analytics and keeps the choice toggleable", async () => {
+  it("enables detailed analytics by default and allows opting out via Settings", async () => {
     const client = createClient();
     const queryClient = createQueryClient();
     seedReadyState(queryClient, { detailedAnalytics: "unset" });
 
     render(<TestApp client={client} queryClient={queryClient} />);
 
-    const consentTitle = await screen.findByText("Help improve BloxBot");
-    expect(consentTitle).toBeVisible();
-    expect(consentTitle.closest("[data-sonner-toast]")).toHaveClass("analytics-consent-toast");
-    fireEvent.click(screen.getByRole("button", { name: "Share usage" }));
-    await expect(desktop.loadConfig()).resolves.toMatchObject({ detailedAnalytics: "enabled" });
+    // No consent toast should appear — analytics are on by default.
+    await screen.findByText("What would you like to build?");
+    expect(screen.queryByText("Help improve BloxBot")).not.toBeInTheDocument();
 
+    // Open Settings > Privacy and verify the toggle is on.
     fireEvent.click(await screen.findByText("Settings"));
     fireEvent.click(await screen.findByRole("button", { name: "Privacy" }));
     const analyticsSwitch = screen.getByRole("switch", {
-      name: "Share detailed usage analytics",
+      name: "Detailed usage analytics",
     });
     expect(analyticsSwitch).toHaveAttribute("aria-checked", "true");
 
+    // Opt out — toggle should flip and config should persist "disabled".
     fireEvent.click(analyticsSwitch);
-
     expect(analyticsSwitch).toHaveAttribute("aria-checked", "false");
     await expect(desktop.loadConfig()).resolves.toMatchObject({ detailedAnalytics: "disabled" });
+
+    // Opt back in — toggle flips and config persists "enabled".
+    fireEvent.click(analyticsSwitch);
+    expect(analyticsSwitch).toHaveAttribute("aria-checked", "true");
+    await expect(desktop.loadConfig()).resolves.toMatchObject({ detailedAnalytics: "enabled" });
   });
 
   it("guides the user until Roblox Studio connects", async () => {

--- a/src/test/desktop.test.ts
+++ b/src/test/desktop.test.ts
@@ -24,7 +24,9 @@ describe("browser desktop fallback", () => {
       lastModel: "openai/gpt-5",
       hiddenModels: [],
       theme: "system",
-      detailedAnalytics: "unset",
+      telemetryNoticeShown: false,
+      usageAnalytics: "on",
+      crashReports: "on",
       studioTargetPrograms: null,
       studioTargetsBySession: {},
     });
@@ -41,7 +43,9 @@ describe("browser desktop fallback", () => {
       lastModel: null,
       hiddenModels: [],
       theme: "system",
-      detailedAnalytics: "unset",
+      telemetryNoticeShown: false,
+      usageAnalytics: "on",
+      crashReports: "on",
       studioTargetPrograms: null,
       studioTargetsBySession: {},
     });
@@ -56,17 +60,22 @@ describe("browser desktop fallback", () => {
       lastModel: null,
       hiddenModels: [],
       theme: "dark",
-      detailedAnalytics: "unset",
+      telemetryNoticeShown: false,
+      usageAnalytics: "on",
+      crashReports: "on",
       studioTargetPrograms: null,
       studioTargetsBySession: {},
     });
   });
 
-  it("persists detailed analytics consent separately from basic analytics", async () => {
+  it("persists telemetry toggles independently", async () => {
     const { desktop } = await import("@/lib/desktop");
 
-    await desktop.patchConfig({ detailedAnalytics: "enabled" });
+    await desktop.patchConfig({ usageAnalytics: "off" });
 
-    await expect(desktop.loadConfig()).resolves.toMatchObject({ detailedAnalytics: "enabled" });
+    await expect(desktop.loadConfig()).resolves.toMatchObject({
+      usageAnalytics: "off",
+      crashReports: "on",
+    });
   });
 });

--- a/src/test/errorBoundary.test.tsx
+++ b/src/test/errorBoundary.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from "@testing-library/react";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, type MockInstance, vi } from "vitest";
 import ErrorBoundary from "@/components/ErrorBoundary";
 
 const captureExceptionSpy = vi.fn();
@@ -13,14 +13,20 @@ function Thrower({ error }: { error: Error }) {
 }
 
 describe("ErrorBoundary", () => {
+  let consoleErrorSpy: MockInstance;
+
+  beforeEach(() => {
+    // Suppress the expected React error boundary console output.
+    consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
   afterEach(() => {
     captureExceptionSpy.mockReset();
+    consoleErrorSpy.mockRestore();
   });
 
   it("forwards caught errors to posthog.captureException", () => {
     const error = new Error("boom");
-    // Suppress the expected React error boundary console output.
-    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
 
     render(
       <ErrorBoundary>
@@ -31,8 +37,6 @@ describe("ErrorBoundary", () => {
     expect(captureExceptionSpy).toHaveBeenCalledOnce();
     expect(captureExceptionSpy).toHaveBeenCalledWith(error);
     expect(screen.getByText("Something went wrong")).toBeInTheDocument();
-
-    spy.mockRestore();
   });
 
   it("renders children when no error occurs", () => {

--- a/src/test/errorBoundary.test.tsx
+++ b/src/test/errorBoundary.test.tsx
@@ -1,0 +1,48 @@
+import { render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import ErrorBoundary from "@/components/ErrorBoundary";
+
+const captureExceptionSpy = vi.fn();
+
+vi.mock("posthog-js/dist/module.full.no-external.js", () => ({
+  default: { captureException: (...args: unknown[]) => captureExceptionSpy(...args) },
+}));
+
+function Thrower({ error }: { error: Error }) {
+  throw error;
+}
+
+describe("ErrorBoundary", () => {
+  afterEach(() => {
+    captureExceptionSpy.mockReset();
+  });
+
+  it("forwards caught errors to posthog.captureException", () => {
+    const error = new Error("boom");
+    // Suppress the expected React error boundary console output.
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    render(
+      <ErrorBoundary>
+        <Thrower error={error} />
+      </ErrorBoundary>,
+    );
+
+    expect(captureExceptionSpy).toHaveBeenCalledOnce();
+    expect(captureExceptionSpy).toHaveBeenCalledWith(error);
+    expect(screen.getByText("Something went wrong")).toBeInTheDocument();
+
+    spy.mockRestore();
+  });
+
+  it("renders children when no error occurs", () => {
+    render(
+      <ErrorBoundary>
+        <p>OK</p>
+      </ErrorBoundary>,
+    );
+
+    expect(screen.getByText("OK")).toBeInTheDocument();
+    expect(captureExceptionSpy).not.toHaveBeenCalled();
+  });
+});

--- a/src/test/errorBoundary.test.tsx
+++ b/src/test/errorBoundary.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, type MockInstance, vi } from "vitest";
 import ErrorBoundary from "@/components/ErrorBoundary";
+import { setCrashReportsEnabled } from "@/lib/analytics";
 
 const captureExceptionSpy = vi.fn();
 
@@ -18,6 +19,7 @@ describe("ErrorBoundary", () => {
   beforeEach(() => {
     // Suppress the expected React error boundary console output.
     consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    setCrashReportsEnabled(true);
   });
 
   afterEach(() => {
@@ -47,6 +49,17 @@ describe("ErrorBoundary", () => {
     );
 
     expect(screen.getByText("OK")).toBeInTheDocument();
+    expect(captureExceptionSpy).not.toHaveBeenCalled();
+  });
+
+  it("does not call captureException when crash reports are disabled", () => {
+    setCrashReportsEnabled(false);
+    const error = new Error("silent");
+    render(
+      <ErrorBoundary>
+        <Thrower error={error} />
+      </ErrorBoundary>,
+    );
     expect(captureExceptionSpy).not.toHaveBeenCalled();
   });
 });

--- a/src/test/telemetry.test.ts
+++ b/src/test/telemetry.test.ts
@@ -1,0 +1,46 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  detailedAnalyticsProperties,
+  isCrashReportsEnabled,
+  isUsageAnalyticsEnabled,
+  setCrashReportsEnabled,
+  setUsageAnalyticsEnabled,
+} from "@/lib/analytics";
+
+describe("Telemetry gating", () => {
+  beforeEach(() => {
+    setUsageAnalyticsEnabled(true);
+    setCrashReportsEnabled(true);
+  });
+
+  it("defaults both toggles to on", () => {
+    expect(isUsageAnalyticsEnabled()).toBe(true);
+    expect(isCrashReportsEnabled()).toBe(true);
+  });
+
+  it("usage analytics toggle gates detailed properties", () => {
+    const props = { provider: "anthropic", model: "claude-sonnet-4" };
+    expect(detailedAnalyticsProperties(props)).toEqual(props);
+    setUsageAnalyticsEnabled(false);
+    expect(detailedAnalyticsProperties(props)).toEqual({});
+  });
+
+  it("toggles can be turned off independently", () => {
+    setUsageAnalyticsEnabled(false);
+    expect(isUsageAnalyticsEnabled()).toBe(false);
+    expect(isCrashReportsEnabled()).toBe(true);
+
+    setCrashReportsEnabled(false);
+    expect(isCrashReportsEnabled()).toBe(false);
+  });
+
+  it("old detailedAnalytics preference is ignored on config load", () => {
+    // The old detailedAnalytics="disabled" value is stripped by the schema.
+    // Both toggles default to on regardless of old preference.
+    // This is a design-level assertion -- verified by the config schema
+    // not containing detailedAnalytics and DEFAULT_APP_CONFIG having
+    // usageAnalytics: "on" and crashReports: "on".
+    expect(isUsageAnalyticsEnabled()).toBe(true);
+    expect(isCrashReportsEnabled()).toBe(true);
+  });
+});

--- a/src/types/desktop.ts
+++ b/src/types/desktop.ts
@@ -13,7 +13,7 @@ import {
 const MutableStrings = Schema.mutable(Schema.Array(Schema.String));
 
 export const ThemePreferenceSchema = Schema.Literal("light", "dark", "system");
-export const DetailedAnalyticsPreferenceSchema = Schema.Literal("unset", "enabled", "disabled");
+export const TelemetryToggleSchema = Schema.Literal("on", "off");
 
 export type ThemePreference = typeof ThemePreferenceSchema.Type;
 
@@ -22,7 +22,9 @@ export const AppConfigSchema = Schema.mutable(
     lastModel: Schema.NullOr(Schema.String),
     hiddenModels: MutableStrings,
     theme: ThemePreferenceSchema,
-    detailedAnalytics: DetailedAnalyticsPreferenceSchema,
+    telemetryNoticeShown: Schema.Boolean,
+    usageAnalytics: TelemetryToggleSchema,
+    crashReports: TelemetryToggleSchema,
     studioTargetPrograms: Schema.NullOr(StudioTargetProgramsSchema),
     studioTargetsBySession: Schema.Record({ key: Schema.String, value: StudioTargetSchema }),
   }),
@@ -34,7 +36,9 @@ export const DEFAULT_APP_CONFIG: AppConfig = {
   lastModel: null,
   hiddenModels: [],
   theme: "system",
-  detailedAnalytics: "unset",
+  telemetryNoticeShown: false,
+  usageAnalytics: "on",
+  crashReports: "on",
   studioTargetPrograms: null,
   studioTargetsBySession: {},
 };
@@ -83,6 +87,7 @@ export interface DesktopApi {
   patchConfig(patch: Partial<AppConfig>): Promise<void>;
   checkForUpdate(): Promise<UpdateInfo | null>;
   installUpdate(): Promise<void>;
+  getDoNotTrack(): Promise<boolean>;
   relaunch(): Promise<void>;
   installStudioTargetPrograms(
     envelopes: StudioTargetProgramEnvelopes,


### PR DESCRIPTION
## Summary

Restructures BloxBot's telemetry to follow Zed/VS Code practice: default-on analytics with a first-run notice, anonymous events, two independent toggles, and DO_NOT_TRACK support. This intentionally goes beyond OpenCode's opt-in posture per product decision.

| Category | Default | Disable methods |
|---|---|---|
| **Usage analytics** (PostHog) | On by default after first-run notice | First-run dialog, Settings > Privacy toggle, `DO_NOT_TRACK=1` |
| **Crash reports** (PostHog Error Tracking) | On by default after first-run notice | First-run dialog, Settings > Privacy toggle, `DO_NOT_TRACK=1` |
| **Update checks** (electron-updater) | On in packaged builds | `BLOXBOT_DISABLE_AUTOUPDATE=1` |

### Design rationale

The telemetry posture follows Zed/VS Code practice: a non-blocking first-run notice before any data collection, anonymous events (`person_profiles: "identified_only"`, no `posthog.identify()`), a published event list (TELEMETRY.md), and split opt-out toggles in Settings. PostHog is never initialized until the notice dialog has rendered and the user dismisses it -- zero network calls or local-storage writes before the notice is shown.

## Changes

### Architecture
- **PostHog init moved** from module scope in `src/main.tsx` to a deferred lifecycle in `src/providers/TelemetryProvider.tsx` -- initialization only happens after config check and first-run notice
- **`before_send` filter** gates every event at the transport level by toggle state, avoiding changes to 45+ call sites
- **`person_profiles: "identified_only"`** (was `"always"`) ensures anonymous events

### First-run notice
- New `TelemetryProvider` component shows a dialog on first launch (`telemetryNoticeShown` config flag)
- "OK" dismisses and initializes PostHog with both toggles on
- "Turn off telemetry" persists both toggles as off and never initializes PostHog

### Two toggles
- `usageAnalytics` (default on): gates all `posthog.capture()` usage events
- `crashReports` (default on): gates `capture_exceptions` and `ErrorBoundary.captureException`
- If both off, PostHog is not initialized at all
- Settings > Privacy shows both with accurate copy

### DO_NOT_TRACK
- New `getDoNotTrack` IPC channel reads `process.env.DO_NOT_TRACK` in the main process
- When truthy (`"1"`, `"true"`): all telemetry disabled, first-run dialog skipped
- Does not affect update checks (they are not telemetry), but the `update_available` / `update_auto_installed` PostHog events are suppressed

### Legacy preference
The old `detailedAnalytics` preference key is intentionally not migrated. The notice dialog re-prompts every user on first launch after this update.

## Files changed (19 files, +586 / -221)

| File | Purpose |
|---|---|
| `src/providers/TelemetryProvider.tsx` | NEW: Deferred PostHog init, first-run notice, two-toggle context |
| `src/test/telemetry.test.ts` | NEW: Toggle gating and independence tests |
| `src/types/desktop.ts` | New config fields, getDoNotTrack in DesktopApi |
| `electron/channels.ts` | Add getDoNotTrack channel |
| `electron/preload.ts` | Wire getDoNotTrack |
| `electron/main.ts` | DO_NOT_TRACK env var handler |
| `src/lib/desktop.ts` | getDoNotTrack effects |
| `src/lib/analytics.ts` | Split toggles (usageAnalytics + crashReports) |
| `src/main.tsx` | Remove all PostHog code (moved to TelemetryProvider) |
| `src/App.tsx` | Add TelemetryProvider to component tree |
| `src/components/ErrorBoundary.tsx` | Gate captureException on crashReportsEnabled |
| `src/components/Settings.tsx` | Two privacy toggles + DO_NOT_TRACK notice |
| `src/providers/PreferencesProvider.tsx` | Remove analytics management (moved to TelemetryProvider) |
| `TELEMETRY.md` | Full event inventory, toggle docs, notice behavior, DNT, anonymous-ID policy |
| `src/test/analytics.test.ts` | Updated for renamed toggles |
| `src/test/app.test.tsx` | Updated for two toggles and notice behavior |
| `src/test/errorBoundary.test.tsx` | Added crash-toggle-off test |
| `src/test/desktop.test.ts` | Updated config shape |
| `src/test/PlaytestPanel.test.tsx` | Updated config shape |

## Test plan

- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes (47 pre-existing warnings, no new)
- [x] `pnpm test` passes (187 vitest + 8 release script tests)
- [ ] First-run dialog appears on fresh install, no network calls before it renders
- [ ] "Turn off telemetry" persists both toggles off
- [ ] DO_NOT_TRACK=1 disables everything
- [ ] Settings > Privacy shows and controls both toggles independently

🤖 Generated with [Claude Code](https://claude.com/claude-code)