### PR TITLE
Prepare v0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+## [0.10.0] - 2026-08-20
+
 ### Added
 
 - Updated multi-Studio routing for Roblox Studio MCP's stateless `studio_id` contract, including Place ID disambiguation, per-session target restoration, and BloxBot identification in Studio's connected AI client list.
@@ -171,7 +173,9 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 - OpenCode downloads are restricted to official GitHub release assets and verified with SHA-256 digests before installation and on every cache reuse.
 - Electron runs with context isolation, renderer sandboxing, Node.js integration disabled, validated IPC payloads, and external navigation blocked.
 
-[Unreleased]: https://github.com/paralov/app-bloxbot-ai/compare/v0.9.0...HEAD
+[Unreleased]: https://github.com/paralov/app-bloxbot-ai/compare/v0.10.0...HEAD
+[0.10.0]: https://github.com/paralov/app-bloxbot-ai/compare/v0.9.1...v0.10.0
+[0.9.1]: https://github.com/paralov/app-bloxbot-ai/compare/v0.9.0...v0.9.1
 [0.9.0]: https://github.com/paralov/app-bloxbot-ai/compare/v0.8.0...v0.9.0
 [0.8.0]: https://github.com/paralov/app-bloxbot-ai/compare/v0.7.1...v0.8.0
 [0.7.1]: https://github.com/paralov/app-bloxbot-ai/compare/v0.7.0...v0.7.1

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "bloxbot",
   "private": true,
-  "version": "0.9.1",
+  "version": "0.10.0",
   "description": "AI-assisted Roblox development from a secure desktop app",
   "type": "module",
   "main": "dist-electron/main/main.js",


### PR DESCRIPTION
## Summary

- bump BloxBot from `0.9.1` to `0.10.0`
- promote the stateless multi-Studio MCP notes from Unreleased to the August 20, 2026 release section
- add the missing `v0.9.1` comparison link and advance the Unreleased comparison to `v0.10.0`

## Validation

- `pnpm test` (190 app tests and 8 release tests)
- `pnpm typecheck`
- `pnpm build`
- `node scripts/release.ts validate`
- `node scripts/release-notes.ts 0.10.0`

## After merge

Manually dispatch the `Release` workflow from `main`. It validates `v0.10.0`, builds all platforms, verifies the exact seven release assets, and publishes the GitHub release.
