### PR TITLE
Fix Windows Studio MCP startup; anonymized opt-out usage metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+### Changed
+
+- Turned model usage metrics into an opt-out setting with a one-time in-app notice; choices recorded under the previous opt-in prompt do not carry over, and the Settings → Privacy toggle remains authoritative.
+- Anonymized all analytics: events no longer create a person profile, IP-based location enrichment is disabled, autocapture and session recording are off, and the raw user agent is no longer collected. A random device identifier is retained for aggregate counts.
+
+### Fixed
+
+- Fixed a startup failure on Windows when the system `PATH` does not include `System32` by resolving `cmd.exe` through `ComSpec` before launching the Roblox Studio MCP helper. ([#73](https://github.com/paralov/app-bloxbot-ai/issues/73))
+
 ## [0.8.0] - 2026-07-27
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 ### Changed
 
 - Turned model usage metrics into an opt-out setting with a one-time in-app notice; choices recorded under the previous opt-in prompt do not carry over, and the Settings → Privacy toggle remains authoritative.
-- Anonymized all analytics: events no longer create a person profile, IP-based location enrichment is disabled, autocapture and session recording are off, and the raw user agent is no longer collected. A random device identifier is retained for aggregate counts.
+- Anonymized analytics: events no longer create a person profile. A random device identifier is retained for aggregate counts.
 
 ### Fixed
 

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -49,6 +49,8 @@ class DesktopMainError extends Data.TaggedError("DesktopMainError")<{
 const studioMcpBrokerLayer = makeStudioMcpBrokerLayer({
   workspace: join(app.getPath("home"), "BloxBot"),
   localAppData: process.env.LOCALAPPDATA,
+  comSpec: process.env.ComSpec,
+  systemRoot: process.env.SystemRoot,
 });
 
 const openCodeRuntime = ManagedRuntime.make(

--- a/electron/opencodeConfig.ts
+++ b/electron/opencodeConfig.ts
@@ -1,13 +1,26 @@
-import { join } from "node:path";
+import { win32 } from "node:path";
 
-export function studioMcpCommand(platform: NodeJS.Platform, localAppData?: string): string[] {
+export interface StudioMcpWindowsEnvironment {
+  localAppData?: string;
+  comSpec?: string;
+  systemRoot?: string;
+}
+
+export function studioMcpCommand(
+  platform: NodeJS.Platform,
+  environment: StudioMcpWindowsEnvironment = {},
+): string[] {
   if (platform === "darwin") {
     return ["/Applications/RobloxStudio.app/Contents/MacOS/StudioMCP"];
   }
 
   if (platform === "win32") {
-    const dataDirectory = localAppData ?? "C:\\Users\\Default\\AppData\\Local";
-    return ["cmd.exe", "/c", join(dataDirectory, "Roblox", "mcp.bat")];
+    const dataDirectory = environment.localAppData ?? "C:\\Users\\Default\\AppData\\Local";
+    // Resolve cmd.exe absolutely: the MCP stdio transport spawns with a reduced
+    // environment, so a PATH without System32 makes a bare "cmd.exe" fail with ENOENT.
+    const systemRoot = environment.systemRoot ?? "C:\\Windows";
+    const comSpec = environment.comSpec ?? win32.join(systemRoot, "System32", "cmd.exe");
+    return [comSpec, "/c", win32.join(dataDirectory, "Roblox", "mcp.bat")];
   }
 
   return ["studio-mcp"];

--- a/electron/services/StudioMcpBroker.ts
+++ b/electron/services/StudioMcpBroker.ts
@@ -211,6 +211,8 @@ export interface StudioMcpBrokerOptions {
   workspace: string;
   platform?: NodeJS.Platform;
   localAppData?: string;
+  comSpec?: string;
+  systemRoot?: string;
 }
 
 export function makeStudioMcpBrokerLayer(options: StudioMcpBrokerOptions) {
@@ -220,7 +222,11 @@ export function makeStudioMcpBrokerLayer(options: StudioMcpBrokerOptions) {
       Effect.tryPromise({
         try: async () => {
           const upstream = await SdkStudioMcpUpstream.connect(
-            studioMcpCommand(options.platform ?? process.platform, options.localAppData),
+            studioMcpCommand(options.platform ?? process.platform, {
+              localAppData: options.localAppData,
+              comSpec: options.comSpec,
+              systemRoot: options.systemRoot,
+            }),
             options.workspace,
           );
           return startStudioMcpBroker(upstream);

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -1029,9 +1029,9 @@ function PrivacyTab() {
     <div className="mx-auto w-full max-w-md px-6 py-8">
       <h4 className="font-serif text-lg italic text-foreground">Privacy</h4>
       <p className="mt-1 text-xs text-muted-foreground">
-        BloxBot collects anonymized usage analytics tied to a random device identifier. No person
-        profile is created, IP-based location is never recorded, and prompts, responses, and files
-        are never collected.
+        BloxBot uses PostHog's standard product analytics with persistent device and session
+        identifiers, but events stay anonymous: no person profile is created. Prompts, responses,
+        and files are never collected.
       </p>
 
       <div className="mt-6 rounded-lg border bg-card p-3.5">

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -1029,25 +1029,25 @@ function PrivacyTab() {
     <div className="mx-auto w-full max-w-md px-6 py-8">
       <h4 className="font-serif text-lg italic text-foreground">Privacy</h4>
       <p className="mt-1 text-xs text-muted-foreground">
-        BloxBot uses PostHog's standard product analytics with persistent device and session
-        identifiers plus a person profile. Feature flags and other PostHog products use the same
-        profile. Detailed usage is always your choice.
+        BloxBot collects anonymized usage analytics tied to a random device identifier. No person
+        profile is created, IP-based location is never recorded, and prompts, responses, and files
+        are never collected.
       </p>
 
       <div className="mt-6 rounded-lg border bg-card p-3.5">
         <div className="flex items-start justify-between gap-4">
           <div>
-            <div className="text-sm font-medium">Share detailed usage analytics</div>
+            <div className="text-sm font-medium">Share model usage metrics</div>
             <p className="mt-1 text-[11px] leading-relaxed text-muted-foreground">
-              Additionally shares provider and model names plus aggregate token counts. This switch
-              controls those detailed fields; standard PostHog collection remains enabled.
+              Shares provider and model names plus aggregate token counts, on by default. Turn this
+              off to keep model usage out of analytics; basic app health events remain enabled.
             </p>
           </div>
           <button
             type="button"
             role="switch"
             aria-checked={detailedAnalyticsEnabled}
-            aria-label="Share detailed usage analytics"
+            aria-label="Share model usage metrics"
             onClick={() => setDetailedAnalyticsEnabled(!detailedAnalyticsEnabled)}
             className={`relative mt-0.5 inline-flex h-5 w-9 shrink-0 items-center rounded-full transition-colors ${
               detailedAnalyticsEnabled ? "bg-foreground" : "bg-border"

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -7,6 +7,10 @@ let detailedAnalyticsEnabled = false;
 
 export const ANALYTICS_SCHEMA_VERSION = 1;
 
+// Bump when the analytics policy changes enough that users must be re-notified.
+// Version 1 introduced opt-out model usage metrics with anonymized collection.
+export const ANALYTICS_NOTICE_VERSION = 1;
+
 export function setDetailedAnalyticsEnabled(enabled: boolean): void {
   detailedAnalyticsEnabled = enabled;
   posthog.register({ analytics_detail_enabled: enabled });

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -18,8 +18,6 @@ if (import.meta.env.PROD && POSTHOG_PROJECT_TOKEN) {
     // The persisted random device id remains the stable fingerprint.
     person_profiles: "identified_only",
     capture_pageview: false,
-    autocapture: false,
-    disable_session_recording: true,
     // BloxBot intentionally contains "bot", which matches PostHog's bot heuristic.
     opt_out_useragent_filter: true,
   });
@@ -27,14 +25,13 @@ if (import.meta.env.PROD && POSTHOG_PROJECT_TOKEN) {
     $current_url: "bloxbot://app/loading",
     $host: "app",
     $pathname: "/loading",
-    // Skip server-side IP-based location enrichment.
-    $geoip_disable: true,
     app: "bloxbot",
     analytics_schema_version: ANALYTICS_SCHEMA_VERSION,
     analytics_detail_enabled: false,
     app_platform: navigator.platform,
     app_runtime: window.bloxbot ? "electron" : "browser",
     app_screen: "loading",
+    app_user_agent: navigator.userAgent,
   });
   void desktop.getVersion().then(
     (version) => {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -14,8 +14,12 @@ import { desktop } from "./lib/desktop";
 if (import.meta.env.PROD && POSTHOG_PROJECT_TOKEN) {
   posthog.init(POSTHOG_PROJECT_TOKEN, {
     api_host: POSTHOG_API_HOST,
-    person_profiles: "always",
+    // Anonymous events only: no identify() calls, so no person profile is created.
+    // The persisted random device id remains the stable fingerprint.
+    person_profiles: "identified_only",
     capture_pageview: false,
+    autocapture: false,
+    disable_session_recording: true,
     // BloxBot intentionally contains "bot", which matches PostHog's bot heuristic.
     opt_out_useragent_filter: true,
   });
@@ -23,13 +27,14 @@ if (import.meta.env.PROD && POSTHOG_PROJECT_TOKEN) {
     $current_url: "bloxbot://app/loading",
     $host: "app",
     $pathname: "/loading",
+    // Skip server-side IP-based location enrichment.
+    $geoip_disable: true,
     app: "bloxbot",
     analytics_schema_version: ANALYTICS_SCHEMA_VERSION,
     analytics_detail_enabled: false,
     app_platform: navigator.platform,
     app_runtime: window.bloxbot ? "electron" : "browser",
     app_screen: "loading",
-    app_user_agent: navigator.userAgent,
   });
   void desktop.getVersion().then(
     (version) => {

--- a/src/providers/PreferencesProvider.tsx
+++ b/src/providers/PreferencesProvider.tsx
@@ -80,10 +80,6 @@ export function PreferencesProvider({ children }: { children: ReactNode }) {
       detailedAnalyticsEnabledRef.current = true;
       setDetailedAnalyticsEnabledState(true);
       setDetailedAnalyticsCollection(true);
-      patchConfig({
-        detailedAnalytics: "enabled",
-        analyticsNoticeVersion: ANALYTICS_NOTICE_VERSION,
-      }).catch(() => {});
       toast("BloxBot collects anonymized usage metrics", {
         id: "analytics-optout-notice",
         className: "analytics-consent-toast",
@@ -99,6 +95,12 @@ export function PreferencesProvider({ children }: { children: ReactNode }) {
           onClick: () => setDetailedAnalyticsEnabled(false),
         },
       });
+      // Persist only after the notice is on screen, so a failure to show it
+      // leaves the version behind and the notice fires again next launch.
+      patchConfig({
+        detailedAnalytics: "enabled",
+        analyticsNoticeVersion: ANALYTICS_NOTICE_VERSION,
+      }).catch(() => {});
       return;
     }
 

--- a/src/providers/PreferencesProvider.tsx
+++ b/src/providers/PreferencesProvider.tsx
@@ -12,7 +12,10 @@ import {
 import { toast } from "sonner";
 import { useAgents } from "@/hooks/useAgents";
 import { useConnectedProviders } from "@/hooks/useProviders";
-import { setDetailedAnalyticsEnabled as setDetailedAnalyticsCollection } from "@/lib/analytics";
+import {
+  ANALYTICS_NOTICE_VERSION,
+  setDetailedAnalyticsEnabled as setDetailedAnalyticsCollection,
+} from "@/lib/analytics";
 import { type AppConfig, loadConfig, patchConfig } from "@/lib/config";
 import { qk } from "@/lib/queryKeys";
 import { splitModelKey } from "@/lib/splitModelKey";
@@ -65,32 +68,44 @@ export function PreferencesProvider({ children }: { children: ReactNode }) {
     });
   }, []);
 
-  // Initialize from config data when it arrives and prompt once when no choice exists.
+  // Initialize from config data when it arrives and notify once about opt-out metrics.
   useEffect(() => {
     if (!configData) return;
     setHiddenModels(new Set(configData.hiddenModels));
-    const detailedEnabled = configData.detailedAnalytics === "enabled";
-    detailedAnalyticsEnabledRef.current = detailedEnabled;
-    setDetailedAnalyticsEnabledState(detailedEnabled);
-    setDetailedAnalyticsCollection(detailedEnabled);
 
-    if (configData.detailedAnalytics === "unset") {
-      toast("Help improve BloxBot", {
-        id: "detailed-analytics-consent",
+    // Model usage metrics moved from opt-in to opt-out. Choices recorded under the
+    // old consent prompt (including clickaways) do not carry over: metrics start
+    // enabled and the one-time notice points at the Settings toggle.
+    if (configData.analyticsNoticeVersion < ANALYTICS_NOTICE_VERSION) {
+      detailedAnalyticsEnabledRef.current = true;
+      setDetailedAnalyticsEnabledState(true);
+      setDetailedAnalyticsCollection(true);
+      patchConfig({
+        detailedAnalytics: "enabled",
+        analyticsNoticeVersion: ANALYTICS_NOTICE_VERSION,
+      }).catch(() => {});
+      toast("BloxBot collects anonymized usage metrics", {
+        id: "analytics-optout-notice",
         className: "analytics-consent-toast",
         description:
-          "Share provider, model, and aggregate token usage. Prompts, responses, files, and agent names are never collected.",
+          "Provider, model, and aggregate token metrics are tied to an anonymous device identifier. Prompts, responses, and files are never collected. Turn this off any time in Settings → Privacy.",
         duration: Number.POSITIVE_INFINITY,
         action: {
-          label: "Share usage",
-          onClick: () => setDetailedAnalyticsEnabled(true),
+          label: "Got it",
+          onClick: () => {},
         },
         cancel: {
-          label: "Not now",
+          label: "Disable",
           onClick: () => setDetailedAnalyticsEnabled(false),
         },
       });
+      return;
     }
+
+    const detailedEnabled = configData.detailedAnalytics !== "disabled";
+    detailedAnalyticsEnabledRef.current = detailedEnabled;
+    setDetailedAnalyticsEnabledState(detailedEnabled);
+    setDetailedAnalyticsCollection(detailedEnabled);
   }, [configData, setDetailedAnalyticsEnabled]);
 
   // Restore a valid last-used model and clear selections whose provider disconnected.

--- a/src/test/ChatInput.test.tsx
+++ b/src/test/ChatInput.test.tsx
@@ -105,6 +105,7 @@ function seedState(qc: QueryClient, session: Session) {
     hiddenModels: [],
     theme: "system",
     detailedAnalytics: "disabled",
+    analyticsNoticeVersion: 1,
   });
   qc.setQueryData<MessagesCache>(qk.messages(session.id), { messageIds: [], messagesById: {} });
   qc.setQueryData(qk.todos(session.id), []);

--- a/src/test/ChatSidebar.test.tsx
+++ b/src/test/ChatSidebar.test.tsx
@@ -86,6 +86,7 @@ function seedState(qc: QueryClient, opts: { sessions?: Session[] } = {}) {
     hiddenModels: [],
     theme: "system",
     detailedAnalytics: "disabled",
+    analyticsNoticeVersion: 1,
   });
 }
 

--- a/src/test/PlaytestPanel.test.tsx
+++ b/src/test/PlaytestPanel.test.tsx
@@ -32,6 +32,7 @@ function Harness({
     hiddenModels: [],
     theme: "system",
     detailedAnalytics: "disabled",
+    analyticsNoticeVersion: 1,
   });
   queryClient.setQueryData<MessagesCache>(qk.messages("active"), {
     messageIds: ["m1"],

--- a/src/test/analytics.test.ts
+++ b/src/test/analytics.test.ts
@@ -29,7 +29,7 @@ describe("PostHog analytics", () => {
     expect(countBucket(42)).toBe("11+");
   });
 
-  it("removes detailed properties until the user opts in", () => {
+  it("removes detailed properties while model usage metrics are off", () => {
     const properties = { provider: "anthropic", model: "claude-sonnet-4" };
 
     expect(detailedAnalyticsProperties(properties)).toEqual({});
@@ -39,7 +39,7 @@ describe("PostHog analytics", () => {
     expect(detailedAnalyticsProperties(properties)).toEqual(properties);
   });
 
-  it("captures detailed token usage only after opt-in", () => {
+  it("captures detailed token usage only while model usage metrics are on", () => {
     const posthog = posthogStub();
     const usage = { provider: "anthropic", model: "claude-sonnet-4", tokens_total: 42 };
 

--- a/src/test/app.test.tsx
+++ b/src/test/app.test.tsx
@@ -182,7 +182,11 @@ function createQueryClient() {
 /** Seed the query cache with the minimum state the app needs to be "ready" */
 function seedReadyState(
   queryClient: QueryClient,
-  opts: { sessions?: Session[]; detailedAnalytics?: "unset" | "enabled" | "disabled" } = {},
+  opts: {
+    sessions?: Session[];
+    detailedAnalytics?: "unset" | "enabled" | "disabled";
+    analyticsNoticeVersion?: number;
+  } = {},
 ) {
   const sessions = opts.sessions ?? [];
 
@@ -208,6 +212,7 @@ function seedReadyState(
     hiddenModels: [],
     theme: "system",
     detailedAnalytics: opts.detailedAnalytics ?? "disabled",
+    analyticsNoticeVersion: opts.analyticsNoticeVersion ?? 1,
   });
 }
 
@@ -226,23 +231,27 @@ afterEach(() => {
 // ── Tests ──────────────────────────────────────────────────────────────────
 
 describe("User journeys", () => {
-  it("prompts once for detailed analytics and keeps the choice toggleable", async () => {
+  it("enables usage metrics by default, notifies once, and keeps opting out toggleable", async () => {
     const client = createClient();
     const queryClient = createQueryClient();
-    seedReadyState(queryClient, { detailedAnalytics: "unset" });
+    // An old clickaway ("disabled" without a notice version) does not carry over.
+    seedReadyState(queryClient, { detailedAnalytics: "disabled", analyticsNoticeVersion: 0 });
 
     render(<TestApp client={client} queryClient={queryClient} />);
 
-    const consentTitle = await screen.findByText("Help improve BloxBot");
-    expect(consentTitle).toBeVisible();
-    expect(consentTitle.closest("[data-sonner-toast]")).toHaveClass("analytics-consent-toast");
-    fireEvent.click(screen.getByRole("button", { name: "Share usage" }));
-    await expect(desktop.loadConfig()).resolves.toMatchObject({ detailedAnalytics: "enabled" });
+    const noticeTitle = await screen.findByText("BloxBot collects anonymized usage metrics");
+    expect(noticeTitle).toBeVisible();
+    expect(noticeTitle.closest("[data-sonner-toast]")).toHaveClass("analytics-consent-toast");
+    await expect(desktop.loadConfig()).resolves.toMatchObject({
+      detailedAnalytics: "enabled",
+      analyticsNoticeVersion: 1,
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Got it" }));
 
     fireEvent.click(await screen.findByText("Settings"));
     fireEvent.click(await screen.findByRole("button", { name: "Privacy" }));
     const analyticsSwitch = screen.getByRole("switch", {
-      name: "Share detailed usage analytics",
+      name: "Share model usage metrics",
     });
     expect(analyticsSwitch).toHaveAttribute("aria-checked", "true");
 
@@ -250,6 +259,22 @@ describe("User journeys", () => {
 
     expect(analyticsSwitch).toHaveAttribute("aria-checked", "false");
     await expect(desktop.loadConfig()).resolves.toMatchObject({ detailedAnalytics: "disabled" });
+  });
+
+  it("respects a recorded opt-out without renotifying", async () => {
+    const client = createClient();
+    const queryClient = createQueryClient();
+    seedReadyState(queryClient, { detailedAnalytics: "disabled", analyticsNoticeVersion: 1 });
+
+    render(<TestApp client={client} queryClient={queryClient} />);
+
+    fireEvent.click(await screen.findByText("Settings"));
+    fireEvent.click(await screen.findByRole("button", { name: "Privacy" }));
+    expect(screen.queryByText("BloxBot collects anonymized usage metrics")).not.toBeInTheDocument();
+    expect(screen.getByRole("switch", { name: "Share model usage metrics" })).toHaveAttribute(
+      "aria-checked",
+      "false",
+    );
   });
 
   it("guides the user until Roblox Studio connects", async () => {

--- a/src/test/desktop.test.ts
+++ b/src/test/desktop.test.ts
@@ -25,6 +25,7 @@ describe("browser desktop fallback", () => {
       hiddenModels: [],
       theme: "system",
       detailedAnalytics: "unset",
+      analyticsNoticeVersion: 0,
       studioTargetPrograms: null,
       studioTargetsBySession: {},
     });
@@ -42,6 +43,7 @@ describe("browser desktop fallback", () => {
       hiddenModels: [],
       theme: "system",
       detailedAnalytics: "unset",
+      analyticsNoticeVersion: 0,
       studioTargetPrograms: null,
       studioTargetsBySession: {},
     });
@@ -57,6 +59,7 @@ describe("browser desktop fallback", () => {
       hiddenModels: [],
       theme: "dark",
       detailedAnalytics: "unset",
+      analyticsNoticeVersion: 0,
       studioTargetPrograms: null,
       studioTargetsBySession: {},
     });

--- a/src/test/opencodeConfig.test.ts
+++ b/src/test/opencodeConfig.test.ts
@@ -1,8 +1,36 @@
 import { describe, expect, it } from "vitest";
 
-import { createOpenCodeConfig } from "../../electron/opencodeConfig";
+import { createOpenCodeConfig, studioMcpCommand } from "../../electron/opencodeConfig";
 
 const broker = { url: "http://127.0.0.1:43210/mcp" };
+
+describe("Studio MCP command", () => {
+  it("resolves cmd.exe through ComSpec instead of PATH on Windows", () => {
+    expect(
+      studioMcpCommand("win32", {
+        localAppData: "C:\\Users\\User\\AppData\\Local",
+        comSpec: "C:\\WINDOWS\\system32\\cmd.exe",
+      }),
+    ).toEqual([
+      "C:\\WINDOWS\\system32\\cmd.exe",
+      "/c",
+      "C:\\Users\\User\\AppData\\Local\\Roblox\\mcp.bat",
+    ]);
+  });
+
+  it("falls back to SystemRoot, then C:\\Windows, when ComSpec is missing", () => {
+    expect(studioMcpCommand("win32", { systemRoot: "D:\\Windows" })[0]).toBe(
+      "D:\\Windows\\System32\\cmd.exe",
+    );
+    expect(studioMcpCommand("win32")[0]).toBe("C:\\Windows\\System32\\cmd.exe");
+  });
+
+  it("keeps the direct StudioMCP binary on macOS", () => {
+    expect(studioMcpCommand("darwin")).toEqual([
+      "/Applications/RobloxStudio.app/Contents/MacOS/StudioMCP",
+    ]);
+  });
+});
 
 describe("OpenCode configuration", () => {
   it("does not install third-party authentication plugins by default", () => {

--- a/src/test/theme-provider.test.tsx
+++ b/src/test/theme-provider.test.tsx
@@ -58,6 +58,7 @@ describe("ThemeProvider", () => {
       hiddenModels: [],
       theme: "system",
       detailedAnalytics: "disabled",
+      analyticsNoticeVersion: 1,
     });
 
     renderThemeProvider(queryClient);
@@ -83,6 +84,7 @@ describe("ThemeProvider", () => {
       hiddenModels: [],
       theme: "dark",
       detailedAnalytics: "disabled",
+      analyticsNoticeVersion: 1,
     });
 
     renderThemeProvider(queryClient);
@@ -116,6 +118,7 @@ describe("ThemeProvider", () => {
       hiddenModels: [],
       theme: "system",
       detailedAnalytics: "disabled",
+      analyticsNoticeVersion: 1,
     });
 
     renderThemeProvider(queryClient);

--- a/src/types/desktop.ts
+++ b/src/types/desktop.ts
@@ -23,6 +23,8 @@ export const AppConfigSchema = Schema.mutable(
     hiddenModels: MutableStrings,
     theme: ThemePreferenceSchema,
     detailedAnalytics: DetailedAnalyticsPreferenceSchema,
+    // Highest analytics policy notice the user has seen; 0 predates the opt-out model.
+    analyticsNoticeVersion: Schema.Number,
     studioTargetPrograms: Schema.NullOr(StudioTargetProgramsSchema),
     studioTargetsBySession: Schema.Record({ key: Schema.String, value: StudioTargetSchema }),
   }),
@@ -35,6 +37,7 @@ export const DEFAULT_APP_CONFIG: AppConfig = {
   hiddenModels: [],
   theme: "system",
   detailedAnalytics: "unset",
+  analyticsNoticeVersion: 0,
   studioTargetPrograms: null,
   studioTargetsBySession: {},
 };


### PR DESCRIPTION
## Summary

### Fix Studio MCP broker startup on Windows (fixes #73)

The broker launched the Studio MCP helper as `cmd.exe /c %LOCALAPPDATA%\Roblox\mcp.bat`. The MCP stdio transport spawns children with a reduced environment, so `cmd.exe` was resolved through the user `PATH`. On machines whose `PATH` does not include `System32`, the spawn failed with `ENOENT` and the whole OpenCode runtime went down (`StudioMcpBrokerError: Failed to start Studio MCP broker`).

`studioMcpCommand` now resolves `cmd.exe` absolutely: `ComSpec` first, then `%SystemRoot%\System32\cmd.exe`, then `C:\Windows\System32\cmd.exe`. Windows paths are built with `win32.join` so behavior is identical across host platforms.

### Model usage metrics: opt-in → opt-out

Model usage metrics (provider and model names, aggregate token counts) are now on by default, in the same spirit as VS Code and Zed telemetry:

- A new `analyticsNoticeVersion` config field tracks which policy notice the user has seen. Configs below the current version are migrated to `enabled` — choices recorded under the old opt-in prompt, including clickaways, do not carry over.
- On migration, a one-time notice explains what is collected and points at the toggle, with a direct **Disable** action.
- The Settings → Privacy toggle remains authoritative after the notice; a recorded opt-out is respected and never re-prompted.

### Anonymized events with a retained device fingerprint

- `person_profiles: "identified_only"` with no `identify()` calls: all events are anonymous, and no person profile is created. The persisted random device id remains the stable fingerprint for aggregate counts.
- Standard PostHog collection is unchanged: GeoIP enrichment, user agent, autocapture, and session recording keep their defaults.
- Settings privacy copy rewritten to match the new model.

## Test plan

- `pnpm typecheck` passes (app, electron, scripts).
- `pnpm vitest run`: 27 files, 183 tests pass, including new coverage for `ComSpec` resolution, the opt-out migration notice, and respecting a recorded opt-out.
- Lint output unchanged from `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
