### PR TITLE
Prepare v0.9.1: create the workspace before starting the Studio MCP broker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+## [0.9.1] - 2026-08-09
+
+### Fixed
+
+- Fixed first-run setup failing with `StudioMcpBrokerError` (`spawn cmd.exe ENOENT`) by creating the `~/BloxBot` workspace before launching the Roblox Studio MCP helper; on fresh installs the workspace did not exist yet and Node reports a missing spawn `cwd` as ENOENT on the executable. ([#76](https://github.com/paralov/app-bloxbot-ai/issues/76))
+
 ## [0.9.0] - 2026-08-07
 
 ### Changed

--- a/electron/services/StudioMcpBroker.ts
+++ b/electron/services/StudioMcpBroker.ts
@@ -12,6 +12,7 @@ import {
   type Tool,
 } from "@modelcontextprotocol/sdk/types.js";
 import { randomUUID } from "node:crypto";
+import { mkdir } from "node:fs/promises";
 import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
 import { Context, Data, Effect, Layer } from "effect";
 
@@ -221,6 +222,7 @@ export function makeStudioMcpBrokerLayer(options: StudioMcpBrokerOptions) {
     Effect.acquireRelease(
       Effect.tryPromise({
         try: async () => {
+          await mkdir(options.workspace, { recursive: true });
           const upstream = await SdkStudioMcpUpstream.connect(
             studioMcpCommand(options.platform ?? process.platform, {
               localAppData: options.localAppData,

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "bloxbot",
   "private": true,
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "AI-assisted Roblox development from a secure desktop app",
   "type": "module",
   "main": "dist-electron/main/main.js",

--- a/src/test/studioMcpBroker.test.ts
+++ b/src/test/studioMcpBroker.test.ts
@@ -1,10 +1,18 @@
+import { existsSync } from "node:fs";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
 import type { Tool } from "@modelcontextprotocol/sdk/types.js";
+import { Effect, Layer } from "effect";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import type { StudioMcpUpstream } from "../../electron/services/StudioMcpBroker";
-import { startStudioMcpBroker } from "../../electron/services/StudioMcpBroker";
+import {
+  makeStudioMcpBrokerLayer,
+  startStudioMcpBroker,
+} from "../../electron/services/StudioMcpBroker";
 
 const tools: Tool[] = [
   {
@@ -64,5 +72,20 @@ describe("Studio MCP broker", () => {
 
     await broker.close();
     expect(upstream.close).toHaveBeenCalledOnce();
+  });
+
+  it("creates the workspace directory before spawning the upstream (#76)", async () => {
+    const tmp = await mkdtemp(join(tmpdir(), "bloxbot-test-"));
+    const workspace = join(tmp, "nested", "BloxBot");
+    try {
+      const layer = makeStudioMcpBrokerLayer({ workspace, platform: "linux" });
+      const result = await Effect.runPromiseExit(Effect.scoped(Layer.build(layer)));
+      // The spawn will fail because "studio-mcp" does not exist, but the
+      // workspace directory must have been created before the spawn attempt.
+      expect(result._tag).toBe("Failure");
+      expect(existsSync(workspace)).toBe(true);
+    } finally {
+      await rm(tmp, { recursive: true, force: true });
+    }
   });
 });


### PR DESCRIPTION
Fixes #76 (and the real cause behind #73).

## Root cause

`makeStudioMcpBrokerLayer` spawns the Studio MCP helper with `cwd: ~/BloxBot`. On a fresh install that directory does not exist yet: it is only created by `prepareOpenCode`, whose first step is `yield* StudioMcpBroker` — so the broker always starts before the `mkdir` runs. Node reports a nonexistent spawn `cwd` as `spawn <executable> ENOENT`, the exact error in both issues.

This is why #74 (resolving `cmd.exe` through `ComSpec`) did not fix it: the stack trace in #76 shows the absolute path `C:\WINDOWS\system32\cmd.exe` being used and still failing with ENOENT, which rules out `PATH`/`ComSpec` as the cause. Verified the error shape locally: `spawn` of a valid absolute executable with a nonexistent `cwd` produces `Error: spawn <executable> ENOENT`.

Upgraded installs never hit this because an earlier version had already created `~/BloxBot`; fresh installs (like the reporter, who deleted all leftovers) always do, on every platform.

## Fix

- Create `options.workspace` (`mkdir` recursive) in the broker layer before `SdkStudioMcpUpstream.connect`.
- Regression test that builds the real layer with a nonexistent nested workspace and asserts the directory exists even when the spawn itself fails.
- CHANGELOG entry and version bump to 0.9.1, ready to release.

## Verification

- `pnpm typecheck`, `pnpm lint`, `pnpm test` all pass (184/184 vitest + 8/8 release script tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)